### PR TITLE
Improve concurrency handling in the Kafka sink

### DIFF
--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
@@ -25,6 +25,10 @@ Type: _string_ | false |
 
 Type: _string_ | false | `org.apache.kafka.common.serialization.StringSerializer`
 
+| *max-inflight-messages* | The maximum number of messages to be written to Kafka concurrently - The default value is the value from the `max.in.flight.requests.per.connection` Kafka property. It configures the maximum number of unacknowledged requests the client before blocking. Note that if this setting is set to be greater than 1 and there are failed sends, there is a risk of message re-ordering due to retries.
+
+Type: _int_ | false | `5`
+
 | *partition* | The target partition id. -1 to let the client determine the partition
 
 Type: _int_ | false | `-1`

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -47,6 +47,8 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "key", type = "string", direction = Direction.OUTGOING, description = "A key to used when writing the record")
 @ConnectorAttribute(name = "partition", type = "int", direction = Direction.OUTGOING, description = "The target partition id. -1 to let the client determine the partition", defaultValue = "-1")
 @ConnectorAttribute(name = "waitForWriteCompletion", type = "boolean", direction = Direction.OUTGOING, description = "Whether the client waits for Kafka to acknowledge the written record before acknowledging the message", defaultValue = "true")
+@ConnectorAttribute(name = "max-inflight-messages", type = "int", direction = Direction.OUTGOING, description = "The maximum number of messages to be written to Kafka concurrently - The default value is the value from the `max.in.flight.requests.per.connection` Kafka property. "
+        + "It configures the maximum number of unacknowledged requests the client before blocking. Note that if this setting is set to be greater than 1 and there are failed sends, there is a risk of message re-ordering due to retries.", defaultValue = "5")
 public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
 
     static final String CONNECTOR_NAME = "smallrye-kafka";

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/NoKafkaTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/NoKafkaTest.java
@@ -56,7 +56,7 @@ public class NoKafkaTest {
                 });
 
         container = KafkaTestBase.baseWeld();
-        KafkaTestBase.addConfig(myKafkaSinkConfig());
+        KafkaTestBase.addConfig(myKafkaSinkConfigWithoutBlockLimit());
         container.addBeanClasses(MyOutgoingBean.class);
         container.initialize();
 
@@ -172,6 +172,18 @@ public class NoKafkaTest {
     }
 
     private MapBasedConfig myKafkaSinkConfig() {
+        String prefix = "mp.messaging.outgoing.temperature-values.";
+        Map<String, Object> config = new HashMap<>();
+        config.put(prefix + "connector", KafkaConnector.CONNECTOR_NAME);
+        config.put(prefix + "value.serializer", StringSerializer.class.getName());
+        config.put(prefix + "max-inflight-messages", "2");
+        config.put(prefix + "max.block.ms", 1000);
+        config.put(prefix + "topic", "output");
+
+        return new MapBasedConfig(config);
+    }
+
+    private MapBasedConfig myKafkaSinkConfigWithoutBlockLimit() {
         String prefix = "mp.messaging.outgoing.temperature-values.";
         Map<String, Object> config = new HashMap<>();
         config.put(prefix + "connector", KafkaConnector.CONNECTOR_NAME);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/documentation/DocumentationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/documentation/DocumentationTest.java
@@ -53,10 +53,7 @@ public class DocumentationTest extends KafkaTestBase {
         AtomicInteger count = new AtomicInteger();
         usage.produceDoubles(50, null, () -> new ProducerRecord<>("prices", count.incrementAndGet() * 1.0));
 
-        await().until(() -> {
-            System.out.println(consumer.list().size());
-            return consumer.list().size() >= 50;
-        });
+        await().until(() -> consumer.list().size() >= 50);
     }
 
     @Test
@@ -84,10 +81,7 @@ public class DocumentationTest extends KafkaTestBase {
     public void testKafkaPriceProducer() {
         KafkaUsage usage = new KafkaUsage();
         List<Double> list = new CopyOnWriteArrayList<>();
-        usage.consumeDoubles("prices", 50, 60, TimeUnit.SECONDS, null, (s, v) -> {
-            System.out.println("adding " + v);
-            list.add(v);
-        });
+        usage.consumeDoubles("prices", 50, 60, TimeUnit.SECONDS, null, (s, v) -> list.add(v));
 
         MapBasedConfig config = getProducerConfiguration();
         Weld weld = baseWeld();
@@ -103,10 +97,7 @@ public class DocumentationTest extends KafkaTestBase {
     public void testKafkaPriceMessageProducer() {
         KafkaUsage usage = new KafkaUsage();
         List<Double> list = new CopyOnWriteArrayList<>();
-        usage.consumeDoubles("prices", 50, 60, TimeUnit.SECONDS, null, (s, v) -> {
-            System.out.println("adding " + v);
-            list.add(v);
-        });
+        usage.consumeDoubles("prices", 50, 60, TimeUnit.SECONDS, null, (s, v) -> list.add(v));
 
         MapBasedConfig config = getProducerConfiguration();
         Weld weld = baseWeld();


### PR DESCRIPTION
Instead of relying on acknowledgment, it does handle a proper request protocol based on the max number of messages that can wait for acknowledgment concurrently.