### PR TITLE
Consistent naming in poms

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>smallrye-reactive-messaging-api</artifactId>
-    <name>SmallRye Reactive Messaging API</name>
+    <name>SmallRye Reactive Messaging : API</name>
 
     <dependencies>
         <!--

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -12,7 +12,9 @@
 
   <artifactId>documentation</artifactId>
   <packaging>pom</packaging>
-
+  
+  <name>SmallRye Reactive Messaging : Documentation</name>  
+    
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/amqp-quickstart/pom.xml
+++ b/examples/amqp-quickstart/pom.xml
@@ -11,6 +11,8 @@
 
   <artifactId>amqp-quickstart</artifactId>
 
+  <name>SmallRye Reactive Messaging : Quickstart :: AMQP</name>  
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/awssns-quickstart/pom.xml
+++ b/examples/awssns-quickstart/pom.xml
@@ -11,7 +11,9 @@
   </parent>
 
   <artifactId>aws-sns-quickstart</artifactId>
-
+  
+  <name>SmallRye Reactive Messaging : Quickstart :: AWS SNS</name>
+  
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/cloud-events/pom.xml
+++ b/examples/cloud-events/pom.xml
@@ -11,6 +11,8 @@
 
   <artifactId>cloud-events-demo</artifactId>
 
+  <name>SmallRye Reactive Messaging : Quickstart :: Cloud Events</name>      
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/gcp-pubsub-quickstart/pom.xml
+++ b/examples/gcp-pubsub-quickstart/pom.xml
@@ -10,7 +10,9 @@
   </parent>
 
   <artifactId>gcp-pubsub-quickstart</artifactId>
-
+  
+  <name>SmallRye Reactive Messaging : Quickstart :: GCP Pub/Sub</name>
+  
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/kafka-quickstart-kotlin/pom.xml
+++ b/examples/kafka-quickstart-kotlin/pom.xml
@@ -10,7 +10,8 @@
   </parent>
 
   <artifactId>kafka-quickstart-kotlin</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  
+  <name>SmallRye Reactive Messaging : Quickstart :: Kafka Kotlin</name>
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/kafka-quickstart/pom.xml
+++ b/examples/kafka-quickstart/pom.xml
@@ -10,8 +10,9 @@
   </parent>
 
   <artifactId>kafka-quickstart</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
-
+  
+  <name>SmallRye Reactive Messaging : Quickstart :: Kafka</name>
+    
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/mqtt-quickstart/pom.xml
+++ b/examples/mqtt-quickstart/pom.xml
@@ -11,6 +11,8 @@
 
   <artifactId>mqtt-quickstart</artifactId>
 
+  <name>SmallRye Reactive Messaging : Quickstart :: MQTT</name>    
+  
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/mqtt-server-quickstart/pom.xml
+++ b/examples/mqtt-server-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
   <artifactId>mqtt-server-quickstart</artifactId>
 
-  <name>SmallRye Reactive Messaging MQTT server quickstart</name>
-
+  <name>SmallRye Reactive Messaging : Quickstart :: MQTT Server</name>    
+  
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>reactive-messaging-quickstart</artifactId>
   
-  <name>SmallRye Reactive Messaging : Quickstart :: Memory</name>    
+  <name>SmallRye Reactive Messaging : Quickstart :: General</name>    
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -11,6 +11,8 @@
   </parent>
 
   <artifactId>reactive-messaging-quickstart</artifactId>
+  
+  <name>SmallRye Reactive Messaging : Quickstart :: Memory</name>    
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>MicroProfile Reactive Streams Messaging Implementation</name>
+  <name>SmallRye Reactive Messaging</name>
+  
   <description>An implementation of the MicroProfile Reactive Streams Messaging specification</description>
   <url>http://smallrye.io</url>
 

--- a/smallrye-connector-attribute-processor/pom.xml
+++ b/smallrye-connector-attribute-processor/pom.xml
@@ -12,6 +12,8 @@
 
   <artifactId>smallrye-connector-attribute-processor</artifactId>
 
+  <name>SmallRye Reactive Messaging : Attribute Processor</name>
+
   <dependencies>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>

--- a/smallrye-connector-attribute-processor/pom.xml
+++ b/smallrye-connector-attribute-processor/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>smallrye-connector-attribute-processor</artifactId>
 
-  <name>SmallRye Reactive Messaging : Attribute Processor</name>
+  <name>SmallRye Reactive Messaging : Connector Attribute Processor</name>
 
   <dependencies>
     <dependency>

--- a/smallrye-reactive-messaging-amqp/pom.xml
+++ b/smallrye-reactive-messaging-amqp/pom.xml
@@ -10,6 +10,8 @@
 
   <artifactId>smallrye-reactive-messaging-amqp</artifactId>
 
+  <name>SmallRye Reactive Messaging : Connector :: AMQP</name>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/smallrye-reactive-messaging-aws-sns/pom.xml
+++ b/smallrye-reactive-messaging-aws-sns/pom.xml
@@ -9,7 +9,7 @@
     <vertx.version>3.8.0</vertx.version>
   </properties>
   <artifactId>smallrye-reactive-messaging-aws-sns</artifactId>
-  <name>Smallrye Reactive Messaging for AWS SNS</name>
+  <name>SmallRye Reactive Messaging : Connector :: AWS SNS</name>
   <description>A module for Smallrye reactive messaging integration with AWS Simple Notification Service (SNS).</description>
   <dependencyManagement>
     <dependencies>

