### PR TITLE
MQTT Client and Connection sharing

### DIFF
--- a/documentation/src/main/doc/modules/mqtt/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/mqtt/pages/inbound.adoc
@@ -53,3 +53,6 @@ include::connectors:partial$META-INF/connector/smallrye-mqtt-incoming.adoc[]
 
 The MQTT connector is based on the https://vertx.io/docs/vertx-mqtt/java/#_vert_x_mqtt_client[Vert.x MQTT client].
 So you can pass any attribute supported by this client.
+
+IMPORTANT: A single instance of `MqttClient` and a single connection is used for each `host` / `port` / `server-name` / `client-id`.
+This client is reused for both the inbound and outbound connectors.

--- a/documentation/src/main/doc/modules/mqtt/pages/outbound.adoc
+++ b/documentation/src/main/doc/modules/mqtt/pages/outbound.adoc
@@ -57,3 +57,6 @@ include::connectors:partial$META-INF/connector/smallrye-mqtt-outgoing.adoc[]
 
 The MQTT connector is based on the https://vertx.io/docs/vertx-mqtt/java/#_vert_x_mqtt_client[Vert.x MQTT client].
 So you can pass any attribute supported by this client.
+
+IMPORTANT: A single instance of `MqttClient` and a single connection is used for each `host` / `port` / `server-name` / `client-id`.
+This client is reused for both the inbound and outbound connectors.

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/Clients.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/Clients.java
@@ -1,0 +1,78 @@
+package io.smallrye.reactive.messaging.mqtt;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
+import io.vertx.mqtt.MqttClientOptions;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.mqtt.MqttClient;
+import io.vertx.mutiny.mqtt.messages.MqttConnAckMessage;
+import io.vertx.mutiny.mqtt.messages.MqttPublishMessage;
+
+public class Clients {
+
+    private static Map<String, ClientHolder> clients = new ConcurrentHashMap<>();
+
+    private Clients() {
+        // avoid direct instantiation.
+    }
+
+    static Uni<MqttClient> getConnectedClient(Vertx vertx, String host, int port, String server,
+            MqttClientOptions options) {
+
+        String id = host + port + "<" + (server == null ? "" : server)
+                + ">-[" + (options.getClientId() != null ? options.getClientId() : "") + "]";
+        ClientHolder holder = clients.computeIfAbsent(id, key -> {
+            MqttClient client = MqttClient.create(vertx, options);
+            return new ClientHolder(client, host, port, server);
+        });
+        return holder.connect();
+    }
+
+    static ClientHolder getHolder(Vertx vertx, String host, int port, String server,
+            MqttClientOptions options) {
+
+        String id = host + port + "<" + (server == null ? "" : server)
+                + ">-[" + (options.getClientId() != null ? options.getClientId() : "") + "]";
+        return clients.computeIfAbsent(id, key -> {
+            MqttClient client = MqttClient.create(vertx, options);
+            return new ClientHolder(client, host, port, server);
+        });
+    }
+
+    /**
+     * Removed all the stored clients.
+     */
+    public static void clear() {
+        clients.clear();
+    }
+
+    public static class ClientHolder {
+
+        private final MqttClient client;
+        private final Uni<MqttConnAckMessage> connection;
+        private final BroadcastProcessor<MqttPublishMessage> messages;
+
+        public ClientHolder(MqttClient client, String host, int port, String server) {
+            this.client = client;
+            this.connection = client.connect(port, host, server).cache();
+            messages = BroadcastProcessor.create();
+            client.publishHandler(messages::onNext);
+            client.closeHandler(v -> messages.onComplete());
+            client.exceptionHandler(messages::onError);
+        }
+
+        public Uni<MqttClient> connect() {
+            return connection
+                    .map(ignored -> client);
+        }
+
+        public Multi<MqttPublishMessage> stream() {
+            return messages;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
@@ -8,6 +8,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Destroyed;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.Config;
@@ -88,5 +90,9 @@ public class MqttConnector implements IncomingConnectorFactory, OutgoingConnecto
         }
 
         return ready;
+    }
+
+    public void destroy(@Observes @Destroyed(ApplicationScoped.class) final Object context) {
+        Clients.clear();
     }
 }

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ConnectionSharingTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ConnectionSharingTest.java
@@ -1,0 +1,110 @@
+package io.smallrye.reactive.messaging.mqtt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.After;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.extension.MediatorManager;
+
+public class ConnectionSharingTest extends MqttTestBase {
+
+    private WeldContainer container;
+
+    @After
+    public void cleanup() {
+        if (container != null) {
+            container.close();
+        }
+        Clients.clear();
+    }
+
+    @Test
+    public void testWithClientId() {
+        Clients.clear();
+        Weld weld = baseWeld(getConfig());
+        weld.addBeanClass(App.class);
+        container = weld.initialize();
+
+        App bean = container.getBeanManager().createInstance().select(App.class).get();
+
+        await().until(() -> this.container.select(MediatorManager.class).get().isInitialized());
+
+        await()
+                .until(() -> this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.prices().size() >= 10);
+        assertThat(bean.prices()).isNotEmpty();
+    }
+
+    private MapBasedConfig getConfig() {
+        String topic = UUID.randomUUID().toString();
+        String prices = "mp.messaging.incoming.prices.";
+        String generator = "mp.messaging.outgoing.to-mqtt.";
+        Map<String, Object> config = new HashMap<>();
+
+        config.put(prices + "topic", topic);
+        config.put(prices + "connector", MqttConnector.CONNECTOR_NAME);
+        config.put(prices + "host", System.getProperty("mqtt-host"));
+        config.put(prices + "port", Integer.valueOf(System.getProperty("mqtt-port")));
+        config.put(prices + "qos", 1);
+        config.put(prices + "client-id", "my-id");
+        if (System.getProperty("mqtt-user") != null) {
+            config.put(prices + "username", System.getProperty("mqtt-user"));
+            config.put(prices + "password", System.getProperty("mqtt-pwd"));
+        }
+
+        config.put(generator + "topic", topic);
+        config.put(generator + "connector", MqttConnector.CONNECTOR_NAME);
+        config.put(generator + "host", System.getProperty("mqtt-host"));
+        config.put(generator + "port", Integer.valueOf(System.getProperty("mqtt-port")));
+        config.put(generator + "qos", 1);
+        config.put(generator + "client-id", "my-id");
+        if (System.getProperty("mqtt-user") != null) {
+            config.put(generator + "username", System.getProperty("mqtt-user"));
+            config.put(generator + "password", System.getProperty("mqtt-pwd"));
+        }
+
+        return new MapBasedConfig(config);
+    }
+
+    @ApplicationScoped
+    public static class App {
+
+        List<String> prices = new CopyOnWriteArrayList<>();
+        Random random = new Random();
+
+        @Incoming("prices")
+        public void processPrices(byte[] priceRaw) {
+            prices.add(new String(priceRaw));
+        }
+
+        @Outgoing("to-mqtt")
+        public Multi<Integer> generate() {
+            return Multi.createFrom().ticks().every(Duration.ofMillis(100))
+                    .map(l -> random.nextInt(100))
+                    .on().overflow().drop()
+                    .transform().byTakingFirstItems(100);
+        }
+
+        public List<String> prices() {
+            return prices;
+        }
+
+    }
+
+}

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSinkTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSinkTest.java
@@ -30,6 +30,7 @@ public class MqttSinkTest extends MqttTestBase {
         if (container != null) {
             container.close();
         }
+        Clients.clear();
     }
 
     @SuppressWarnings("unchecked")
