### PR TITLE
Add support for Kafka's ConsumerRebalanceListener

### DIFF
--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -69,4 +69,8 @@ Type: _string_ | false |
 
 Type: _int_ | false | `1`
 
+| *consumer-rebalance-listener.name* | The name set in `javax.inject.Named` of a bean that implements `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener`. If set the listener will be applied to the consumer.
+
+Type: _string_ | false | 
+
 |===

--- a/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumer.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumer.java
@@ -1,0 +1,21 @@
+package inbound;
+
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+@ApplicationScoped
+public class KafkaRebalancedConsumer {
+
+    @Incoming("rebalanced-example")
+    @Acknowledgment(Acknowledgment.Strategy.NONE)
+    public CompletionStage<Void> consume(IncomingKafkaRecord<Integer, String> message) {
+        // We don't need to ACK messages because in this example we set offset during consumer re-balance
+        return CompletableFuture.completedFuture(null);
+    }
+
+}

--- a/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumerRebalanceListener.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumerRebalanceListener.java
@@ -1,0 +1,60 @@
+package inbound;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+@Named("rebalanced-example.rebalancer")
+public class KafkaRebalancedConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
+
+    private static final Logger LOGGER = Logger.getLogger(KafkaRebalancedConsumerRebalanceListener.class.getName());
+
+    /**
+     * When receiving a list of partitions will search for the earliest offset within 10 minutes
+     * and seek the consumer to it.
+     *
+     * @param consumer        underlying consumer
+     * @param topicPartitions set of assigned topic partitions
+     * @return A {@link Uni} indicating operations complete or failure
+     */
+    @Override
+    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions) {
+        long now = System.currentTimeMillis();
+        long shouldStartAt = now - 600_000L; //10 minute ago
+
+        return Uni
+            .combine()
+            .all()
+            .unis(topicPartitions
+                .stream()
+                .map(topicPartition -> {
+                    LOGGER.info("Assigned " + topicPartition);
+                    return consumer.offsetsForTimes(topicPartition, shouldStartAt)
+                        .onItem()
+                        .invoke(o -> LOGGER.info("Seeking to " + o))
+                        .onItem()
+                        .produceUni(o -> consumer
+                            .seek(topicPartition, o == null ? 0L : o.getOffset())
+                            .onItem()
+                            .invoke(v -> LOGGER.info("Seeked to " + o))
+                        );
+                })
+                .collect(Collectors.toList()))
+            .combinedWith(a -> null);
+    }
+
+    @Override
+    public Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions) {
+        return Uni
+            .createFrom()
+            .nullItem();
+    }
+}

