### PR TITLE
Change default for retry-attempts to infinite retries

### DIFF
--- a/doc/kafka.adoc
+++ b/doc/kafka.adoc
@@ -46,7 +46,8 @@ be set using the `kafka.bootstrap.servers` config property.
 | group.id | false (BUT should be set in production)  | | the group id. A new random group id is generated if omitted. This feature is only for development. In production, a group id should be set.
 | enable.auto.commit | false | false | whether or not the messages are committed automatically
 | retry | false | true | Whether it should retry to re-established the connection to the broker is it fails
-| retry-attempts | false | 5 | Number of retries
+| retry-attempts | false | Infinite | Number of retries
+| retry-max-wait | false | 30 | Max wait time in seconds between retries
 | broadcast | false | false | Whether the received messages can be dispatched to several `@Incoming`
 |===
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -124,6 +124,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         config.put("value.deserializer", IntegerDeserializer.class.getName());
         config.put("retry", true);
         config.put("retry-attempts", 100);
+        config.put("retry-max-wait", 30);
 
         KafkaSource<String, Integer> source = new KafkaSource<>(vertx, new MapBasedConfig(config), SERVERS);
         List<KafkaRecord> messages1 = new ArrayList<>();


### PR DESCRIPTION
If not specified by the user, the default retry behaviour is to always
retry, with an exponential backoff wait time, up to the retry max wait
time (30 seconds by default).

If the user specify a retry-attempts, then the nubmer of retries will be
limited to that number.

A new env var is also introduced, 'retry-max-wait'. It is used to set
the max wait time in seconds between retries, with a default of 30
seconds.