### PR TITLE
Use 'amqp-host' as stated in documentation and not 'amqp-server'

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -57,7 +57,7 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
     private Integer configuredPort;
 
     @Inject
-    @ConfigProperty(name = "amqp-server", defaultValue = "localhost")
+    @ConfigProperty(name = "amqp-host", defaultValue = "localhost")
     private String configuredHost;
 
     @Inject


### PR DESCRIPTION
The documentation states that amqp-host can be used to set the hostname of the AMQP server, but the code actually uses amqp-server. This change makes the actual setting be amqp-host.