### PR TITLE
disable java 13 builds as the jdk cannot be downloaded at the moment

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -39,19 +39,19 @@ jobs:
         - name: Build with Maven
           run: mvn -B clean install --file pom.xml
 
-  build_java13:
-    runs-on: ubuntu-latest
-    steps:
-        - uses: actions/checkout@v1
-        - name: Install JDK 13
-          uses: joschi/setup-jdk@v1.0.0
-          with:
-              java-version: 'openjdk13'
-        - name: Build with Maven
-          run: mvn -B clean install --file pom.xml
+#  build_java13:
+#    runs-on: ubuntu-latest
+#    steps:
+#        - uses: actions/checkout@v1
+#        - name: Install JDK 13
+#          uses: joschi/setup-jdk@v1.0.0
+#          with:
+#              java-version: 'openjdk13'
+#        - name: Build with Maven
+#          run: mvn -B clean install --file pom.xml
 
   quality:
-    needs: [build_java8, build_java11, build_java12, build_java13]
+    needs: [build_java8, build_java11, build_java12]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/build-pull.yml
+++ b/.github/workflows/build-pull.yml
@@ -36,13 +36,13 @@ jobs:
             - name: Build with Maven
               run: mvn -B clean install --file pom.xml
 
-    build_java13:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v1
-            - name: Install JDK 13
-              uses: joschi/setup-jdk@v1.0.0
-              with:
-                  java-version: 'openjdk13'
-            - name: Build with Maven
-              run: mvn -B clean install --file pom.xml
+#    build_java13:
+#        runs-on: ubuntu-latest
+#        steps:
+#            - uses: actions/checkout@v1
+#            - name: Install JDK 13
+#              uses: joschi/setup-jdk@v1.0.0
+#              with:
+#                  java-version: 'openjdk13'
+#            - name: Build with Maven
+#              run: mvn -B clean install --file pom.xml


### PR DESCRIPTION
This would need to be reverted once fixed