@@ -114,6 +115,7 @@ public class MqttSinkTest extends MqttTestBase {
     @Test
     @Repeat(times = 5)
     public void testABeanProducingMessagesSentToMQTT() throws InterruptedException {
+        Clients.clear();
         Weld weld = baseWeld(getConfig());
         weld.addBeanClass(ProducingBean.class);
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
@@ -27,6 +27,7 @@ public class MqttSourceTest extends MqttTestBase {
         if (container != null) {
             container.close();
         }
+        Clients.clear();
     }
 
     @Test

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MultipleTopicsConsumptionTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MultipleTopicsConsumptionTest.java
@@ -1,0 +1,151 @@
+package io.smallrye.reactive.messaging.mqtt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.After;
+import org.junit.Test;
+
+import io.smallrye.reactive.messaging.extension.MediatorManager;
+
+public class MultipleTopicsConsumptionTest extends MqttTestBase {
+
+    private WeldContainer container;
+
+    @After
+    public void cleanup() {
+        if (container != null) {
+            container.close();
+        }
+        Clients.clear();
+    }
+
+    @Test
+    public void testWithClientId() {
+        Clients.clear();
+        Weld weld = baseWeld(getConfig("my-id"));
+        weld.addBeanClass(Consumers.class);
+        container = weld.initialize();
+
+        Consumers bean = container.getBeanManager().createInstance().select(Consumers.class).get();
+
+        await().until(() -> this.container.select(MediatorManager.class).get().isInitialized());
+
+        await()
+                .until(() -> this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());
+
+        assertThat(bean.prices()).isEmpty();
+        assertThat(bean.products()).isEmpty();
+
+        AtomicInteger counter1 = new AtomicInteger();
+        AtomicInteger counter2 = new AtomicInteger();
+        new Thread(() -> usage.produceIntegers("prices", 10, null, counter1::getAndIncrement))
+                .start();
+        new Thread(() -> usage.produceIntegers("products", 10, null, counter2::getAndIncrement))
+                .start();
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.products().size() >= 10);
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.prices().size() >= 10);
+    }
+
+    @Test
+    public void testWithoutClientId() {
+        Clients.clear();
+        Weld weld = baseWeld(getConfig(null));
+        weld.addBeanClass(Consumers.class);
+        container = weld.initialize();
+
+        Consumers bean = container.getBeanManager().createInstance().select(Consumers.class).get();
+
+        await().until(() -> this.container.select(MediatorManager.class).get().isInitialized());
+
+        await()
+                .until(() -> this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());
+
+        assertThat(bean.prices()).isEmpty();
+        assertThat(bean.products()).isEmpty();
+
+        AtomicInteger counter1 = new AtomicInteger();
+        AtomicInteger counter2 = new AtomicInteger();
+        new Thread(() -> usage.produceIntegers("prices", 10, null, counter1::getAndIncrement))
+                .start();
+        new Thread(() -> usage.produceIntegers("products", 10, null, counter2::getAndIncrement))
+                .start();
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.products().size() >= 10);
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.prices().size() >= 10);
+    }
+
+    private MapBasedConfig getConfig(String id) {
+        String prices = "mp.messaging.incoming.prices.";
+        String products = "mp.messaging.incoming.products.";
+        Map<String, Object> config = new HashMap<>();
+
+        config.put(prices + "topic", "prices");
+        config.put(prices + "connector", MqttConnector.CONNECTOR_NAME);
+        config.put(prices + "host", System.getProperty("mqtt-host"));
+        config.put(prices + "port", Integer.valueOf(System.getProperty("mqtt-port")));
+        config.put(prices + "qos", 1);
+        if (id != null) {
+            config.put(prices + "client-id", id);
+        }
+        if (System.getProperty("mqtt-user") != null) {
+            config.put(prices + "username", System.getProperty("mqtt-user"));
+            config.put(prices + "password", System.getProperty("mqtt-pwd"));
+        }
+
+        config.put(products + "topic", "products");
+        config.put(products + "connector", MqttConnector.CONNECTOR_NAME);
+        config.put(products + "host", System.getProperty("mqtt-host"));
+        config.put(products + "port", Integer.valueOf(System.getProperty("mqtt-port")));
+        config.put(products + "qos", 1);
+        if (id != null) {
+            config.put(products + "client-id", id);
+        }
+        if (System.getProperty("mqtt-user") != null) {
+            config.put(products + "username", System.getProperty("mqtt-user"));
+            config.put(products + "password", System.getProperty("mqtt-pwd"));
+        }
+
+        return new MapBasedConfig(config);
+    }
+
+    @ApplicationScoped
+    public static class Consumers {
+
+        List<String> prices = new CopyOnWriteArrayList<>();
+        List<String> products = new CopyOnWriteArrayList<>();
+
+        @Incoming("prices")
+        public void processPrices(byte[] priceRaw) {
+            prices.add(new String(priceRaw));
+        }
+
+        @Incoming("products")
+        public void processProducts(byte[] productRaw) {
+            products.add(new String(productRaw));
+        }
+
+        public List<String> prices() {
+            return prices;
+        }
+
+        public List<String> products() {
+            return products;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
@@ -27,6 +27,7 @@ public class SecureMqttSourceTest extends SecureMqttTestBase {
         if (container != null) {
             container.close();
         }
+        Clients.clear();
     }
 
     @Test


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/9302.

This commit fixes 2 issues:

1. When the connector uses a client id, reuses among multiple channels, the connection callback  is not called, as the broker consider that the first connection is already established. The solution is to shared the client and connection.
2. When you have 2 incoming configurations sharing the same client and connection, as a single message callback can be registered on the client, it must share the stream and filter items transiting on this stream by only selecting the one matching the configured topic

A note in the documentation has been added.