### PR TITLE
Make bean constructors protected rather than package protected

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
@@ -39,7 +39,7 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
     protected final ChannelRegistry registry;
 
     // CDI requirement for normal scoped beans
-    ConfiguredChannelFactory() {
+    protected ConfiguredChannelFactory() {
         this.incomingConnectorFactories = null;
         this.outgoingConnectorFactories = null;
         this.config = null;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConnectorConfig.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConnectorConfig.java
@@ -22,7 +22,7 @@ public class ConnectorConfig implements Config {
 
     private final String topic;
 
-    ConnectorConfig(String prefix, Config overall, String channel) {
+    protected ConnectorConfig(String prefix, Config overall, String channel) {
         this.prefix = Objects.requireNonNull(prefix, "the prefix must not be set");
         this.overall = Objects.requireNonNull(overall, "the config must not be set");
         this.name = Objects.requireNonNull(channel, "the channel name must be set");

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/LegacyConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/LegacyConfiguredChannelFactory.java
@@ -25,7 +25,7 @@ public class LegacyConfiguredChannelFactory extends ConfiguredChannelFactory {
     private static final String SINK_CONFIG_PREFIX = "smallrye.messaging.sink.";
 
     // CDI requirement for normal scoped beans
-    LegacyConfiguredChannelFactory() {
+    protected LegacyConfiguredChannelFactory() {
         super();
     }
 


### PR DESCRIPTION
Without this change, when trying to run this in WildFly, I see errors like:
```
aused by: java.lang.IllegalAccessError: tried to access method io.smallrye.reactive.messaging.impl.LegacyConfiguredChannelFactory.<init>()V from class io.smallrye.reactive.messaging.impl.LegacyConfiguredChannelFactory$Proxy$_$$_WeldClientProxy
	at io.smallrye.reactive.messaging.impl.LegacyConfiguredChannelFactory$Proxy$_$$_WeldClientProxy.<init>(Unknown Source)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at org.jboss.weld.bean.proxy.DefaultProxyInstantiator.newInstance(DefaultProxyInstantiator.java:43)
```
Closer inspection shows the proxy to be loaded by the deployment module, while LegacyConfiguredChannelFactory is loaded by the module provided by the server. Although the package name is the same, I believe JBoss Module treats classes loaded by different modules as belonging to different packages so the proxy cannot access its superclass constructor.

After changing the constructor to protected, it loads fine in WildFly.



