### PR TITLE
Externalize the in-memory connector

### DIFF
--- a/doc/testing.adoc
+++ b/doc/testing.adoc
@@ -1,4 +1,4 @@
-== Testing without external broker
+== Testing without the infrastructure
 
 It's not rare to have to test your application but deploying the infrastructure can be cumbersome.
 While Docker or Test Containers have improved the the testing experience, you may want to mock this infrastructure.
@@ -8,14 +8,25 @@ It allows switching the connector used for a channel with an _in-memory_ connect
 This connector can then provide a way to send messages for incoming channels, or check the received messages for outgoing
 channels.
 
-For example, in a test, you can do something like:
+To use the _in-memory_ connector, you need to add the following dependency to your project:
 
-[source, java]
+[source,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>io.smallrye.reactive</groupId>
+  <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
+  <version>{version}</version>
+</dependency>
+----
+
+Then, in a test, you can do something like:
+
+[source,java]
 ----
 // ...
-import io.smallrye.reactive.messaging.connector.InMemoryConnector;
-import io.smallrye.reactive.messaging.connector.InMemorySource;
-import io.smallrye.reactive.messaging.connector.InMemorySink;
+import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
+import io.smallrye.reactive.messaging.connectors.InMemorySource;
+import io.smallrye.reactive.messaging.connectors.InMemorySink;
 // ...
 
 @Test

--- a/doc/testing.adoc
+++ b/doc/testing.adoc
@@ -1,7 +1,7 @@
 == Testing without the infrastructure
 
 It's not rare to have to test your application but deploying the infrastructure can be cumbersome.
-While Docker or Test Containers have improved the the testing experience, you may want to mock this infrastructure.
+While Docker or Test Containers have improved the the testing experience, you may want to _mock_ this infrastructure.
 
 SmallRye Reactive Messaging proposes an _in-memory_ connector for this exact purpose.
 It allows switching the connector used for a channel with an _in-memory_ connector.
@@ -16,6 +16,7 @@ To use the _in-memory_ connector, you need to add the following dependency to yo
   <groupId>io.smallrye.reactive</groupId>
   <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
   <version>{version}</version>
+  <scope>test</scope>
 </dependency>
 ----
 
@@ -68,3 +69,7 @@ class MyTest {
 }
 ----
 
+[IMPORTANT]
+====
+This connector has been designed for testing purpose only.
+====

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
   <modules>
     <module>api</module>
     <module>smallrye-reactive-messaging-provider</module>
+    <module>smallrye-reactive-messaging-in-memory</module>
     <module>smallrye-reactive-messaging-kafka</module>
     <module>smallrye-reactive-messaging-mqtt</module>
     <module>smallrye-reactive-messaging-mqtt-server</module>

--- a/smallrye-reactive-messaging-gcp-pubsub/pom.xml
+++ b/smallrye-reactive-messaging-gcp-pubsub/pom.xml
@@ -49,11 +49,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/smallrye-reactive-messaging-in-memory/pom.xml
+++ b/smallrye-reactive-messaging-in-memory/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>smallrye-reactive-messaging</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>smallrye-reactive-messaging-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>coverage</id>
+      <properties>
+        <argLine>@{jacocoArgLine}</argLine>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/connectors/InMemoryConnector.java
+++ b/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/connectors/InMemoryConnector.java
@@ -1,4 +1,4 @@
-package io.smallrye.reactive.messaging.connector;
+package io.smallrye.reactive.messaging.connectors;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,7 +25,7 @@ import io.reactivex.processors.UnicastProcessor;
 /**
  * An implementation of connector used for testing applications without having to use external broker.
  * The idea is to substitute the `connector` of a specific channel to use `smallrye-in-memory`.
- * Then your test can send message and checked the received messages.
+ * Then, your test can send message and checked the received messages.
  */
 @ApplicationScoped
 @Connector(InMemoryConnector.CONNECTOR)

--- a/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/connectors/InMemorySink.java
+++ b/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/connectors/InMemorySink.java
@@ -1,4 +1,4 @@
-package io.smallrye.reactive.messaging.connector;
+package io.smallrye.reactive.messaging.connectors;
 
 import java.util.List;
 

--- a/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/connectors/InMemorySource.java
+++ b/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/connectors/InMemorySource.java
@@ -1,4 +1,4 @@
-package io.smallrye.reactive.messaging.connector;
+package io.smallrye.reactive.messaging.connectors;
 
 /**
  * Allows interacting with an in-memory source.

--- a/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/InMemoryConnectorTest.java
+++ b/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/InMemoryConnectorTest.java
@@ -18,13 +18,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.smallrye.reactive.messaging.MapBasedConfig;
-import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
-import io.smallrye.reactive.messaging.connector.InMemoryConnector;
-import io.smallrye.reactive.messaging.connector.InMemorySink;
-import io.smallrye.reactive.messaging.connector.InMemorySource;
-
-public class InMemoryConnectorTest extends WeldTestBaseWithoutTails {
+public class InMemoryConnectorTest extends WeldTestBase {
 
     @Before
     public void install() {

--- a/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/MapBasedConfig.java
+++ b/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/MapBasedConfig.java
@@ -1,0 +1,70 @@
+package io.smallrye.reactive.messaging.connectors;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.*;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * An implementation of {@link Config} based on a simple {@link Map}.
+ * This class is just use to mock real configuration, so should only be used for tests.
+ * <p>
+ * Note that this implementation does not do any conversion, so you must pass the expected object instances.
+ */
+public class MapBasedConfig implements Config {
+    protected static final String CONFIG_FILE_PATH = "target/test-classes/META-INF/microprofile-config.properties";
+    private final Map<String, Object> map;
+
+    public MapBasedConfig(Map<String, Object> map) {
+        this.map = map;
+    }
+
+    @Override
+    public <T> T getValue(String propertyName, Class<T> propertyType) {
+        return getOptionalValue(propertyName, propertyType).orElseThrow(() -> new NoSuchElementException(propertyName));
+    }
+
+    @Override
+    public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+        @SuppressWarnings("unchecked")
+        T value = (T) map.get(propertyName);
+        return Optional.ofNullable(value);
+    }
+
+    @Override
+    public Iterable<String> getPropertyNames() {
+        return map.keySet();
+    }
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources() {
+        return Collections.emptyList();
+    }
+
+    public void write() {
+        File out = new File(CONFIG_FILE_PATH);
+        if (out.isFile()) {
+            out.delete();
+        }
+        out.getParentFile().mkdirs();
+
+        Properties properties = new Properties();
+        map.forEach((key, value) -> properties.setProperty(key, value.toString()));
+        try (FileOutputStream fos = new FileOutputStream(out)) {
+            properties.store(fos, "file generated for testing purpose");
+            fos.flush();
+            System.out.println("Installed configuration:");
+            List<String> list = Files.readAllLines(out.toPath());
+            list.forEach(System.out::println);
+            System.out.println("---------");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+    }
+}

--- a/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/WeldTestBase.java
+++ b/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/WeldTestBase.java
@@ -1,4 +1,4 @@
-package io.smallrye.reactive.messaging;
+package io.smallrye.reactive.messaging.connectors;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,7 +18,8 @@ import org.junit.BeforeClass;
 
 import io.reactivex.Flowable;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
-import io.smallrye.reactive.messaging.connectors.MyDummyConnector;
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.MediatorFactory;
 import io.smallrye.reactive.messaging.extension.ChannelProducer;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
@@ -27,7 +28,7 @@ import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
 import io.smallrye.reactive.messaging.impl.LegacyConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.metrics.MetricDecorator;
 
-public class WeldTestBaseWithoutTails {
+public class WeldTestBase {
 
     static final List<String> EXPECTED = Flowable.range(1, 10).flatMap(i -> Flowable.just(i, i))
             .map(i -> Integer.toString(i))
@@ -44,7 +45,7 @@ public class WeldTestBaseWithoutTails {
 
     public static void releaseConfig() {
         SmallRyeConfigProviderResolver.instance()
-                .releaseConfig(ConfigProvider.getConfig(WeldTestBaseWithoutTails.class.getClassLoader()));
+                .releaseConfig(ConfigProvider.getConfig(WeldTestBase.class.getClassLoader()));
         clearConfigFile();
     }
 
@@ -98,8 +99,9 @@ public class WeldTestBaseWithoutTails {
                 ConfiguredChannelFactory.class,
                 LegacyConfiguredChannelFactory.class,
                 MetricDecorator.class,
-                // Messaging provider
-                MyDummyConnector.class,
+
+                // In memory connector
+                InMemoryConnector.class,
 
                 // SmallRye config
                 io.smallrye.config.inject.ConfigProducer.class);

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/IncomingOnlyCompletionStageMethodTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/IncomingOnlyCompletionStageMethodTest.java
@@ -13,7 +13,7 @@ import io.smallrye.reactive.messaging.beans.IncomingOnlyBeanProducingANonVoidCom
 public class IncomingOnlyCompletionStageMethodTest extends WeldTestBaseWithoutTails {
 
     @Override
-    public List<Class> getBeans() {
+    public List<Class<?>> getBeans() {
         return Collections.singletonList(SourceOnly.class);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/PublisherShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/PublisherShapeTest.java
@@ -29,7 +29,7 @@ import io.smallrye.reactive.messaging.beans.BeanReturningPayloads;
 public class PublisherShapeTest extends WeldTestBaseWithoutTails {
 
     @Override
-    public List<Class> getBeans() {
+    public List<Class<?>> getBeans() {
         return Collections.singletonList(CollectorOnly.class);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
@@ -31,7 +31,7 @@ import io.smallrye.reactive.messaging.beans.BeanReturningASubscriberOfPayloads;
 public class SubscriberShapeTest extends WeldTestBaseWithoutTails {
 
     @Override
-    public List<Class> getBeans() {
+    public List<Class<?>> getBeans() {
         return Collections.singletonList(SourceOnly.class);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/ConcatTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/ConcatTest.java
@@ -13,7 +13,7 @@ import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 public class ConcatTest extends WeldTestBaseWithoutTails {
 
     @Override
-    public List<Class> getBeans() {
+    public List<Class<?>> getBeans() {
         return Collections.singletonList(BeanUsingConcat.class);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/MergeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/MergeTest.java
@@ -13,7 +13,7 @@ import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 public class MergeTest extends WeldTestBaseWithoutTails {
 
     @Override
-    public List<Class> getBeans() {
+    public List<Class<?>> getBeans() {
         return Collections.singletonList(BeanUsingMerge.class);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/OneTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/OneTest.java
@@ -13,7 +13,7 @@ import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 public class OneTest extends WeldTestBaseWithoutTails {
 
     @Override
-    public List<Class> getBeans() {
+    public List<Class<?>> getBeans() {
         return Collections.singletonList(BeanUsingOne.class);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/tck/incoming/IncomingTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/tck/incoming/IncomingTest.java
@@ -21,7 +21,7 @@ import io.smallrye.reactive.messaging.tck.MockedReceiver;
 public class IncomingTest extends WeldTestBase {
 
     @Override
-    public List<Class> getBeans() {
+    public List<Class<?>> getBeans() {
         return Arrays.asList(
                 Bean.class,
                 MessagingManager.class);


### PR DESCRIPTION
Fix #324

* Move the in-memory connector to its own module
* Update doc
* Small refactoring of the tests