### PR TITLE
Export a metric for the count of messages on each channel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,11 @@
     <microprofile-reactive-messaging.version>1.0</microprofile-reactive-messaging.version>
     <microprofile-reactive-streams.version>1.0.1</microprofile-reactive-streams.version>
     <microprofile-config.version>1.3</microprofile-config.version>
+    <microprofile-metrics-api.version>2.0</microprofile-metrics-api.version>
 
     <smallrye-reactive-streams-ops.version>1.0.10</smallrye-reactive-streams-ops.version>
     <smallrye-config.version>1.5.1</smallrye-config.version>
+    <smallrye-metrics.version>2.1.5</smallrye-metrics.version>
 
     <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
 
@@ -146,11 +148,23 @@
         <version>${microprofile-config.version}</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+          <groupId>org.eclipse.microprofile.metrics</groupId>
+          <artifactId>microprofile-metrics-api</artifactId>
+          <version>${microprofile-metrics-api.version}</version>
+        <scope>provided</scope>
+      </dependency>
 
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config</artifactId>
         <version>${smallrye-config.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-metrics</artifactId>
+        <version>${smallrye-metrics.version}</version>
       </dependency>
 
       <dependency>

--- a/smallrye-reactive-messaging-provider/pom.xml
+++ b/smallrye-reactive-messaging-provider/pom.xml
@@ -21,6 +21,11 @@
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
+    <dependency>
+        <groupId>org.eclipse.microprofile.metrics</groupId>
+        <artifactId>microprofile-metrics-api</artifactId>
+        <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss</groupId>

--- a/smallrye-reactive-messaging-provider/pom.xml
+++ b/smallrye-reactive-messaging-provider/pom.xml
@@ -37,6 +37,13 @@
       <artifactId>smallrye-config</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-metrics</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
   </dependencies>
 
   <profiles>

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
@@ -5,7 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
-import javax.enterprise.inject.spi.CDI;
+import javax.enterprise.inject.Instance;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -20,6 +20,7 @@ public abstract class AbstractMediator {
 
     protected final MediatorConfiguration configuration;
     private Invoker invoker;
+    private Instance<PublisherDecorator> decorators;
 
     public AbstractMediator(MediatorConfiguration configuration) {
         this.configuration = configuration;
@@ -27,6 +28,10 @@ public abstract class AbstractMediator {
 
     public synchronized void setInvoker(Invoker invoker) {
         this.invoker = invoker;
+    }
+
+    public void setDecorators(Instance<PublisherDecorator> decorators) {
+        this.decorators = decorators;
     }
 
     public void run() {
@@ -109,7 +114,7 @@ public abstract class AbstractMediator {
             return null;
         }
 
-        for (PublisherDecorator decorator : CDI.current().select(PublisherDecorator.class)) {
+        for (PublisherDecorator decorator : decorators) {
             input = decorator.decorate(input, getConfiguration().getOutgoing());
         }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
@@ -5,6 +5,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+import javax.enterprise.inject.spi.CDI;
+
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
@@ -106,6 +108,11 @@ public abstract class AbstractMediator {
         if (input == null) {
             return null;
         }
+
+        for (PublisherDecorator decorator : CDI.current().select(PublisherDecorator.class)) {
+            input = decorator.decoratePublisher(input, getConfiguration().getOutgoing());
+        }
+
         if (configuration.getBroadcast()) {
             Flowable<Message> flow = Flowable.fromPublisher(input.buildRs());
             if (configuration.getNumberOfSubscriberBeforeConnecting() != 0) {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
@@ -110,7 +110,7 @@ public abstract class AbstractMediator {
         }
 
         for (PublisherDecorator decorator : CDI.current().select(PublisherDecorator.class)) {
-            input = decorator.decoratePublisher(input, getConfiguration().getOutgoing());
+            input = decorator.decorate(input, getConfiguration().getOutgoing());
         }
 
         if (configuration.getBroadcast()) {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/ProcessorMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/ProcessorMediator.java
@@ -232,7 +232,7 @@ public class ProcessorMediator extends AbstractMediator {
         if (configuration.consumption() == MediatorConfiguration.Consumption.PAYLOAD) {
             this.processor = ReactiveStreams.<Message> builder()
                     .flatMapCompletionStage(managePreProcessingAck())
-                    .map(input -> {
+                    .<Message> map(input -> {
                         Object result = invoke(input.getPayload());
                         if (configuration.getAcknowledgment() == Acknowledgment.Strategy.POST_PROCESSING) {
                             return Message.of(result, () -> input.ack());
@@ -244,7 +244,7 @@ public class ProcessorMediator extends AbstractMediator {
         } else {
             this.processor = ReactiveStreams.<Message> builder()
                     .flatMapCompletionStage(managePreProcessingAck())
-                    .map(input -> {
+                    .<Message> map(input -> {
                         Object result = invoke(input);
                         if (configuration.getAcknowledgment() == Acknowledgment.Strategy.POST_PROCESSING) {
                             return Message.of(result, () -> input.ack());

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
@@ -1,0 +1,20 @@
+package io.smallrye.reactive.messaging;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+
+/**
+ * SPI to allow extension of publishers included in the final graph
+ */
+public interface PublisherDecorator {
+
+    /**
+     * Decorate a publisher
+     * 
+     * @param publisher the publisher to decorate
+     * @param the name of the channel to which this publisher publishes
+     * @return the extended publisher
+     */
+    public PublisherBuilder<? extends Message> decoratePublisher(PublisherBuilder<? extends Message> publisher, String name);
+
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
@@ -12,9 +12,9 @@ public interface PublisherDecorator {
      * Decorate a publisher
      * 
      * @param publisher the publisher to decorate
-     * @param the name of the channel to which this publisher publishes
+     * @param channelName the name of the channel to which this publisher publishes
      * @return the extended publisher
      */
-    public PublisherBuilder<? extends Message> decoratePublisher(PublisherBuilder<? extends Message> publisher, String name);
+    public PublisherBuilder<? extends Message> decorate(PublisherBuilder<? extends Message> publisher, String channelName);
 
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
@@ -42,6 +42,7 @@ import io.smallrye.reactive.messaging.ChannelRegistry;
 import io.smallrye.reactive.messaging.Invoker;
 import io.smallrye.reactive.messaging.MediatorConfiguration;
 import io.smallrye.reactive.messaging.MediatorFactory;
+import io.smallrye.reactive.messaging.PublisherDecorator;
 import io.smallrye.reactive.messaging.Shape;
 import io.smallrye.reactive.messaging.WeavingException;
 import io.smallrye.reactive.messaging.annotations.Incomings;
@@ -88,6 +89,9 @@ public class MediatorManager {
 
     @Inject
     BeanManager beanManager;
+
+    @Inject
+    Instance<PublisherDecorator> decorators;
 
     private volatile boolean initialized;
 
@@ -159,6 +163,8 @@ public class MediatorManager {
                     AbstractMediator mediator = createMediator(configuration);
 
                     LOGGER.debug("Initializing {}", mediator.getMethodAsString());
+
+                    mediator.setDecorators(decorators);
 
                     try {
                         Object beanInstance = beanManager.getReference(configuration.getBean(), Object.class,

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
@@ -76,7 +76,7 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
     }
 
     private List<String> getConnectors(BeanManager beanManager, Class<?> clazz) {
-        return beanManager.getBeans(clazz).stream()
+        return beanManager.getBeans(clazz, Any.Literal.INSTANCE).stream()
                 .map(BeanAttributes::getQualifiers)
                 .flatMap(set -> set.stream().filter(a -> a.annotationType().equals(Connector.class)))
                 .map(annotation -> ((Connector) annotation).value())

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
@@ -147,7 +147,7 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
         PublisherBuilder<? extends Message> publisher = mySourceFactory.getPublisherBuilder(config);
 
         for (PublisherDecorator decorator : CDI.current().select(PublisherDecorator.class)) {
-            publisher = decorator.decoratePublisher(publisher, name);
+            publisher = decorator.decorate(publisher, name);
         }
 
         return publisher;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
@@ -10,7 +10,6 @@ import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.BeanAttributes;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.Config;
@@ -39,6 +38,9 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
 
     protected final Config config;
     protected final ChannelRegistry registry;
+
+    @Inject
+    private Instance<PublisherDecorator> publisherDecoratorInstance;
 
     // CDI requirement for normal scoped beans
     protected ConfiguredChannelFactory() {
@@ -146,7 +148,7 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
 
         PublisherBuilder<? extends Message> publisher = mySourceFactory.getPublisherBuilder(config);
 
-        for (PublisherDecorator decorator : CDI.current().select(PublisherDecorator.class)) {
+        for (PublisherDecorator decorator : publisherDecoratorInstance) {
             publisher = decorator.decorate(publisher, name);
         }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/metrics/MetricDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/metrics/MetricDecorator.java
@@ -1,0 +1,39 @@
+package io.smallrye.reactive.messaging.metrics;
+
+import java.util.function.Consumer;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+
+import io.smallrye.reactive.messaging.PublisherDecorator;
+
+@ApplicationScoped
+public class MetricDecorator implements PublisherDecorator {
+
+    @Inject
+    private Instance<MetricRegistry> registryInstance;
+
+    @Override
+    public PublisherBuilder<? extends Message> decoratePublisher(PublisherBuilder<? extends Message> publisher,
+            String channelName) {
+        if (registryInstance.isResolvable()) {
+            return publisher.peek(incrementCount(channelName));
+        } else {
+            return publisher;
+        }
+    }
+
+    private <T extends Message> Consumer<T> incrementCount(String channelName) {
+        MetricRegistry registry = registryInstance.get();
+        Counter counter = registry.counter("mp.messaging.message.count", new Tag("channel", channelName));
+        return (m) -> counter.inc();
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import javax.enterprise.inject.se.SeContainer;
 import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.enterprise.inject.spi.Extension;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.After;
@@ -25,6 +26,7 @@ import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
 import io.smallrye.reactive.messaging.impl.LegacyConfiguredChannelFactory;
+import io.smallrye.reactive.messaging.metrics.MetricDecorator;
 
 public class WeldTestBaseWithoutTails {
 
@@ -96,6 +98,7 @@ public class WeldTestBaseWithoutTails {
                 ChannelProducer.class,
                 ConfiguredChannelFactory.class,
                 LegacyConfiguredChannelFactory.class,
+                MetricDecorator.class,
                 // Messaging provider
                 MyDummyConnector.class,
 
@@ -129,6 +132,11 @@ public class WeldTestBaseWithoutTails {
 
     public void addBeanClass(Class<?>... beanClass) {
         initializer.addBeanClasses(beanClass);
+    }
+
+    @SafeVarargs
+    public final void addExtensionClass(Class<? extends Extension>... extensionClasses) {
+        initializer.addExtensions(extensionClasses);
     }
 
     public void initialize() {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/AppendingDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/AppendingDecorator.java
@@ -1,0 +1,27 @@
+package io.smallrye.reactive.messaging.decorator;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+
+import io.smallrye.reactive.messaging.PublisherDecorator;
+
+@ApplicationScoped
+public class AppendingDecorator implements PublisherDecorator {
+
+    @Override
+    public PublisherBuilder<? extends Message> decorate(PublisherBuilder<? extends Message> publisher, String channelName) {
+        return publisher.map((m) -> this.appendString(m, channelName));
+    }
+
+    private Message appendString(Message message, String string) {
+        if (message.getPayload() instanceof String) {
+            String payload = (String) message.getPayload();
+            return Message.of(payload + "-" + string, message::ack);
+        } else {
+            return message;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/CountingDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/CountingDecorator.java
@@ -1,0 +1,27 @@
+package io.smallrye.reactive.messaging.decorator;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+
+import io.smallrye.reactive.messaging.PublisherDecorator;
+
+@ApplicationScoped
+public class CountingDecorator implements PublisherDecorator {
+
+    private AtomicInteger messsageCount = new AtomicInteger(0);
+
+    @Override
+    public PublisherBuilder<? extends Message> decorate(PublisherBuilder<? extends Message> publisher,
+            String channelName) {
+        return publisher.peek(m -> messsageCount.incrementAndGet());
+    }
+
+    public int getMesssageCount() {
+        return messsageCount.get();
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/DecoratorTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/DecoratorTest.java
@@ -1,0 +1,75 @@
+package io.smallrye.reactive.messaging.decorator;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import io.smallrye.reactive.messaging.MyCollector;
+import io.smallrye.reactive.messaging.WeldTestBase;
+
+public class DecoratorTest extends WeldTestBase {
+
+    @Test
+    public void testDecorator() {
+        addBeanClass(AppendingDecorator.class, SimpleProducerBean.class);
+        initialize();
+
+        MyCollector collector = container.select(MyCollector.class).get();
+
+        // Expect the values in the stream to have "-sink" appended by the decorator
+        List<String> expected = SimpleProducerBean.TEST_STRINGS.stream()
+                .map((s) -> s + "-sink")
+                .collect(Collectors.toList());
+
+        await().until(() -> collector.payloads(), hasSize(expected.size()));
+        assertEquals(expected, collector.payloads());
+    }
+
+    @Test
+    public void testMultiStage() {
+        addBeanClass(AppendingDecorator.class, MultiStageBean.class);
+        initialize();
+
+        MyCollector collector = container.select(MyCollector.class).get();
+
+        // Expect the values in the stream to be emitted twice and have the name of each channel appended by the decorator
+        List<String> expected = MultiStageBean.TEST_STRINGS.stream()
+                .flatMap((s) -> Stream.of(s, s))
+                .map((s) -> s + "-A-B-sink")
+                .collect(Collectors.toList());
+
+        await().until(() -> collector.payloads(), hasSize(expected.size()));
+        assertEquals(expected, collector.payloads());
+    }
+
+    @Test
+    public void testMultiDecorator() {
+        addBeanClass(AppendingDecorator.class, CountingDecorator.class, MultiStageBean.class);
+        initialize();
+
+        MyCollector collector = container.select(MyCollector.class).get();
+
+        // Expect the values in the stream to be emitted twice and have the name of each channel appended by the decorator
+        List<String> expected = MultiStageBean.TEST_STRINGS.stream()
+                .flatMap((s) -> Stream.of(s, s))
+                .map((s) -> s + "-A-B-sink")
+                .collect(Collectors.toList());
+
+        await().until(() -> collector.payloads(), hasSize(expected.size()));
+        assertEquals(expected, collector.payloads());
+
+        CountingDecorator countingDecorator = container.select(CountingDecorator.class).get();
+
+        // Each message goes through A, is replicated and then goes through B and sink
+        // Therefore each input message results in the counting decorator being incremented
+        // five times
+        assertEquals(MultiStageBean.TEST_STRINGS.size() * 5, countingDecorator.getMesssageCount());
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/MultiStageBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/MultiStageBean.java
@@ -1,0 +1,35 @@
+package io.smallrye.reactive.messaging.decorator;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+
+@ApplicationScoped
+public class MultiStageBean {
+
+    public static final List<String> TEST_STRINGS = Arrays.asList("foo", "bar", "baz");
+
+    @Outgoing("A")
+    public PublisherBuilder<String> produceTestStrings() {
+        return ReactiveStreams.fromIterable(TEST_STRINGS);
+    }
+
+    @Incoming("A")
+    @Outgoing("B")
+    public PublisherBuilder<String> doubleUp(String input) {
+        return ReactiveStreams.of(input, input);
+    }
+
+    @Incoming("B")
+    @Outgoing("sink")
+    public String doNothing(String input) {
+        return input;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/SimpleProducerBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/SimpleProducerBean.java
@@ -1,0 +1,19 @@
+package io.smallrye.reactive.messaging.decorator;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+
+public class SimpleProducerBean {
+
+    public static final List<String> TEST_STRINGS = Arrays.asList("foo", "bar", "baz");
+
+    @Outgoing("sink")
+    public PublisherBuilder<String> createStrings() {
+        return ReactiveStreams.fromIterable(TEST_STRINGS);
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metrics/MetricsTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metrics/MetricsTest.java
@@ -1,0 +1,37 @@
+package io.smallrye.reactive.messaging.metrics;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.junit.Test;
+
+import io.smallrye.metrics.setup.MetricCdiInjectionExtension;
+import io.smallrye.reactive.messaging.MyCollector;
+import io.smallrye.reactive.messaging.WeldTestBase;
+
+public class MetricsTest extends WeldTestBase {
+
+    @Test
+    public void testMetrics() {
+        addBeanClass(MetricsTestBean.class);
+        addExtensionClass(MetricCdiInjectionExtension.class);
+        initialize();
+
+        MyCollector collector = container.select(MyCollector.class).get();
+
+        await().until(() -> collector.hasCompleted());
+
+        assertEquals(MetricsTestBean.TEST_MESSAGES.size(), getCounter("source").getCount());
+
+        // Between source and sink, each message is duplicated so we expect double the count for sink
+        assertEquals(MetricsTestBean.TEST_MESSAGES.size() * 2, getCounter("sink").getCount());
+    }
+
+    private Counter getCounter(String channelName) {
+        MetricRegistry registry = container.select(MetricRegistry.class).get();
+        return registry.counter("mp.messaging.message.count", new Tag("channel", channelName));
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metrics/MetricsTestBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metrics/MetricsTestBean.java
@@ -1,0 +1,29 @@
+package io.smallrye.reactive.messaging.metrics;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+
+@ApplicationScoped
+public class MetricsTestBean {
+
+    public static final List<String> TEST_MESSAGES = Arrays.asList("foo", "bar", "baz");
+
+    @Outgoing("source")
+    public PublisherBuilder<String> source() {
+        return ReactiveStreams.fromIterable(TEST_MESSAGES);
+    }
+
+    @Incoming("source")
+    @Outgoing("sink")
+    public PublisherBuilder<String> duplicate(String input) {
+        return ReactiveStreams.of(input, input);
+    }
+
+}

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -26,6 +26,11 @@
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-metrics</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>jakarta.annotation</groupId>


### PR DESCRIPTION
Add support for the spec proposal here: eclipse/microprofile-reactive-messaging#31
Spec PR: eclipse/microprofile-reactive-messaging#84

Currently, this introduces a dependency from the provider component on the MP Metrics API, though the provider will still work (without metrics) if there's no MP Metrics implementation present at runtime.

If that's not desirable, then the `MetricDecorator` could be moved out to its own component.

I also fixed a couple of issues I encountered along the way as separate commits, though they could be moved out to separate PRs instead.