--- a/documentation/src/main/doc/modules/kafka/pages/consumer-rebalance-listener.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/consumer-rebalance-listener.adoc
@@ -1,0 +1,36 @@
+[#kafka-consumer-rebalance-listener]
+=== Consumer Rebalance Listener
+
+An implementation of the consumer re-balance listener can be provided which affords us fine grain controls of the assigned
+offset. Common uses are storing offsets in a separate store to enable deliver exactly-once semantics, and starting from
+a specific time window.
+
+Whenever the topic partitions assigned method is called the consumer will pause. It will only resume once the returned
+Uni succeeds. In the case of failure it will retry until success or until the consumer session times out in which case
+it will resume again forcing a new consumer re-balance.
+
+==== Example
+
+In this example we will set-up a consumer that always starts on messages from at most 10 minutes ago. First we need to provide
+a bean managed implementation of `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener` annotated with
+`javax.inject.Named`. We then must configure our inbound connector to use this named bean.
+
+[source, java]
+----
+include::example$inbound/KafkaRebalancedConsumerRebalanceListener.java[]
+----
+
+[source, java]
+----
+include::example$inbound/KafkaRebalancedConsumer.java[]
+----
+
+To configure the inbound connector to use the provided listener we either set the consumer rebalance listener's name:
+
+* `mp.messaging.incoming.rebalanced-example.consumer-rebalance-listener.name=rebalanced-example.rebalancer`
+
+Or have the listener's name be the same as the group id:
+
+* `mp.messaging.incoming.rebalanced-example.group.id=rebalanced-example.rebalancer`
+
+Setting the consumer re-balance listener's name takes precedence over using the group id.

--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -94,3 +94,5 @@ It may also contain the `dead-letter-cause` with the message from the cause, if 
 include::connectors:partial$META-INF/connector/smallrye-kafka-incoming.adoc[]
 
 You can also pass any property supported by the https://vertx.io/docs/vertx-kafka-client/java/[Vert.x Kafka client] as attribute.
+
+include::consumer-rebalance-listener.adoc[]

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
@@ -1,0 +1,63 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.Set;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+
+/**
+ *
+ * When implemented by a managed bean annotated with {@link javax.inject.Named} and
+ * configured against an inbound connector will be applied as a consumer re-balance listener
+ * to that inbound connector's consumer.
+ *
+ *
+ * To configure which listener you want to use, set the name in the inbound connector's consumer re-balance listener attribute,
+ * ex:
+ * {@code
+ *  mp.messaging.incoming.example.consumer-rebalance- listener.name=ExampleConsumerRebalanceListener
+ * }
+ * {@code @Named("ExampleConsumerRebalanceListener")}
+ *
+ * Alternatively, name your listener (using the {@code @Named} annotation) to be the group id used by the connector, ex:
+ * {@code
+ *  mp.messaging.incoming.example.group.id=my-group
+ * }
+ * {@code @Named("my-group")}
+ *
+ * Setting the consumer re-balance listener name takes precedence over using the group id.
+ *
+ * For more details:
+ *
+ * @see org.apache.kafka.clients.consumer.ConsumerRebalanceListener
+ */
+public interface KafkaConsumerRebalanceListener {
+
+    /**
+     * Called when the consumer is assigned topic partitions
+     * This method might be called for each consumer available to the connector
+     *
+     * The consumer will be paused until the returned {@link Uni}
+     * indicates success. On failure will retry using an exponential back off until the consumer can
+     * be considered timed-out by Kafka, in which case will resume anyway triggering a new re-balance.
+     *
+     * @see KafkaConsumer#pause()
+     * @see KafkaConsumer#resume()
+     *
+     * @param consumer underlying consumer
+     * @param topicPartitions set of assigned topic partitions
+     * @return A {@link Uni} indicating operations complete or failure
+     */
+    Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions);
+
+    /**
+     * Called when the consumer is revoked topic partitions
+     * This method might be called for each consumer available to the connector
+     *
+     * @param consumer underlying consumer
+     * @param topicPartitions set of revoked topic partitions
+     * @return A {@link Uni} indicating operations complete or failure
+     */
+    Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions);
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -93,4 +93,41 @@ public interface KafkaLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 18218, value = "An exception has been caught while closing the Kafka consumer")
     void exceptionOnClose(@Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18219, value = "Loading KafkaConsumerRebalanceListener from configured name '%s'")
