### PR TITLE
Use mutiny retry expire when handling failure during kafka re-balance

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -85,31 +85,26 @@ public class KafkaSource<K, V> {
                     // If the re-balance assign fails we must resume the consumer in order to force a consumer group
                     // re-balance. To do so we must wait until after the poll interval time or
                     // poll interval time + session timeout if group instance id is not null.
-                    final long consumerReEnableWaitTime = Long.parseLong(
-                            kafkaConfiguration.getOrDefault(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "300000"))
-                            + (kafkaConfiguration.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG) == null ? 0L
-                                    : Long.parseLong(
-                                            kafkaConfiguration.getOrDefault(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG,
-                                                    "10000")));
-
                     // We will retry the re-balance consumer listener on failure using an exponential backoff until
                     // we can allow the kafka consumer to do it on its own. We do this because by default it would take
                     // 5 minutes for kafka to do this which is too long. With defaults consumerReEnableWaitTime would be
                     // 500000 millis. We also can't simply retry indefinitely because once the consumer has been paused
                     // for consumerReEnableWaitTime kafka will force a re-balance once resumed.
-                    // We are doing retries using the time intervals 2s, 4s, 8s, 10s, 10s, 10s, 10s...
-                    // The following formula will give us a reasonable number for retry attempt that is just greater
-                    // than consumerReEnableWaitTime
-                    final long consumerReEnableRetryMaxAttempts = 1
-                            + Math.max(0, 3 + (consumerReEnableWaitTime - 14_000) / 10_000);
+                    final long consumerReEnableWaitTime = Long.parseLong(
+                            kafkaConfiguration.getOrDefault(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "300000"))
+                            + (kafkaConfiguration.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG) == null ? 0L
+                                    : Long.parseLong(
+                                            kafkaConfiguration.getOrDefault(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG,
+                                                    "10000")))
+                            + 11_000L; // it's possible that it might expire 10 seconds before when we need it to
 
                     kafkaConsumer.partitionsAssignedHandler(set -> {
                         kafkaConsumer.pause();
                         log.executingConsumerAssignedRebalanceListener(group);
                         listener.onPartitionsAssigned(kafkaConsumer, set)
                                 .onFailure().invoke(t -> log.unableToExecuteConsumerAssignedRebalanceListener(group, t))
-                                .onFailure().retry().withBackOff(Duration.ofSeconds(1), Duration.ofSeconds(10)).withJitter(0.0)
-                                .atMost(consumerReEnableRetryMaxAttempts)
+                                .onFailure().retry().withBackOff(Duration.ofSeconds(1), Duration.ofSeconds(10))
+                                .expireIn(consumerReEnableWaitTime)
                                 .subscribe()
                                 .with(
                                         a -> {


### PR DESCRIPTION
@cescoffier Noticed you updated Mutiny. Simplified some code here.