### PR TITLE
Configure Kafka Source to use the same group-id if configured for con…

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -7,7 +7,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.literal.NamedLiteral;
@@ -32,16 +31,11 @@ public class KafkaSource<K, V> {
     private final KafkaFailureHandler failureHandler;
 
     public KafkaSource(Vertx vertx,
+            String group,
             KafkaConnectorIncomingConfiguration config,
             Instance<KafkaConsumerRebalanceListener> consumerRebalanceListeners) {
 
         Map<String, String> kafkaConfiguration = new HashMap<>();
-
-        String group = config.getGroupId().orElseGet(() -> {
-            String s = UUID.randomUUID().toString();
-            log.noGroupId(s);
-            return s;
-        });
 
         JsonHelper.asJsonObject(config.config())
                 .forEach(e -> kafkaConfiguration.put(e.getKey(), e.getValue().toString()));


### PR DESCRIPTION
…currency (partitions > 1)

If the user configured `group-id` in the inbound connector configs there is no issue. But if not configured we were generating a unique group id per `KafkaSource`. In this case each `KafkaSource` would receive all events from the Topic with no load balancing.