+    void loadingConsumerRebalanceListenerFromConfiguredName(String configuredName);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18220, value = "Loading KafkaConsumerRebalanceListener from group id '%s'")
+    void loadingConsumerRebalanceListenerFromGroupId(String consumerGroup);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 18221, value = "Unable to execute consumer assigned re-balance listener for group '%s'. The consumer has been paused. Will retry until the consumer session times out in which case will resume to force a new re-balance attempt.")
+    void unableToExecuteConsumerAssignedRebalanceListener(String consumerGroup, @Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 18222, value = "Unable to execute consumer revoked re-balance listener for group '%s'")
+    void unableToExecuteConsumerRevokedRebalanceListener(String consumerGroup, @Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18223, value = "Executing consumer assigned re-balance listener for group '%s'")
+    void executingConsumerAssignedRebalanceListener(String consumerGroup);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18224, value = "Executing consumer revoked re-balance listener for group '%s'")
+    void executingConsumerRevokedRebalanceListener(String consumerGroup);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18225, value = "Executed consumer assigned re-balance listener for group '%s'")
+    void executedConsumerAssignedRebalanceListener(String consumerGroup);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18226, value = "Executed consumer revoked re-balance listener for group '%s'")
+    void executedConsumerRevokedRebalanceListener(String consumerGroup);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 18227, value = "Re-enabling consumer for group '%s'. This consumer was paused because of a re-balance failure.")
+    void reEnablingConsumerforGroup(String consumerGroup);
+
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionBeanWithoutAck.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionBeanWithoutAck.java
@@ -1,0 +1,29 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class ConsumptionBeanWithoutAck {
+
+    private final List<Integer> list = Collections.synchronizedList(new ArrayList<>());
+
+    @Incoming("data")
+    @Acknowledgment(Acknowledgment.Strategy.NONE)
+    public CompletionStage<Void> sink(KafkaRecord<String, Integer> input) {
+        list.add(input.getPayload() + 1);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public List<Integer> getResults() {
+        return list;
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
@@ -1,0 +1,38 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+
+@ApplicationScoped
+@Named("ConsumptionConsumerRebalanceListener")
+public class ConsumptionConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
+
+    private final Map<Integer, TopicPartition> assigned = new ConcurrentHashMap<>();
+
+    @Override
+    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
+        set.forEach(topicPartition -> this.assigned.put(topicPartition.getPartition(), topicPartition));
+        return Uni
+                .createFrom()
+                .nullItem();
+    }
+
+    @Override
+    public Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
+        return Uni
+                .createFrom()
+                .nullItem();
+    }
+
+    public Map<Integer, TopicPartition> getAssigned() {
+        return assigned;
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
@@ -1,0 +1,37 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+
+@ApplicationScoped
+@Named("my-group-starting-on-fifth-fail-on-first-attempt")
+public class StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener
+        extends StartFromFifthOffsetFromLatestConsumerRebalanceListener {
+
+    private final AtomicBoolean failOnFirstAttempt = new AtomicBoolean(true);
+
+    @Override
+    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
+        // will perform the underlying operation but simulate an error on the first attempt
+        return super.onPartitionsAssigned(consumer, set)
+                .onItem()
+                .produceUni(a -> {
+                    if (!set.isEmpty() && failOnFirstAttempt.getAndSet(false)) {
+                        return Uni
+                                .createFrom()
+                                .failure(new Exception("testing failure"));
+                    } else {
+                        return Uni
+                                .createFrom()
+                                .item(a);
+                    }
+                });
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.java
@@ -1,0 +1,30 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+
+@ApplicationScoped
+@Named("my-group-starting-on-fifth-fail-until-second-rebalance")
+public class StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener
+        extends StartFromFifthOffsetFromLatestConsumerRebalanceListener {
+    private final AtomicBoolean failOnFirstAttempt = new AtomicBoolean(true);
+
+    @Override
+    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
+        if (!set.isEmpty() && failOnFirstAttempt.getAndSet(false)) {
+            // will perform the underlying operation but simulate an error
+            return super.onPartitionsAssigned(consumer, set)
+                    .onItem()
+                    .failWith(a -> new Exception("testing failure"));
+        }
+        return super.onPartitionsAssigned(consumer, set);
+
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
@@ -1,0 +1,44 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+
+@ApplicationScoped
+@Named("my-group-starting-on-fifth-happy-path")
+public class StartFromFifthOffsetFromLatestConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
+
+    private volatile int rebalanceCount = 0;
+
+    @Override
+    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
+        rebalanceCount++;
+        return Uni
+                .combine()
+                .all()
+                .unis(set
+                        .stream()
+                        .map(topicPartition -> consumer.endOffsets(topicPartition)
+                                .onItem()
+                                .produceUni(o -> consumer.seek(topicPartition, Math.max(0L, o - 5L))))
+                        .collect(Collectors.toList()))
+                .combinedWith(a -> null);
+    }
+
+    @Override
+    public Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions) {
+        return Uni
+                .createFrom()
+                .nullItem();
+    }
+
+    public int getRebalanceCount() {
+        return rebalanceCount;
+    }
+}


### PR DESCRIPTION
Details https://github.com/smallrye/smallrye-reactive-messaging/issues/577

Had to create a custom listener interface that also receives the KafkaConsumer beside the assigned topics with partitions. This is necessary for use cases that involves seeking to specific offsets during rebalance/initialization.