### PR TITLE
Migrate the MQTT quickstart to the new configuration format

### DIFF
--- a/examples/mqtt-quickstart/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/mqtt-quickstart/src/main/resources/META-INF/microprofile-config.properties
@@ -1,20 +1,20 @@
 
 # MQTT Sink
-smallrye.messaging.sink.data.type=io.smallrye.reactive.messaging.mqtt.Mqtt
+smallrye.messaging.sink.data.connector=smallrye-mqtt
 smallrye.messaging.sink.data.topic=default
 smallrye.messaging.sink.data.host=localhost
 smallrye.messaging.sink.data.port=1883
-smallrye.messaging.sink.my-stream.auto-generated-client-id=true
+smallrye.messaging.sink.data.auto-generated-client-id=true
 
 # MQTT sink (we write to using an Emitter)
-smallrye.messaging.sink.my-stream.type=io.smallrye.reactive.messaging.mqtt.Mqtt
+smallrye.messaging.sink.my-stream.connector=smallrye-mqtt
 smallrye.messaging.sink.my-stream.topic=hello
 smallrye.messaging.sink.my-stream.host=localhost
 smallrye.messaging.sink.my-stream.port=1883
 smallrye.messaging.sink.my-stream.auto-generated-client-id=true
 
 # MQTT source (we read from)
-smallrye.messaging.source.my-topic.type=io.smallrye.reactive.messaging.mqtt.Mqtt
+smallrye.messaging.source.my-topic.connector=smallrye-mqtt
 smallrye.messaging.source.my-topic.topic=#
 smallrye.messaging.source.my-topic.host=localhost
 smallrye.messaging.source.my-topic.port=1883


### PR DESCRIPTION
Fixed #139  
After updating the mp config the mqtt quickstart works again.