### PR TITLE
CloudEvents Serializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <jackson.version>2.9.7</jackson.version>
     <smallrye-reactive-streams-ops.version>0.4.0</smallrye-reactive-streams-ops.version>
     <smallrye-config.version>1.3.4</smallrye-config.version>
-    <cloudevent.version>0.2.0</cloudevent.version>
+    <cloudevent.version>0.2.1</cloudevent.version>
 
     <asciidoctor-maven-plugin.version>1.5.7.1</asciidoctor-maven-plugin.version>
     <asciidoctorj.version>1.5.8.1</asciidoctorj.version>

--- a/smallrye-reactive-messaging-http/pom.xml
+++ b/smallrye-reactive-messaging-http/pom.xml
@@ -27,6 +27,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>smallrye-reactive-messaging-cloud-events</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
       <version>2.19.0</version>

--- a/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/converters/CloudEventSerializer.java
+++ b/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/converters/CloudEventSerializer.java
@@ -1,0 +1,22 @@
+package io.smallrye.reactive.messaging.http.converters;
+
+import io.cloudevents.json.Json;
+import io.smallrye.reactive.messaging.cloudevents.CloudEventMessage;
+import io.vertx.reactivex.core.buffer.Buffer;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class CloudEventSerializer extends Serializer<CloudEventMessage> {
+
+ @Override
+  public CompletionStage<Buffer> convert(CloudEventMessage payload) {
+    return CompletableFuture.completedFuture(Buffer.buffer(Json.encode(payload)));
+  }
+
+  @Override
+  public Class<? extends CloudEventMessage> input() {
+    return CloudEventMessage.class;
+  }
+
+}

--- a/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/converters/Serializer.java
+++ b/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/converters/Serializer.java
@@ -20,6 +20,7 @@ public abstract class Serializer<I> implements Converter<I, Buffer> {
     CONVERTERS.add(new ByteBufferSerializer());
     CONVERTERS.add(new JsonArraySerializer());
     CONVERTERS.add(new JsonObjectSerializer());
+    CONVERTERS.add(new CloudEventSerializer());
   }
 
   public static synchronized <I> Serializer<I> lookup(Object payload, String converterClassName) {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


Adding a CloudEventSerializer, for posting "structured mode" CloudEvents.

Possible demo code:
```java
  @Incoming("source")
  @Outgoing("to-http")
  public HttpMessage<CloudEventMessage>  process(CloudEventMessage<String> message) {
    return HttpMessage.HttpMessageBuilder.<CloudEventMessage>create()
      .withMethod("PUT")
      .withPayload(message)
      .withHeader("Content-Type", "application/cloudevents+json")
      .build();
  }
```

and the server would receive it like:

```
Host: localhost:8080
Content-Length: 236
Content-Type: application/cloudevents+json
User-Agent: Vert.x-WebClient/3.6.0

{"schemaURL":null,"specVersion":"0.2","time":"2018-12-18T14:51:03.791784+01:00","data":"11","extensions":[],"contentType":"text/plain","id":"244741bd-a8c4-4af1-89b4-87809581541c","type":"counter","payload":"11","source":"local://timer"}

```