### PR TITLE
AMQP connector: configuration via global AmqpClientOptions bean

### DIFF
--- a/doc/amqp.adoc
+++ b/doc/amqp.adoc
@@ -96,16 +96,11 @@ and connection timeout can also be configured using the `amqp-host`, `amqp-port`
 `amqp-password`, `amqp-use-ssl`, `amqp-reconnect-attempts`, `amqp-reconnect-interval`, and
 `amqp-connect-timeout` configuration properties.
 
-Also there is the possibility to provide a named bean AmqpClientOptions to configure the details to connect with the remote broker.
+Optionally, the connection configuration details can be specified using a named bean of the type `AmqpClientOptions` which will be used to configure the vertx clients.
 
-[source]
-----
-mp.messaging.incoming.data.address=data
-mp.messaging.incoming.data.connector=smallrye-amqp
-mp.messaging.incoming.data.broadcast=true
-mp.messaging.incoming.data.client-options-name=custom-client-config
-----
-[source]
+Example of named bean:
+
+[source, java]
 ----
     @Produces
     @Named("custom-client-config")
@@ -117,4 +112,24 @@ mp.messaging.incoming.data.client-options-name=custom-client-config
                 .setPassword("secret")
                 .setContainerId("my-container-id");
     }
+----
+This kind of configuration can be applied at two levels: channel and global.
+
+NOTE: The bean configuration at global level won't apply to a channel with bean configuration specified. In other words, bean configuration priority is: first channel level and second global level.
+
+Example of using a named bean to configure one channel:
+
+[source]
+----
+mp.messaging.incoming.data.address=data
+mp.messaging.incoming.data.connector=smallrye-amqp
+mp.messaging.incoming.data.broadcast=true
+mp.messaging.incoming.data.client-options-name=custom-client-config
+----
+
+Example of using a named bean to configure all channels:
+
+[source]
+----
+amqp-client-options-name=custom-client-config
 ----

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -134,7 +134,7 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
             throw new IllegalStateException(
                     "Cannot find a " + AmqpClientOptions.class.getName() + " bean named " + optionsBeanName);
         }
-        LOGGER.debug("Creating amqp client from bean named '{}'", optionsBeanName);
+        LOGGER.debug("Creating AMQP client from bean named '{}'", optionsBeanName);
         return AmqpClient.create(new io.vertx.axle.core.Vertx(vertx.getDelegate()), options.get());
     }
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/VarConfigSource.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/VarConfigSource.java
@@ -33,6 +33,10 @@ public class VarConfigSource implements ConfigSource {
         if (optionsName != null) {
             INCOMING_BEAN_CONFIG.put(prefix + "client-options-name", optionsName);
         }
+        String globalOptionsName = System.getProperty("amqp-client-options-name");
+        if (globalOptionsName != null) {
+            INCOMING_BEAN_CONFIG.put("amqp-client-options-name", globalOptionsName);
+        }
 
         prefix = "mp.messaging.outgoing.sink.";
         OUTGOING_BEAN_CONFIG.put(prefix + "address", "sink");
@@ -46,6 +50,10 @@ public class VarConfigSource implements ConfigSource {
         optionsName = System.getProperty("client-options-name");
         if (optionsName != null) {
             OUTGOING_BEAN_CONFIG.put(prefix + "client-options-name", optionsName);
+        }
+        globalOptionsName = System.getProperty("amqp-client-options-name");
+        if (globalOptionsName != null) {
+            OUTGOING_BEAN_CONFIG.put("amqp-client-options-name", globalOptionsName);
         }
 
         prefix = "mp.messaging.outgoing.amqp.";


### PR DESCRIPTION
This PR adds on top of the feature to configure the amqp connector via CDI using AmqpClientOptions beans. 
With this PR will be possible to configure the amqp clients for all amqp channels at once specifiying one env var `amqp-client-options-name` which have to have the name of an AmqpClientOptions bean.
This change is backwards compatible and the usage of this new env var is not mandatory, however if used must contain the name of an existing AmqpClientOptions bean (which makes total sense)