### PR TITLE
AMQP connector - configure amqp client via CDI producing an AmqpClientOptions bean

### DIFF
--- a/doc/amqp.adoc
+++ b/doc/amqp.adoc
@@ -74,3 +74,25 @@ and connection timeout can also be configured using the `amqp-host`, `amqp-port`
 `amqp-password`, `amqp-use-ssl`, `amqp-reconnect-attempts`, `amqp-reconnect-interval`, and
 `amqp-connect-timeout` configuration properties.
 
+Also there is the possibility to provide a named bean AmqpClientOptions to configure the details to connect with the remote broker.
+
+[source]
+----
+mp.messaging.incoming.data.address=data
+mp.messaging.incoming.data.connector=smallrye-amqp
+mp.messaging.incoming.data.broadcast=true
+mp.messaging.incoming.data.client-options-name=custom-client-config
+----
+[source]
+----
+    @Produces
+    @Named("custom-client-config")
+    public AmqpClientOptions amqpClientConfig() {
+        return new AmqpClientOptions()
+                .setHost("localhost")
+                .setPort(5672)
+                .setUsername("username")
+                .setPassword("secret")
+                .setContainerId("my-container-id");
+    }
+----

--- a/examples/amqp-quickstart/pom.xml
+++ b/examples/amqp-quickstart/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
-      <version>${cdi.version}</version>
     </dependency>
 
   </dependencies>

--- a/examples/amqp-quickstart/src/main/java/acme/AmqpConfiguration.java
+++ b/examples/amqp-quickstart/src/main/java/acme/AmqpConfiguration.java
@@ -1,0 +1,30 @@
+package acme;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+import io.vertx.amqp.AmqpClientOptions;
+
+public class AmqpConfiguration {
+
+    @Produces
+    @Named("my-topic-config")
+    public AmqpClientOptions options() {
+        return new AmqpClientOptions()
+                .setHost("localhost")
+                .setPort(5672)
+                .setUsername("smallrye")
+                .setPassword("smallrye");
+    }
+
+    @Produces
+    @Named("my-topic-config2")
+    public AmqpClientOptions options2() {
+        return new AmqpClientOptions()
+                .setHost("localhost")
+                .setPort(5672)
+                .setUsername("smallrye")
+                .setPassword("smallrye");
+    }
+
+}

--- a/examples/amqp-quickstart/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/amqp-quickstart/src/main/resources/META-INF/microprofile-config.properties
@@ -13,8 +13,10 @@ smallrye.messaging.sink.data.durable=true
 smallrye.messaging.sink.my-channel.connector=smallrye-amqp
 smallrye.messaging.sink.my-channel.address=hello
 smallrye.messaging.sink.my-channel.durable=true
+smallrye.messaging.sink.my-channel.client-options-name=my-topic-config
 
 # AMQP source (we read from)
 smallrye.messaging.source.my-topic.connector=smallrye-amqp
 smallrye.messaging.source.my-topic.address=hello
 smallrye.messaging.source.my-topic.durable=true
+smallrye.messaging.source.my-topic.client-options-name=my-topic-config2

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ClientConfigurationBean.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ClientConfigurationBean.java
@@ -1,0 +1,20 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+import io.vertx.amqp.AmqpClientOptions;
+
+public class ClientConfigurationBean {
+
+    @Produces
+    @Named("myclientoptions")
+    public AmqpClientOptions options() {
+        return new AmqpClientOptions()
+                .setHost(System.getProperty("amqp-host"))
+                .setPort(Integer.valueOf(System.getProperty("amqp-port")))
+                .setUsername(System.getProperty("amqp-user"))
+                .setPassword(System.getProperty("amqp-pwd"));
+    }
+
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/VarConfigSource.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/VarConfigSource.java
@@ -25,6 +25,10 @@ public class VarConfigSource implements ConfigSource {
         INCOMING_BEAN_CONFIG.put(prefix + "port", System.getProperty("amqp-port"));
         INCOMING_BEAN_CONFIG.put("amqp-username", System.getProperty("amqp-user"));
         INCOMING_BEAN_CONFIG.put("amqp-password", System.getProperty("amqp-pwd"));
+        String optionsName = System.getProperty("client-options-name");
+        if (optionsName != null) {
+            INCOMING_BEAN_CONFIG.put(prefix + "client-options-name", optionsName);
+        }
 
         prefix = "mp.messaging.outgoing.sink.";
         OUTGOING_BEAN_CONFIG.put(prefix + "address", "sink");
@@ -34,6 +38,10 @@ public class VarConfigSource implements ConfigSource {
         OUTGOING_BEAN_CONFIG.put(prefix + "durable", "true");
         OUTGOING_BEAN_CONFIG.put("amqp-username", System.getProperty("amqp-user"));
         OUTGOING_BEAN_CONFIG.put("amqp-password", System.getProperty("amqp-pwd"));
+        optionsName = System.getProperty("client-options-name");
+        if (optionsName != null) {
+            OUTGOING_BEAN_CONFIG.put(prefix + "client-options-name", optionsName);
+        }
     }
 
     @Override


### PR DESCRIPTION
Related to #349 
This PR adds a new config property `client-options-name` to allow configure the amqp connector via CDI ie:
```properties
mp.messaging.incoming.data.client-options-name=my-topic-config
```
```Java
    @Produces
    @Named("my-topic-config")
    public AmqpClientOptions options() {
        return new AmqpClientOptions()
                .setHost("localhost")
                .setPort(5672)
                .setUsername("smallrye")
                .setPassword("smallrye");
    }
```

This eases the configuration of features like SSL to connect with remote AMQP brokers.
Also note that this functionality is backwards compatible.