--- a/smallrye-reactive-messaging-camel/pom.xml
+++ b/smallrye-reactive-messaging-camel/pom.xml
@@ -10,6 +10,8 @@
 
   <artifactId>smallrye-reactive-messaging-camel</artifactId>
 
+  <name>SmallRye Reactive Messaging : Connector :: Camel</name>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/smallrye-reactive-messaging-cloud-events/pom.xml
+++ b/smallrye-reactive-messaging-cloud-events/pom.xml
@@ -10,6 +10,8 @@
 
   <artifactId>smallrye-reactive-messaging-cloud-events</artifactId>
 
+  <name>SmallRye Reactive Messaging : Connector :: Cloud Events</name>
+
   <dependencies>
     <dependency>
       <groupId>io.cloudevents</groupId>

--- a/smallrye-reactive-messaging-gcp-pubsub/pom.xml
+++ b/smallrye-reactive-messaging-gcp-pubsub/pom.xml
@@ -10,7 +10,7 @@
 
   </properties>
   <artifactId>smallrye-reactive-messaging-gcp-pubsub</artifactId>
-  <name>Smallrye Reactive Messaging for GCP Pub/Sub</name>
+  <name>SmallRye Reactive Messaging : Connector :: GCP Pub/Sub</name>
   <description>A module for Smallrye reactive messaging integration with GCP Pub/Sub Service</description>
   <dependencyManagement>
     <dependencies>

--- a/smallrye-reactive-messaging-http/pom.xml
+++ b/smallrye-reactive-messaging-http/pom.xml
@@ -10,6 +10,8 @@
 
   <artifactId>smallrye-reactive-messaging-http</artifactId>
 
+  <name>SmallRye Reactive Messaging : Connector :: HTTP</name>
+
   <dependencies>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/smallrye-reactive-messaging-in-memory/pom.xml
+++ b/smallrye-reactive-messaging-in-memory/pom.xml
@@ -2,14 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>io.smallrye.reactive</groupId>
-        <artifactId>smallrye-reactive-messaging</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
-    </parent>
+  <parent>
+    <groupId>io.smallrye.reactive</groupId>
+    <artifactId>smallrye-reactive-messaging</artifactId>
+    <version>2.1.0-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
-
+  <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
+    
+  <name>SmallRye Reactive Messaging : Connector :: In-memory</name>
+    
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/smallrye-reactive-messaging-jms/pom.xml
+++ b/smallrye-reactive-messaging-jms/pom.xml
@@ -10,6 +10,8 @@
 
   <artifactId>smallrye-reactive-messaging-jms</artifactId>
 
+  <name>SmallRye Reactive Messaging : Connector :: JMS</name>  
+
   <properties>
     <artemis.version>2.12.0</artemis.version>
   </properties>

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -11,6 +11,8 @@
 
   <artifactId>smallrye-reactive-messaging-kafka</artifactId>
 
+  <name>SmallRye Reactive Messaging : Connector :: Kafka</name>
+
   <properties>
     <kafka.version>2.5.0</kafka.version>
     <debezium.version>1.1.2.Final</debezium.version>

--- a/smallrye-reactive-messaging-mqtt-server/pom.xml
+++ b/smallrye-reactive-messaging-mqtt-server/pom.xml
@@ -11,6 +11,8 @@
 
   <artifactId>smallrye-reactive-messaging-mqtt-server</artifactId>
 
+  <name>SmallRye Reactive Messaging : Connector :: MQTT Server</name>
+
   <properties>
     <!-- Test dependencies versions -->
     <version.junit5>5.6.2</version.junit5>

--- a/smallrye-reactive-messaging-mqtt/pom.xml
+++ b/smallrye-reactive-messaging-mqtt/pom.xml
@@ -11,6 +11,8 @@
 
   <artifactId>smallrye-reactive-messaging-mqtt</artifactId>
 
+  <name>SmallRye Reactive Messaging : Connector :: MQTT</name>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/smallrye-reactive-messaging-provider/pom.xml
+++ b/smallrye-reactive-messaging-provider/pom.xml
@@ -10,7 +10,8 @@
 
   <artifactId>smallrye-reactive-messaging-provider</artifactId>
 
-
+  <name>SmallRye Reactive Messaging : Provider</name>
+  
   <dependencies>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>

--- a/smallrye-reactive-messaging-vertx-eventbus/pom.xml
+++ b/smallrye-reactive-messaging-vertx-eventbus/pom.xml
@@ -10,6 +10,8 @@
 
   <artifactId>smallrye-reactive-messaging-vertx-eventbus</artifactId>
 
+  <name>SmallRye Reactive Messaging : Connector :: VertX EventBus</name>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -10,6 +10,8 @@
 
   <artifactId>tck</artifactId>
 
+  <name>SmallRye Reactive Messaging : TCK</name>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.microprofile.reactive.messaging</groupId>


### PR DESCRIPTION
A small PR that add consistent naming in the poms. That might help navigating the modules (especially for a newcomer)

Before:
![before](https://user-images.githubusercontent.com/6836179/83680863-d354dc00-a5e1-11ea-9573-bc2262556e38.png)

After:
![after](https://user-images.githubusercontent.com/6836179/83680881-dc45ad80-a5e1-11ea-8813-d9d731f91747.png)



Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>