### PR TITLE
Fix the In Memory connector

### DIFF
--- a/documentation/src/main/doc/modules/ROOT/examples/testing/MyTest.java
+++ b/documentation/src/main/doc/modules/ROOT/examples/testing/MyTest.java
@@ -16,7 +16,8 @@ public class MyTest {
     // 1. Switch the channels to the in-memory connector:
     @BeforeAll
     public static void switchMyChannels() {
-        InMemoryConnector.switchChannelToInMemory("prices", "processed-prices");
+        InMemoryConnector.switchIncomingChannelsToInMemory("prices");
+        InMemoryConnector.switchOutgoingChannelsToInMemory("processed-prices");
     }
 
     // 2. Don't forget to reset the channel after the tests:

--- a/documentation/src/main/doc/modules/ROOT/examples/testing/MyTestSetup.java
+++ b/documentation/src/main/doc/modules/ROOT/examples/testing/MyTestSetup.java
@@ -1,0 +1,23 @@
+package testing;
+
+import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MyTestSetup {
+
+    // tag::code[]
+    public Map<String, String> start() {
+        Map<String, String> env = new HashMap<>();
+        env.putAll(InMemoryConnector.switchIncomingChannelsToInMemory("prices"));
+        env.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory("my-data-stream"));
+        return env;
+    }
+
+    public void stop() {
+        InMemoryConnector.clear();
+    }
+    // end::code[]
+
+}

--- a/documentation/src/main/doc/modules/ROOT/pages/testing/testing.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/testing/testing.adoc
@@ -1,5 +1,7 @@
 = Testing without brokers
 
+IMPORTANT: Due to a more strict channel name validation introduced in 2.x, the API has changed in 2.1.0.
+
 It's not rare to have to test your application but deploying the infrastructure can be cumbersome.
 While Docker or Test Containers have improved the testing experience, you may want to _mock_ this infrastructure.
 
@@ -33,3 +35,11 @@ When switching a channel to the in-memory connector, all the configuration prope
 ====
 This connector has been designed for testing purpose only.
 ====
+
+The _switch_ methods return `Map<String, String>` instances containing the set properties.
+While these system properties are already set, you can retrieve them and pass them around, for example if you need to start an external process with these properties:
+
+[source, java, indent=0]
+----
+include::example$testing/MyTestSetup.java[tags=code]
+----

--- a/smallrye-reactive-messaging-in-memory/pom.xml
+++ b/smallrye-reactive-messaging-in-memory/pom.xml
@@ -23,6 +23,24 @@
     </dependency>
   </dependencies>
 
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.jboss.jandex</groupId>
+          <artifactId>jandex-maven-plugin</artifactId>
+          <version>1.0.7</version>
+          <executions>
+            <execution>
+              <id>make-index</id>
+              <goals>
+                <goal>jandex</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+
   <profiles>
     <profile>
       <id>coverage</id>


### PR DESCRIPTION
* Cannot switch both incoming and outgoing due to the new validation mechanism (spec enforcement)
* Update documentation
* Add jandex plugin - required to fix https://github.com/quarkusio/quarkus/issues/6427