### PR TITLE
Update getting-started.adoc

### DIFF
--- a/documentation/src/main/doc/modules/ROOT/pages/getting-started.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/getting-started.adoc
@@ -23,6 +23,11 @@ Creates a Maven project, and include the following dependency in your pom.xml:
   <artifactId>weld-se-core</artifactId>
   <version>{weld-version}</version>
 </dependency>
+<dependency>
+  <groupId>io.smallrye.config</groupId>
+  <artifactId>smallrye-config</artifactId>
+  <version>1.7.0</version>
+</dependency>
 ----
 
 Once created, create a class file with a `public static void main(String... args)` method:


### PR DESCRIPTION
I add a dependency to suppress the following exception

```text
Exception in thread "main" org.jboss.weld.exceptions.DeploymentException: WELD-001408: Unsatisfied dependencies for type int with qualifiers @Default
  at injection point [BackedAnnotatedField] @Inject io.smallrye.reactive.messaging.extension.MediatorManager.defaultBufferSize
  at io.smallrye.reactive.messaging.extension.MediatorManager.defaultBufferSize(MediatorManager.java:0)

	at org.jboss.weld.bootstrap.Validator.validateInjectionPointForDeploymentProblems(Validator.java:378)
	at org.jboss.weld.bootstrap.Validator.validateInjectionPoint(Validator.java:290)
	at org.jboss.weld.bootstrap.Validator.validateGeneralBean(Validator.java:143)
	at org.jboss.weld.bootstrap.Validator.validateRIBean(Validator.java:164)
	at org.jboss.weld.bootstrap.Validator.validateBean(Validator.java:526)
	at org.jboss.weld.bootstrap.ConcurrentValidator$1.doWork(ConcurrentValidator.java:64)
	at org.jboss.weld.bootstrap.ConcurrentValidator$1.doWork(ConcurrentValidator.java:62)
	at org.jboss.weld.executor.IterativeWorkerTaskFactory$1.call(IterativeWorkerTaskFactory.java:62)
	at org.jboss.weld.executor.IterativeWorkerTaskFactory$1.call(IterativeWorkerTaskFactory.java:55)
	at org.jboss.weld.executor.CommonForkJoinPoolExecutorServices.lambda$wrap$0(CommonForkJoinPoolExecutorServices.java:70)
	at java.util.concurrent.ForkJoinTask$AdaptedCallable.exec(ForkJoinTask.java:1424)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```