### PR TITLE
Include the SmallRye config impl on the classpath

### DIFF
--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -29,6 +29,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <version>1.3.9</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <version>${weld-core.version}</version>


### PR DESCRIPTION
Without it the Getting Started example blows up:

```
org.jboss.weld.exceptions.DeploymentException: WELD-001408: Unsatisfied dependencies for type long with qualifiers @ConfigProperty
  at injection point [BackedAnnotatedField] @Inject @ConfigProperty io.smallrye.reactive.messaging.extension.MediatorManager.defaultBufferSize
  at io.smallrye.reactive.messaging.extension.MediatorManager.defaultBufferSize(MediatorManager.java:0)

    at org.jboss.weld.bootstrap.Validator.validateInjectionPointForDeploymentProblems (Validator.java:378)
    at org.jboss.weld.bootstrap.Validator.validateInjectionPoint (Validator.java:290)
    at org.jboss.weld.bootstrap.Validator.validateGeneralBean (Validator.java:143)
    at org.jboss.weld.bootstrap.Validator.validateRIBean (Validator.java:164)
    at org.jboss.weld.bootstrap.Validator.validateBean (Validator.java:526)
```