### PR TITLE
Adding JsonIgnore for payload property

### DIFF
--- a/smallrye-reactive-messaging-cloud-events/src/main/java/io/smallrye/reactive/messaging/cloudevents/DefaultCloudEventMessage.java
+++ b/smallrye-reactive-messaging-cloud-events/src/main/java/io/smallrye/reactive/messaging/cloudevents/DefaultCloudEventMessage.java
@@ -1,5 +1,6 @@
 package io.smallrye.reactive.messaging.cloudevents;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.Extension;
 
@@ -61,7 +62,13 @@ public class DefaultCloudEventMessage<T> implements CloudEventMessage<T> {
   }
 
   @Override
+  @JsonIgnore
   public T getPayload() {
     return delegate.getData().orElseThrow(() -> new IllegalArgumentException("Invalid message - no payload"));
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
   }
 }


### PR DESCRIPTION
@cescoffier not sure if that's the best... but the solution works, because the CloudEvent should not write out the `payload` field (see #71)

Also included a delegate to the `toString()`