### PR TITLE
Change connector name to smallrye-vertx-eventbus

### DIFF
--- a/smallrye-reactive-messaging-vertx-eventbus/src/main/java/io/smallrye/reactive/messaging/eventbus/VertxEventBusConnector.java
+++ b/smallrye-reactive-messaging-vertx-eventbus/src/main/java/io/smallrye/reactive/messaging/eventbus/VertxEventBusConnector.java
@@ -21,7 +21,7 @@ import io.vertx.reactivex.core.Vertx;
 @Connector(VertxEventBusConnector.CONNECTOR_NAME)
 public class VertxEventBusConnector implements OutgoingConnectorFactory, IncomingConnectorFactory {
 
-    static final String CONNECTOR_NAME = "smallrye.vertx.eventbus";
+    static final String CONNECTOR_NAME = "smallrye-vertx-eventbus";
 
     @Inject
     Instance<Vertx> instanceOfVertx;


### PR DESCRIPTION
The connector name was coded incorrectly as smallrye.vertx.eventbus. The correct name is smallrye-vertx-eventbus.