### PR TITLE
Allow delayed subscription to channel handled by emitters

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/EmitterImpl.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/EmitterImpl.java
@@ -133,7 +133,7 @@ public class EmitterImpl<T> implements Emitter<T> {
             String name) {
         FlowableEmitter<Message<? extends T>> emitter = reference.get();
         if (emitter == null) {
-            throw new IllegalStateException("No one subscribed to channel " + name);
+            throw new IllegalStateException("No subscriber found for the channel " + name);
         }
         if (emitter.isCancelled()) {
             throw new IllegalStateException("The subscription to " + name + " has been cancelled");

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ReactiveMessagingExtension.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ReactiveMessagingExtension.java
@@ -110,9 +110,11 @@ public class ReactiveMessagingExtension implements Extension {
             for (InjectionPoint ip : emitterInjectionPoints) {
                 String name = ChannelProducer.getChannelName(ip);
                 EmitterImpl<?> emitter = (EmitterImpl<?>) registry.getEmitter(name);
-                if (!emitter.isConnected()) {
-                    done.addDeploymentProblem(
-                            new DeploymentException("No channel found for name: " + name + ", injection point: " + ip));
+                if (!emitter.isSubscribed()) {
+                    // Subscription may happen later, just print a warning.
+                    // Attempting an emission without being subscribed would result in an error.
+                    LOGGER.warn("No subscriber for channel {}  attached to the emitter {}.{}", name,
+                            ip.getBean().getBeanClass().getName(), ip.getMember().getName());
                 }
                 // TODO validate the required type
             }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/LegacyEmitterInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/LegacyEmitterInjectionTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.spi.DeploymentException;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -109,14 +108,16 @@ public class LegacyEmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.isCaught()).isTrue();
     }
 
-    @Test(expected = DeploymentException.class)
+    @Test(expected = IllegalStateException.class)
     public void testWithMissingStream() {
-        installInitializeAndGet(BeanWithMissingStream.class);
+        // The error is only thrown when a message is emitted as the subscription can be delayed.
+        installInitializeAndGet(EmitterInjectionTest.BeanWithMissingStream.class).emitter().send(Message.of("foo"));
     }
 
-    @Test(expected = DeploymentException.class)
+    @Test(expected = IllegalStateException.class)
     public void testWithMissingChannel() {
-        installInitializeAndGet(BeanWithMissingChannel.class);
+        // The error is only thrown when a message is emitted as the subscription can be delayed.
+        installInitializeAndGet(EmitterInjectionTest.BeanWithMissingChannel.class).emitter().send(Message.of("foo"));
     }
 
     @Test


### PR DESCRIPTION
This is useful when the user wants to inject the `Publisher` attached to the emitter and managed the subscription directly.
So, the emitter must not checked whether it got a subscription during the initialization, but should thrown an IllegalStateException when an interaction is attempted (send, complete, fail...).

Also this PR improves the very bad error messages (like the unfamous 'stream is not connected')