### PR TITLE
Rework Kafka Message API

### DIFF
--- a/examples/kafka-quickstart/src/main/java/acme/Receiver.java
+++ b/examples/kafka-quickstart/src/main/java/acme/Receiver.java
@@ -17,8 +17,8 @@ public class Receiver {
         String payload = message.getPayload();
         String key = message.getKey();
         MessageHeaders headers = message.getHeaders();
-        Integer partition = message.getPartition();
-        Long timestamp = message.getTimestamp();
+        int partition = message.getPartition();
+        long timestamp = message.getTimestamp();
         System.out.println("received: " + payload + " from topic " + message.getTopic());
         return message.ack();
     }

--- a/examples/snippets/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumer.java
+++ b/examples/snippets/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumer.java
@@ -11,8 +11,8 @@ public class KafkaConsumer {
     JsonObject payload = message.getPayload();
     String key = message.getKey();
     MessageHeaders headers = message.getHeaders();
-    Integer partition = message.getPartition();
-    Long timestamp = message.getTimestamp();
+    int partition = message.getPartition();
+    long timestamp = message.getTimestamp();
   }
   // end::kafka-message[]
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaMessage.java
@@ -18,7 +18,7 @@ public interface KafkaMessage<K, T> extends Message<T> {
      * @return the new outgoing kafka message
      */
     static <K, T> KafkaMessage<K, T> of(K key, T value) {
-        return new SendingKafkaMessage<>(null, key, value, null, null, new MessageHeaders(), null);
+        return new SendingKafkaMessage<>(null, key, value, -1, -1, new MessageHeaders(), null);
     }
 
     /**
@@ -63,7 +63,7 @@ public interface KafkaMessage<K, T> extends Message<T> {
      * @return the new outgoing kafka message
      */
     static <K, T> KafkaMessage<K, T> of(String topic, K key, T value) {
-        return new SendingKafkaMessage<>(topic, key, value, null, null, new MessageHeaders(), null);
+        return new SendingKafkaMessage<>(topic, key, value, -1, -1, new MessageHeaders(), null);
     }
 
     /**
@@ -72,13 +72,13 @@ public interface KafkaMessage<K, T> extends Message<T> {
      * @param topic the topic, must not be {@code null}
      * @param key the key, can be {@code null}
      * @param value the value / payload, must not be {@code null}
-     * @param timestamp the timestamp, can be {@code null}
-     * @param partition the partition, can be {@code null}
+     * @param timestamp the timestamp, can be {@code -1} to indicate no timestamp
+     * @param partition the partition, can be {@code -1} to indicate no partition
      * @param <K> the type of the key
      * @param <T> the type of the value
      * @return the new outgoing kafka message
      */
-    static <K, T> KafkaMessage<K, T> of(String topic, K key, T value, Long timestamp, Integer partition) {
+    static <K, T> KafkaMessage<K, T> of(String topic, K key, T value, long timestamp, int partition) {
         return new SendingKafkaMessage<>(topic, key, value, timestamp, partition, new MessageHeaders(), null);
     }
 
@@ -116,16 +116,23 @@ public interface KafkaMessage<K, T> extends Message<T> {
     String getTopic();
 
     /**
-     * Gets the partition on which the record is sent or received.
+     * Gets the partition on which the record is sent or received. {@code -1} if not set.
      *
-     * @return the partition, {@code null} or {@code negative} indicates that the partition is not set
+     * @return the partition, {@code -1} indicates that the partition is not set
      */
-    Integer getPartition();
+    int getPartition();
 
     /**
-     * @return the record timestamp, {@code null} if not set.
+     * @return the record timestamp, {@code -1} if not set.
      */
-    Long getTimestamp();
+    long getTimestamp();
+
+    /**
+     * Gets the message offset, {@code -1} if not set.
+     *
+     * @return the message offset, -1 for outgoing messages.
+     */
+    long getOffset();
 
     /**
      * @return the message headers.

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaSink.java
@@ -74,7 +74,7 @@ class KafkaSink {
                             if (this.partition != -1) {
                                 actualPartition = this.partition;
                             }
-                            if (km.getPartition() != null) {
+                            if (km.getPartition() != -1) {
                                 actualPartition = km.getPartition();
                             }
 
@@ -90,7 +90,7 @@ class KafkaSink {
                                 record = new ProducerRecord<>(
                                         actualTopicToBeUSed,
                                         actualPartition,
-                                        km.getTimestamp(),
+                                        km.getTimestamp() == -1 ? null : km.getTimestamp(),
                                         km.getKey() == null ? this.key : km.getKey(),
                                         km.getPayload(),
                                         km.getHeaders().unwrap());

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/ReceivedKafkaMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/ReceivedKafkaMessage.java
@@ -27,21 +27,29 @@ public class ReceivedKafkaMessage<K, T> implements KafkaMessage<K, T> {
         return record.value();
     }
 
+    @Override
     public K getKey() {
         return record.key();
     }
 
+    @Override
     public String getTopic() {
         return record.topic();
     }
 
-    public Integer getPartition() {
+    @Override
+    public int getPartition() {
         return record.partition();
     }
 
     @Override
-    public Long getTimestamp() {
+    public long getTimestamp() {
         return record.timestamp();
+    }
+
+    @Override
+    public long getOffset() {
+        return record.offset();
     }
 
     @Override

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/SendingKafkaMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/SendingKafkaMessage.java
@@ -9,12 +9,12 @@ public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
     private final String topic;
     private final K key;
     private final T value;
-    private final Integer partition;
-    private final Long timestamp;
+    private final int partition;
+    private final long timestamp;
     private final MessageHeaders headers;
     private final Supplier<CompletionStage<Void>> ack;
 
-    public SendingKafkaMessage(String topic, K key, T value, Long timestamp, Integer partition, MessageHeaders headers,
+    public SendingKafkaMessage(String topic, K key, T value, long timestamp, int partition, MessageHeaders headers,
             Supplier<CompletionStage<Void>> ack) {
         this.topic = topic;
         this.key = key;
@@ -50,7 +50,7 @@ public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
     }
 
     @Override
-    public Long getTimestamp() {
+    public long getTimestamp() {
         return timestamp;
     }
 
@@ -65,10 +65,15 @@ public class SendingKafkaMessage<K, T> implements KafkaMessage<K, T> {
     }
 
     @Override
-    public Integer getPartition() {
-        if (partition == null || partition < 0) {
-            return null;
+    public int getPartition() {
+        if (partition < 0) {
+            return -1;
         }
         return partition;
+    }
+
+    @Override
+    public long getOffset() {
+        return -1;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionBean.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionBean.java
@@ -14,11 +14,13 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 public class ConsumptionBean {
 
     private List<Integer> list = new ArrayList<>();
+    private List<KafkaMessage<String, Integer>> kafka = new ArrayList<>();
 
     @Incoming("data")
     @Outgoing("sink")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(KafkaMessage<String, Integer> input) {
+        kafka.add(input);
         return Message.of(input.getPayload() + 1, input::ack);
     }
 
@@ -29,5 +31,9 @@ public class ConsumptionBean {
 
     public List<Integer> getResults() {
         return list;
+    }
+
+    public List<KafkaMessage<String, Integer>> getKafkaMessages() {
+        return kafka;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaMessageTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaMessageTest.java
@@ -15,8 +15,9 @@ public class KafkaMessageTest {
         assertThat(message.getKey()).isEqualTo("foo");
         assertThat(message.getTopic()).isNull();
         assertThat(message.getHeaders().unwrap()).isEmpty();
-        assertThat(message.getPartition()).isNull();
-        assertThat(message.getTimestamp()).isNull();
+        assertThat(message.getPartition()).isEqualTo(-1);
+        assertThat(message.getTimestamp()).isEqualTo(-1);
+        assertThat(message.getOffset()).isEqualTo(-1);
     }
 
     @Test
@@ -26,8 +27,8 @@ public class KafkaMessageTest {
         assertThat(message.getKey()).isEqualTo("foo");
         assertThat(message.getTopic()).isEqualTo("topic");
         assertThat(message.getHeaders().unwrap()).isEmpty();
-        assertThat(message.getPartition()).isNull();
-        assertThat(message.getTimestamp()).isNull();
+        assertThat(message.getPartition()).isEqualTo(-1);
+        assertThat(message.getTimestamp()).isEqualTo(-1);
     }
 
     @Test
@@ -44,13 +45,13 @@ public class KafkaMessageTest {
 
     @Test
     public void testCreationOfKafkaMessageWithEverythingButWithNullValues() {
-        KafkaMessage<String, String> message = KafkaMessage.of(null, null, "bar", null, null);
+        KafkaMessage<String, String> message = KafkaMessage.of(null, null, "bar", -1, -1);
         assertThat(message.getPayload()).isEqualTo("bar");
         assertThat(message.getKey()).isNull();
         assertThat(message.getTopic()).isNull();
         assertThat(message.getHeaders().unwrap()).isEmpty();
-        assertThat(message.getPartition()).isNull();
-        assertThat(message.getTimestamp()).isNull();
+        assertThat(message.getPartition()).isEqualTo(-1);
+        assertThat(message.getTimestamp()).isEqualTo(-1);
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -167,6 +167,14 @@ public class KafkaSourceTest extends KafkaTestBase {
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
         assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        List<KafkaMessage<String, Integer>> messages = bean.getKafkaMessages();
+        messages.forEach(m -> {
+            assertThat(m.getTopic()).isEqualTo("data");
+            assertThat(m.getTimestamp()).isGreaterThan(0);
+            assertThat(m.getPartition()).isGreaterThan(-1);
+            assertThat(m.getOffset()).isGreaterThan(-1);
+        });
     }
 
     private ConsumptionBean deploy(MapBasedConfig config) {


### PR DESCRIPTION
* avoid using objects to primitive type
* allow accessing offset on received message (Fix #268)
* add Kafka message checks in the tests