### PR TITLE
Small typo fixes

### DIFF
--- a/doc/http.adoc
+++ b/doc/http.adoc
@@ -1,10 +1,10 @@
 == Emitting HTTP requests
 
-You can also _push_ the incming messages to a HTTP endpoint using the _HTTP connector_.
+You can also _push_ the incoming messages to a HTTP endpoint using the _HTTP connector_.
 
 === Dependency
 
-To enable the MQTT support, you need the following dependency:
+To enable the HTTP support, you need the following dependency:
 
 [source,xml,subs=attributes+]
 ----


### PR DESCRIPTION
HTTP instead of MQTT - and typo in _incoming_ 

/asign @cescoffier 