### PR TITLE
Do not swallow the main exception when reporting a synchronous initialisation failure

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ReactiveMessagingExtension.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ReactiveMessagingExtension.java
@@ -132,12 +132,7 @@ public class ReactiveMessagingExtension implements Extension {
             }
 
         } catch (Exception e) {
-            if (e.getCause() == null) {
-                done.addDeploymentProblem(e);
-            } else {
-                done.addDeploymentProblem(e.getCause());
-            }
-
+            done.addDeploymentProblem(e);
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/InvalidBindingTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/InvalidBindingTest.java
@@ -39,7 +39,7 @@ public class InvalidBindingTest extends WeldTestBaseWithoutTails {
             fail("Invalid weaving not detected");
         } catch (DeploymentException e) {
             assertThat(e.getCause())
-                    .isInstanceOf(WeavingException.class)
+                    .hasCauseInstanceOf(WeavingException.class)
                     .hasMessageContaining("`source`")
                     .hasMessageContaining("#sink")
                     .hasMessageContaining("(2)");
@@ -70,7 +70,8 @@ public class InvalidBindingTest extends WeldTestBaseWithoutTails {
         } catch (DeploymentException e) {
             e.getCause().printStackTrace();
             assertThat(e.getCause())
-                    .isInstanceOf(WeavingException.class)
+                    .isInstanceOf(DeploymentException.class)
+                    .hasCauseInstanceOf(WeavingException.class)
                     .hasMessageContaining("source")
                     .hasMessageContaining("Synchronous");
         }


### PR DESCRIPTION
Fix #515 