### PR TITLE
Allows multiple subscription on the Emitter

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/EmitterImpl.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/EmitterImpl.java
@@ -28,15 +28,16 @@ public class EmitterImpl<T> implements Emitter<T> {
 
     private AtomicReference<Throwable> synchronousFailure = new AtomicReference<>();
 
-    EmitterImpl(String name, String overFlowStrategy, long bufferSize, long defaultBufferSize) {
+    public EmitterImpl(String name, String overFlowStrategy, long bufferSize, long defaultBufferSize) {
         this.name = name;
         if (defaultBufferSize <= 0) {
             throw new IllegalArgumentException("The default buffer size must be strictly positive");
         }
 
         Consumer<MultiEmitter<? super Message<? extends T>>> deferred = fe -> {
-            if (!internal.compareAndSet(null, fe)) {
-                fe.fail(new Exception("Emitter already created"));
+            MultiEmitter<? super Message<? extends T>> previous = internal.getAndSet(fe);
+            if (previous != null) {
+                previous.complete();
             }
         };
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterInjectionTest.java
@@ -20,8 +20,10 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import io.reactivex.subscribers.TestSubscriber;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Merge;
+import io.smallrye.reactive.messaging.extension.EmitterImpl;
 
 public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
 
@@ -575,6 +577,21 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         public void consume(final String b) {
             list.add(b);
         }
+    }
+
+    @Test // Reproduce #511
+    public void testWeCanHaveSeveralSubscribers() {
+        EmitterImpl<String> emitter = new EmitterImpl<>("my-channel", "BUFFER", 128, 128);
+        Publisher<Message<? extends String>> publisher = emitter.getPublisher();
+
+        TestSubscriber<Message<? extends String>> sub1 = new TestSubscriber<>();
+        publisher.subscribe(sub1);
+
+        TestSubscriber<Message<? extends String>> sub2 = new TestSubscriber<>();
+        publisher.subscribe(sub2);
+
+        sub1.assertNoErrors();
+        sub2.assertNoErrors();
     }
 
 }


### PR DESCRIPTION
Allows multiple (consecutive) subscription on the Emitter.

The fix has been tested on the reproducer given for https://github.com/quarkusio/quarkus/issues/7974.