### PR TITLE
Emitter updates to match spec changes

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/OnOverflow.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/OnOverflow.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,14 +18,17 @@
  */
 package org.eclipse.microprofile.reactive.messaging;
 
-import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Allows configuring the back pressure policy on injected {@link Emitter}:
+ * Configures the back pressure policy on an injected {@link Emitter}:
  *
  * <pre>
  * {
@@ -52,14 +55,24 @@ public @interface OnOverflow {
          * This creates a buffer with the size specified by {@link #bufferSize()} if present.
          * Otherwise, the size will be the value of the config property
          * <strong>mp.messaging.emitter.default-buffer-size</strong>.
-         * If the buffer is full, an error will be propagated.
+         * <p>
+         * If the buffer is full, an {@link IllegalStateException} will be thrown by the {@code Emitter.send} method.
          */
         BUFFER,
+
         /**
          * Buffers <strong>all</strong> values until the downstream consumes it.
-         * This creates an unbound buffer. If the buffer is full, the application will die of {@code OutOfMemory}.
+         * This creates an unbounded buffer so the application may run out of memory if values are continually added faster than
+         * they are consumed.
          */
         UNBOUNDED_BUFFER,
+
+        /**
+         * Causes an {@link IllegalStateException} to be thrown by the {@code Emitter.send} method if the downstream can't keep
+         * up.
+         */
+        THROW_EXCEPTION,
+
         /**
          * Drops the most recent value if the downstream can't keep up. It means that new value emitted by the upstream
          * are ignored.
@@ -67,7 +80,8 @@ public @interface OnOverflow {
         DROP,
 
         /**
-         * Propagates a failure in case the downstream can't keep up.
+         * Sends an error signal to the downstream subscriber in the case where it can't keep up.
+         * This terminates the reactive stream so no more values will be published.
          */
         FAIL,
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/EmitterImpl.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/EmitterImpl.java
@@ -56,15 +56,17 @@ public class EmitterImpl<T> implements Emitter<T> {
 
         switch (strategy) {
             case BUFFER:
-                Multi<Message<? extends T>> multi = Multi.createFrom().emitter(deferred, BackPressureStrategy.BUFFER);
                 if (bufferSize > 0) {
-                    return getPublisherUsingBufferStrategy(bufferSize, multi);
+                    return ThrowingEmitter.create(deferred, bufferSize);
                 } else {
-                    return getPublisherUsingBufferStrategy(defaultBufferSize, multi);
+                    return ThrowingEmitter.create(deferred, defaultBufferSize);
                 }
 
             case UNBOUNDED_BUFFER:
                 return Multi.createFrom().emitter(deferred, BackPressureStrategy.BUFFER);
+
+            case THROW_EXCEPTION:
+                return ThrowingEmitter.create(deferred, 0);
 
             case DROP:
                 return Multi.createFrom().emitter(deferred, BackPressureStrategy.DROP);
@@ -174,8 +176,9 @@ public class EmitterImpl<T> implements Emitter<T> {
     }
 
     @Override
-    public boolean isRequested() {
+    public boolean hasRequests() {
         MultiEmitter<? super Message<? extends T>> emitter = internal.get();
         return !isCancelled() && emitter.requested() > 0;
     }
+
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/LegacyEmitterImpl.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/LegacyEmitterImpl.java
@@ -35,7 +35,7 @@ public class LegacyEmitterImpl<T> implements Emitter<T> {
 
     @Override
     public boolean isRequested() {
-        return delegate.isRequested();
+        return delegate.hasRequests();
     }
 
     @Override

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ThrowingEmitter.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ThrowingEmitter.java
@@ -1,0 +1,88 @@
+package io.smallrye.reactive.messaging.extension;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.subscription.BackPressureStrategy;
+import io.smallrye.mutiny.subscription.MultiEmitter;
+
+/**
+ * An Emitter which throws an exception if asked to emit when there's insufficient requests from downstream.
+ * <p>
+ * Can be configured with a buffer to allow a certain number of items to be emitted without downstream requests.
+ *
+ * @param <T> the type to emit
+ */
+class ThrowingEmitter<T> implements MultiEmitter<T> {
+
+    private MultiEmitter<? super T> delegate;
+    private AtomicLong requested;
+
+    public static <T> Multi<T> create(Consumer<MultiEmitter<? super T>> deferred, long bufferSize) {
+        // ThrowingEmitter works by wrapping around a delegate emitter and tracking the requests from downstream so that it can throw an exception from emit() if there aren't sufficient requests
+
+        // If there's no buffer we can use IGNORE since we do our own counting of requests, otherwise we need the delegate to buffer requests for us
+        BackPressureStrategy backPressureStrategy = bufferSize == 0 ? BackPressureStrategy.IGNORE : BackPressureStrategy.BUFFER;
+
+        // Use deferred so that we can add a separate on request callback for each subscriber
+        return Multi.createFrom().deferred(() -> {
+
+            ThrowingEmitter<T> throwingEmitter = new ThrowingEmitter<>(bufferSize);
+
+            // When someone subscribes, wrap the emitter with our throwing emitter
+            Consumer<MultiEmitter<? super T>> consumer = emitter -> {
+                throwingEmitter.delegate = emitter;
+                deferred.accept(throwingEmitter);
+            };
+
+            // Create the Multi and attach the request callback
+            return Multi.createFrom().emitter(consumer, backPressureStrategy).on().request(throwingEmitter::request);
+        });
+    }
+
+    public ThrowingEmitter(long bufferSize) {
+        requested = new AtomicLong(bufferSize);
+    }
+
+    public MultiEmitter<T> emit(T item) {
+        // Decrement requested without going below zero
+        long requests;
+        do {
+            requests = requested.get();
+        } while (requests > 0 && !requested.compareAndSet(requests, requests - 1));
+
+        if (requests <= 0) {
+            throw new IllegalStateException("Insufficient downstream requests to emit item");
+        }
+
+        delegate.emit(item);
+        return this;
+    }
+
+    public void fail(Throwable failure) {
+        delegate.fail(failure);
+    }
+
+    public void complete() {
+        delegate.complete();
+    }
+
+    public MultiEmitter<T> onTermination(Runnable onTermination) {
+        delegate.onTermination(onTermination);
+        return this;
+    }
+
+    public boolean isCancelled() {
+        return delegate.isCancelled();
+    }
+
+    public long requested() {
+        return delegate.requested();
+    }
+
+    public void request(long requests) {
+        Subscriptions.add(requested, requests);
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterInjectionTest.java
@@ -34,7 +34,7 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.emitter()).isNotNull();
         assertThat(bean.list()).containsExactly("a", "b", "c");
         assertThat(bean.emitter().isCancelled()).isTrue();
-        assertThat(bean.emitter().isRequested()).isFalse();
+        assertThat(bean.emitter().hasRequests()).isFalse();
     }
 
     @Test
@@ -49,7 +49,7 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         await().until(() -> bean.list().size() == 3);
         assertThat(bean.list()).containsExactly("a", "b", "c");
         assertThat(bean.emitter().isCancelled()).isTrue();
-        assertThat(bean.emitter().isRequested()).isFalse();
+        assertThat(bean.emitter().hasRequests()).isFalse();
     }
 
     @Test
@@ -60,7 +60,7 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.emitter()).isNotNull();
         assertThat(bean.list()).containsExactly("a", "b", "c");
         assertThat(bean.emitter().isCancelled()).isTrue();
-        assertThat(bean.emitter().isRequested()).isFalse();
+        assertThat(bean.emitter().hasRequests()).isFalse();
     }
 
     @Test
@@ -70,7 +70,7 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.emitter()).isNotNull();
         assertThat(bean.list()).containsExactly("A", "B", "C");
         assertThat(bean.emitter().isCancelled()).isTrue();
-        assertThat(bean.emitter().isRequested()).isFalse();
+        assertThat(bean.emitter().hasRequests()).isFalse();
     }
 
     @Test
@@ -80,7 +80,7 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.emitter()).isNotNull();
         assertThat(bean.list()).containsExactly("a", "b", "c");
         assertThat(bean.emitter().isCancelled()).isFalse();
-        assertThat(bean.emitter().isRequested()).isTrue();
+        assertThat(bean.emitter().hasRequests()).isTrue();
     }
 
     @Test
