### PR TITLE
Enable the strict mode for the TCK

### DIFF
--- a/tck/src/main/java/io/smallrye/reactive/messaging/tck/SmallRyeReactiveMessagingExtender.java
+++ b/tck/src/main/java/io/smallrye/reactive/messaging/tck/SmallRyeReactiveMessagingExtender.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.tck;
 
+import static io.smallrye.reactive.messaging.extension.MediatorManager.STRICT_MODE_PROPERTY;
+
 import javax.enterprise.inject.spi.Extension;
 
 import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
@@ -12,6 +14,7 @@ import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 public class SmallRyeReactiveMessagingExtender implements ArchiveExtender {
     @Override
     public void extend(JavaArchive archive) {
+        System.setProperty(STRICT_MODE_PROPERTY, "true");
         archive
                 .addPackages(true, ChannelRegistry.class.getPackage())
                 .addAsServiceProvider(Extension.class, ReactiveMessagingExtension.class)


### PR DESCRIPTION
Improvements in the TCK would require the strict mode to thrown DeploymentException or DefinitionException.