### PR TITLE
Decrease logging levels of sending messages

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaSink.java
@@ -94,7 +94,7 @@ class KafkaSink {
                                         km.getKey() == null ? this.key : km.getKey(),
                                         km.getPayload(),
                                         km.getHeaders().unwrap());
-                                LOGGER.info("Sending message {} to Kafka topic '{}'", message, record.topic());
+                                LOGGER.debug("Sending message {} to Kafka topic '{}'", message, record.topic());
                             }
                         } else {
                             if (this.topic == null) {
@@ -111,7 +111,7 @@ class KafkaSink {
                         CompletableFuture<Message> future = new CompletableFuture<>();
                         Handler<AsyncResult<Void>> handler = ar -> {
                             if (ar.succeeded()) {
-                                LOGGER.info("Message {} sent successfully to Kafka topic '{}'", message, record.topic());
+                                LOGGER.debug("Message {} sent successfully to Kafka topic '{}'", message, record.topic());
                                 future.complete(message);
                             } else {
                                 LOGGER.error("Message {} was not sent to Kafka topic '{}'", message, record.topic(),


### PR DESCRIPTION
@cescoffier I find the repeated logging of the following a bit too verbose
```
10:20:50,103 INFO  [io.smallrye.reactive.messaging.kafka.KafkaSink] (pool-14-thread-1) Sending message io.smallrye.reactive.messaging.kafka.SendingKafkaMessage@7f7eeadc to Kafka topic 'kafka'
10:20:50,107 INFO  [io.smallrye.reactive.messaging.kafka.KafkaSink] (vert.x-eventloop-thread-1) Message io.smallrye.reactive.messaging.kafka.SendingKafkaMessage@7f7eeadc sent successfully to Kafka topic 'kafka'
```
Alternatively I could work around this in the WF logging configuration