@@ -90,7 +90,7 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.emitter()).isNotNull();
         assertThat(bean.list()).containsExactly("a", "b", "c");
         assertThat(bean.emitter().isCancelled()).isFalse();
-        assertThat(bean.emitter().isRequested()).isTrue();
+        assertThat(bean.emitter().hasRequests()).isTrue();
     }
 
     @Test
@@ -101,7 +101,7 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.emitter()).isNotNull();
         assertThat(bean.list()).containsExactly("a", "b");
         assertThat(bean.emitter().isCancelled()).isTrue();
-        assertThat(bean.emitter().isRequested()).isFalse();
+        assertThat(bean.emitter().hasRequests()).isFalse();
         assertThat(bean.isCaught()).isTrue();
     }
 
@@ -113,7 +113,7 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.emitter()).isNotNull();
         assertThat(bean.list()).containsExactly("a", "b");
         assertThat(bean.emitter().isCancelled()).isTrue();
-        assertThat(bean.emitter().isRequested()).isFalse();
+        assertThat(bean.emitter().hasRequests()).isFalse();
         assertThat(bean.isCaught()).isTrue();
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/BufferOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/BufferOverflowStrategyTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import io.reactivex.Flowable;
 import io.reactivex.Scheduler;
 import io.reactivex.schedulers.Schedulers;
