### PR TITLE
Use the config passed as argument in ConfiguredChannelFactory

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
@@ -12,7 +12,6 @@ import javax.enterprise.inject.spi.DeploymentException;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.*;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
@@ -74,7 +73,10 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
                 LOGGER.info("Found incoming connectors: {}", getConnectors(beanManager, IncomingConnectorFactory.class));
                 LOGGER.info("Found outgoing connectors: {}", getConnectors(beanManager, OutgoingConnectorFactory.class));
             }
-            this.config = ConfigProvider.getConfig();
+            //TODO Should we try to merge all the config?
+            // For now take the first one.
+            this.config = config.stream().findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Unable to retrieve the config"));
         }
     }
 


### PR DESCRIPTION
Fix for the following issue: https://github.com/smallrye/smallrye-reactive-messaging/issues/419

It's only a revert of commit: 1fe889e97b9fa50ba349af370b96e37f9df75c39

Unit tests still passing.
The behaviour was tested on a project using this library.