### PR TITLE
Add tracing to kafka

### DIFF
--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -46,11 +46,12 @@
       <artifactId>opentracing-util</artifactId>
       <version>0.31.0</version>
     </dependency>
-<!--    <dependency>-->
-<!--      <groupId>io.opentracing.contrib</groupId>-->
-<!--      <artifactId>opentracing-kafka-streams</artifactId>-->
-<!--      <version>0.1.4</version>-->
-<!--    </dependency>-->
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-kafka-client</artifactId>
+      <!-- Version compatible with OpenTracing 0.31.0 (used in MicroProfile-OpenTracing)  -->
+      <version>0.0.20</version>
+    </dependency>
 
     <dependency>
       <groupId>io.debezium</groupId>

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -37,6 +37,22 @@
     </dependency>
 
     <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <version>0.31.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+      <version>0.31.0</version>
+    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>io.opentracing.contrib</groupId>-->
+<!--      <artifactId>opentracing-kafka-streams</artifactId>-->
+<!--      <version>0.1.4</version>-->
+<!--    </dependency>-->
+
+    <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-core</artifactId>
       <version>${debezium.version}</version>

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/HeadersMapExtractTracingAdapter.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/HeadersMapExtractTracingAdapter.java
@@ -1,0 +1,36 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+import io.opentracing.propagation.TextMap;
+
+public class HeadersMapExtractTracingAdapter implements TextMap {
+
+    private final Map<String, String> map = new HashMap<>();
+
+    public HeadersMapExtractTracingAdapter(Headers headers) {
+        for (Header header : headers) {
+            byte[] headerValue = header.value();
+            map.put(header.key(),
+                    headerValue == null ? null : new String(headerValue, StandardCharsets.UTF_8));
+        }
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        return map.entrySet().iterator();
+    }
+
+    @Override
+    public void put(String key, String value) {
+        throw new UnsupportedOperationException(
+                "HeadersMapExtractAdapter should only be used with Tracer.extract()");
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/HeadersMapInjectTracingAdapter.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/HeadersMapInjectTracingAdapter.java
@@ -1,0 +1,28 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import org.apache.kafka.common.header.Headers;
+
+import io.opentracing.propagation.TextMap;
+
+public class HeadersMapInjectTracingAdapter implements TextMap {
+
+    private final Headers headers;
+
+    HeadersMapInjectTracingAdapter(Headers headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        throw new UnsupportedOperationException("iterator should never be used with Tracer.inject()");
+    }
+
+    @Override
+    public void put(String key, String value) {
+        headers.add(key, value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -62,6 +62,7 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     @Override
     public PublisherBuilder<? extends Message<?>> getPublisherBuilder(Config config) {
         String s = servers;
+        System.out.println("kafkaConnector - Creating kafkaSource");
         KafkaSource<Object, Object> source = new KafkaSource<>(vertx, config, s);
         sources.add(source);
         return source.getSource();

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaMessage.java
@@ -3,8 +3,9 @@ package io.smallrye.reactive.messaging.kafka;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
-import io.opentracing.Span;
 import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.opentracing.SpanContext;
 
 public interface KafkaMessage<K, T> extends Message<T> {
 
@@ -12,7 +13,7 @@ public interface KafkaMessage<K, T> extends Message<T> {
         return new SendingKafkaMessage<>(null, key, value, null, null, new MessageHeaders(), null, null);
     }
 
-    static <K, T> KafkaMessage<K, T> ofAndTraced(K key, T value, Span span) {
+    static <K, T> KafkaMessage<K, T> ofAndTraced(K key, T value, SpanContext span) {
         return new SendingKafkaMessage<>(null, key, value, null, null, new MessageHeaders(), null, span);
     }
 
@@ -29,7 +30,7 @@ public interface KafkaMessage<K, T> extends Message<T> {
                 null);
     }
 
-    Span getSpan();
+    SpanContext getSpanContext();
 
     T getPayload();
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaMessage.java
@@ -3,30 +3,33 @@ package io.smallrye.reactive.messaging.kafka;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
+import io.opentracing.Span;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 public interface KafkaMessage<K, T> extends Message<T> {
 
     static <K, T> KafkaMessage<K, T> of(K key, T value) {
-        return new SendingKafkaMessage<>(null, key, value, null, null, new MessageHeaders(), null);
+        return new SendingKafkaMessage<>(null, key, value, null, null, new MessageHeaders(), null, null);
     }
 
-    static <K, T> KafkaMessage<K, T> withKeyAndValue(K key, T value) {
-        return new SendingKafkaMessage<>(null, key, value, null, null,
-                new MessageHeaders(), null);
+    static <K, T> KafkaMessage<K, T> ofAndTraced(K key, T value, Span span) {
+        return new SendingKafkaMessage<>(null, key, value, null, null, new MessageHeaders(), null, span);
     }
 
     static <K, T> KafkaMessage<K, T> of(String topic, K key, T value) {
-        return new SendingKafkaMessage<>(topic, key, value, null, null, new MessageHeaders(), null);
+        return new SendingKafkaMessage<>(topic, key, value, null, null, new MessageHeaders(), null, null);
     }
 
     static <K, T> KafkaMessage<K, T> of(String topic, K key, T value, Long timestamp, Integer partition) {
-        return new SendingKafkaMessage<>(topic, key, value, timestamp, partition, new MessageHeaders(), null);
+        return new SendingKafkaMessage<>(topic, key, value, timestamp, partition, new MessageHeaders(), null, null);
     }
 
     default KafkaMessage<K, T> withAck(Supplier<CompletionStage<Void>> ack) {
-        return new SendingKafkaMessage<>(getTopic(), getKey(), getPayload(), getTimestamp(), getPartition(), getHeaders(), ack);
+        return new SendingKafkaMessage<>(getTopic(), getKey(), getPayload(), getTimestamp(), getPartition(), getHeaders(), ack,
+                null);
     }
+
+    Span getSpan();
 
     T getPayload();
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/ReceivedKafkaMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/ReceivedKafkaMessage.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
+import io.opentracing.Span;
 import io.vertx.reactivex.kafka.client.consumer.KafkaConsumer;
 import io.vertx.reactivex.kafka.client.consumer.KafkaConsumerRecord;
 
@@ -14,11 +15,13 @@ public class ReceivedKafkaMessage<K, T> implements KafkaMessage<K, T> {
     private final KafkaConsumerRecord<K, T> record;
     private final KafkaConsumer<K, T> consumer;
     private final MessageHeaders headers;
+    private final Span span;
 
-    public ReceivedKafkaMessage(KafkaConsumer<K, T> consumer, KafkaConsumerRecord<K, T> record) {
+    public ReceivedKafkaMessage(KafkaConsumer<K, T> consumer, KafkaConsumerRecord<K, T> record, Span span) {
         this.record = Objects.requireNonNull(record);
         this.consumer = Objects.requireNonNull(consumer);
         this.headers = new MessageHeaders(record.getDelegate().record().headers());
+        this.span = span;
     }
 
     @Override
@@ -56,5 +59,10 @@ public class ReceivedKafkaMessage<K, T> implements KafkaMessage<K, T> {
     public CompletionStage<Void> ack() {
         consumer.commit();
         return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public Span getSpan() {
+        return span;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/ReceivedKafkaMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/ReceivedKafkaMessage.java
@@ -6,7 +6,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.vertx.reactivex.kafka.client.consumer.KafkaConsumer;
 import io.vertx.reactivex.kafka.client.consumer.KafkaConsumerRecord;
 
@@ -15,13 +15,13 @@ public class ReceivedKafkaMessage<K, T> implements KafkaMessage<K, T> {
     private final KafkaConsumerRecord<K, T> record;
     private final KafkaConsumer<K, T> consumer;
     private final MessageHeaders headers;
-    private final Span span;
+    private final SpanContext spanContext;
 
-    public ReceivedKafkaMessage(KafkaConsumer<K, T> consumer, KafkaConsumerRecord<K, T> record, Span span) {
+    public ReceivedKafkaMessage(KafkaConsumer<K, T> consumer, KafkaConsumerRecord<K, T> record, SpanContext spanContext) {
         this.record = Objects.requireNonNull(record);
         this.consumer = Objects.requireNonNull(consumer);
         this.headers = new MessageHeaders(record.getDelegate().record().headers());
-        this.span = span;
+        this.spanContext = spanContext;
     }
 
     @Override
@@ -62,7 +62,7 @@ public class ReceivedKafkaMessage<K, T> implements KafkaMessage<K, T> {
     }
 
     @Override
-    public Span getSpan() {
-        return span;
+    public SpanContext getSpanContext() {
+        return spanContext;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/SendingKafkaMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/SendingKafkaMessage.java
@@ -4,7 +4,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
-import io.opentracing.Span;
+import io.opentracing.SpanContext;
 
 public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
 
@@ -16,10 +16,10 @@ public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
     // TODO Should be immutable and use a builder instead.
     private final MessageHeaders headers;
     private final Supplier<CompletionStage<Void>> ack;
-    private final Span span;
+    private final SpanContext spanContext;
 
     public SendingKafkaMessage(String topic, K key, T value, Long timestamp, Integer partition, MessageHeaders headers,
-            Supplier<CompletionStage<Void>> ack, Span span) {
+            Supplier<CompletionStage<Void>> ack, SpanContext spanContext) {
         this.topic = topic;
         this.key = key;
         this.value = value;
@@ -27,7 +27,7 @@ public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
         this.timestamp = timestamp;
         this.headers = headers;
         this.ack = ack;
-        this.span = span;
+        this.spanContext = spanContext;
     }
 
     @Override
@@ -70,7 +70,7 @@ public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
     }
 
     @Override
-    public Span getSpan() {
-        return span;
+    public SpanContext getSpanContext() {
+        return spanContext;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/SendingKafkaMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/SendingKafkaMessage.java
@@ -4,6 +4,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
+import io.opentracing.Span;
+
 public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
 
     private final String topic;
@@ -14,9 +16,10 @@ public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
     // TODO Should be immutable and use a builder instead.
     private final MessageHeaders headers;
     private final Supplier<CompletionStage<Void>> ack;
+    private final Span span;
 
     public SendingKafkaMessage(String topic, K key, T value, Long timestamp, Integer partition, MessageHeaders headers,
-            Supplier<CompletionStage<Void>> ack) {
+            Supplier<CompletionStage<Void>> ack, Span span) {
         this.topic = topic;
         this.key = key;
         this.value = value;
@@ -24,6 +27,7 @@ public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
         this.timestamp = timestamp;
         this.headers = headers;
         this.ack = ack;
+        this.span = span;
     }
 
     @Override
@@ -63,5 +67,10 @@ public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
     @Override
     public Integer getPartition() {
         return partition;
+    }
+
+    @Override
+    public Span getSpan() {
+        return span;
     }
 }

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicMqttSinkTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicMqttSinkTest.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.paho.client.mqttv3.MqttMessage;

--- a/smallrye-reactive-messaging-provider/pom.xml
+++ b/smallrye-reactive-messaging-provider/pom.xml
@@ -27,6 +27,16 @@
       <artifactId>smallrye-config</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <version>0.31.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+      <version>0.31.0</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/smallrye-reactive-messaging-provider/pom.xml
+++ b/smallrye-reactive-messaging-provider/pom.xml
@@ -27,6 +27,7 @@
       <artifactId>smallrye-config</artifactId>
       <scope>test</scope>
     </dependency>
+    <!--     TODO remove used in testing to print active span-->
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/PublisherMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/PublisherMediator.java
@@ -9,6 +9,8 @@ import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.reactivestreams.Publisher;
 
+import io.opentracing.util.GlobalTracer;
+
 public class PublisherMediator extends AbstractMediator {
 
     private PublisherBuilder<Message> publisher;
@@ -43,6 +45,7 @@ public class PublisherMediator extends AbstractMediator {
 
     @Override
     public void initialize(Object bean) {
+        System.out.println(this.getClass().getName() + ":, active span" + GlobalTracer.get().activeSpan());
         super.initialize(bean);
         switch (configuration.production()) {
             case STREAM_OF_MESSAGE: // 1, 3
@@ -116,7 +119,10 @@ public class PublisherMediator extends AbstractMediator {
     }
 
     private void produceIndividualCompletionStageOfMessages() {
-        setPublisher(ReactiveStreams.<CompletionStage<Message>> generate(this::invoke)
+        setPublisher(ReactiveStreams.<CompletionStage<Message>> generate(() -> {
+            System.out.println("Individual message");
+            return invoke();
+        })
                 .flatMapCompletionStage(Function.identity()));
     }
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

TODOs:

- [ ] How to link spans in processors? https://github.com/smallrye/smallrye-reactive-messaging/issues/214
- [ ] Link spans created by CDI `@Traced` on the handlers.

The span context has to be propagated manually in the processor:
```java
@Incoming("data-processor-in")
@Outgoing("data-processor-out")
public CompletionStage<KafkaMessage<String, String>> send(KafkaMessage<String, String> message) {
  CompletableFuture<KafkaMessage<String, String>> future = new CompletableFuture<>();
  future.complete(KafkaMessage.ofAndTraced(message.getKey(), message.getPayload().toUpperCase(), message.getSpan()));
  return future;
}
``` 