### PR TITLE
Use JSON to serialize the body of outgoing AMQP messages

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/IncomingAmqpMetadata.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/IncomingAmqpMetadata.java
@@ -14,7 +14,7 @@ public class IncomingAmqpMetadata {
     /**
      * The Application Properties attached to the Message.
      */
-    public final JsonObject properties;
+    private final JsonObject properties;
 
     /**
      * The Content-Type of the message payload


### PR DESCRIPTION
When the AMQP Connector needs to serialize the payload to create an outbound AMQP Message, it should not use `toString`, but use JSON mapping.
The `content-type` is set to `application/json` making the consumer aware of the content.