-import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 
 public class BufferOverflowStrategyTest extends WeldTestBaseWithoutTails {
@@ -54,7 +53,8 @@ public class BufferOverflowStrategyTest extends WeldTestBaseWithoutTails {
 
         await().until(() -> bean.exception() != null);
         assertThat(bean.output()).doesNotContain("999");
-        assertThat(bean.failure()).isNotNull().isInstanceOf(BackPressureFailure.class);
+        assertThat(bean.failure()).isNull();
+        assertThat(bean.exception()).isInstanceOf(IllegalStateException.class);
     }
 
     @ApplicationScoped

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyEmitterBufferOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyEmitterBufferOverflowStrategyTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import io.reactivex.Flowable;
 import io.reactivex.Scheduler;
 import io.reactivex.schedulers.Schedulers;
-import io.smallrye.mutiny.subscription.BackPressureFailure;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Channel;
 import io.smallrye.reactive.messaging.annotations.Emitter;
@@ -58,7 +57,8 @@ public class LegacyEmitterBufferOverflowStrategyTest extends WeldTestBaseWithout
 
         await().until(() -> bean.exception() != null);
         assertThat(bean.output()).doesNotContain("999");
-        assertThat(bean.failure()).isNotNull().isInstanceOf(BackPressureFailure.class);
+        assertThat(bean.failure()).isNull();
+        assertThat(bean.exception()).isInstanceOf(IllegalStateException.class);
     }
 
     @ApplicationScoped

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/ThrowExceptionOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/ThrowExceptionOverflowStrategyTest.java
@@ -1,0 +1,139 @@
+package io.smallrye.reactive.messaging.inject.overflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.reactivex.Flowable;
+import io.reactivex.Scheduler;
+import io.reactivex.schedulers.Schedulers;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class ThrowExceptionOverflowStrategyTest extends WeldTestBaseWithoutTails {
+
+    private static ExecutorService executor;
+
+    @BeforeClass
+    public static void init() {
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        executor.shutdown();
+    }
+
+    @Test
+    public void testNormal() throws InterruptedException {
+        BeanUsingThrowExceptionOverflowStrategy bean = installInitializeAndGet(BeanUsingThrowExceptionOverflowStrategy.class);
+        bean.emitOne();
+
+        await().until(() -> bean.output().size() == 1);
+        assertThat(bean.output()).containsExactly("1");
+        assertThat(bean.accepted()).containsExactly("1");
+        assertThat(bean.rejected()).isEmpty();
+    }
+
+    @Test
+    public void testOverflow() throws InterruptedException, ExecutionException, TimeoutException {
+        BeanUsingThrowExceptionOverflowStrategy bean = installInitializeAndGet(BeanUsingThrowExceptionOverflowStrategy.class);
+        Future<?> future = bean.emit999();
+
+        future.get(10, TimeUnit.SECONDS); // Will throw exception if emitter.send() throws an unexpected exception
+
+        assertThat(bean.accepted().size() + bean.rejected().size()).isEqualTo(999);
+        assertThat(bean.accepted()).contains("1");
+        assertThat(bean.rejected()).isNotEmpty();
+
+        await().until(() -> bean.output().size() == bean.accepted().size());
+        assertThat(bean.output()).containsExactlyElementsOf(bean.accepted());
+        assertThat(bean.failure()).isNull();
+    }
+
+    @ApplicationScoped
+    public static class BeanUsingThrowExceptionOverflowStrategy {
+
+        @Inject
+        @Channel("hello")
+        @OnOverflow(value = OnOverflow.Strategy.THROW_EXCEPTION)
+        Emitter<String> emitter;
+
+        private List<String> output = new CopyOnWriteArrayList<>();
+        private List<String> accepted = new CopyOnWriteArrayList<>();
+        private List<String> rejected = new CopyOnWriteArrayList<>();
+
+        private volatile Throwable downstreamFailure;
+
+        public List<String> output() {
+            return output;
+        }
+
+        public List<String> accepted() {
+            return accepted;
+        }
+
+        public List<String> rejected() {
+            return rejected;
+        }
+
+        public Throwable failure() {
+            return downstreamFailure;
+        }
+
+        public void emitOne() throws InterruptedException {
+            emit("1");
+            emitter.complete();
+        }
+
+        public Future<?> emit999() {
+            return executor.submit(() -> {
+                for (int i = 1; i < 1000; i++) {
+                    emit("" + i);
+                }
+                return null;
+            });
+        }
+
+        private void emit(String item) throws InterruptedException {
+            try {
+                emitter.send(item);
+                accepted.add(item);
+            } catch (IllegalStateException e) {
+                rejected.add(item);
+                Thread.sleep(1);
+            }
+        }
+
+        @Incoming("hello")
+        @Outgoing("out")
+        public Flowable<String> consume(Flowable<String> values) {
+            Scheduler scheduler = Schedulers.from(executor);
+            return values
+                    .observeOn(scheduler)
+                    .delay(1, TimeUnit.MILLISECONDS, scheduler)
+                    .doOnError(err -> downstreamFailure = err);
+        }
+
+        @Incoming("out")
+        public void out(String s) {
+            output.add(s);
+        }
+
+    }
+}


### PR DESCRIPTION
Updates to the implementation of `Emitter` to match the changes from eclipse/microprofile-reactive-messaging#87

* Add support for the `THROW_EXCEPTION` backpressure strategy
* Update the `BUFFER` backpressure strategy to throw an exception if the buffer is full, rather than failing the stream