### PR TITLE
Fix example execution (maven-exec-plugin config issue)

### DIFF
--- a/examples/amqp-quickstart/pom.xml
+++ b/examples/amqp-quickstart/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>amqp-quickstart</artifactId>
 
-  <name>SmallRye Reactive Messaging : Quickstart :: AMQP</name>  
+  <name>SmallRye Reactive Messaging : Quickstart :: AMQP</name>
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -101,6 +101,7 @@
         </executions>
         <configuration>
           <mainClass>${mainClass}</mainClass>
+          <classpathScope>compile</classpathScope>
         </configuration>
       </plugin>
 

--- a/examples/kafka-quickstart-kotlin/pom.xml
+++ b/examples/kafka-quickstart-kotlin/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>kafka-quickstart-kotlin</artifactId>
-  
+
   <name>SmallRye Reactive Messaging : Quickstart :: Kafka Kotlin</name>
 
   <properties>
@@ -136,6 +136,7 @@
         </executions>
         <configuration>
           <mainClass>${mainClass}</mainClass>
+          <classpathScope>compile</classpathScope>
         </configuration>
       </plugin>
 

--- a/examples/mqtt-quickstart/README.md
+++ b/examples/mqtt-quickstart/README.md
@@ -9,11 +9,11 @@ First you need a MQTT server. You can follow the instructions from the [Eclipse 
 
 ## Start the application
 
-The application can be started using: 
+The application can be started using:
 
 ```bash
 mvn package exec:java
-```  
+```
 
 Then, looking at the output you can see messages successfully send to and retrieved from a MQTT topic.
 
@@ -22,8 +22,8 @@ Then, looking at the output you can see messages successfully send to and retrie
 In addition to the commandline output, the application is composed by 3 components:
 
 * `BeanUsingAnEmitter` - a bean sending a changing hello message to MQTT topic every second.
-* `Sender` - a bean sending a fixed message to a dynamic MQTT topic every 5 seconds.
-* `Receiver`  - on the consuming side, the `Receiver` retreives messages from a MQTT topic and writes the message content to `stdout`.
+* `Sender` - a bean sending a fixed message to the "hello" MQTT topic every 5 seconds.
+* `Receiver`  - on the consuming side, the `Receiver` retrieves messages from a MQTT topic and writes the message content to `stdout`.
 
 The interaction with MQTT is managed by MicroProfile Reactive Messaging.
 The configuration is located in the microprofile config properties.

--- a/examples/mqtt-quickstart/pom.xml
+++ b/examples/mqtt-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
   <artifactId>mqtt-quickstart</artifactId>
 
-  <name>SmallRye Reactive Messaging : Quickstart :: MQTT</name>    
-  
+  <name>SmallRye Reactive Messaging : Quickstart :: MQTT</name>
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -101,6 +101,7 @@
         </executions>
         <configuration>
           <mainClass>${mainClass}</mainClass>
+          <classpathScope>compile</classpathScope>
         </configuration>
       </plugin>
 

--- a/examples/mqtt-quickstart/src/main/java/acme/Sender.java
+++ b/examples/mqtt-quickstart/src/main/java/acme/Sender.java
@@ -1,6 +1,5 @@
 package acme;
 
-import java.time.LocalDate;
 import java.util.concurrent.*;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -18,8 +17,8 @@ public class Sender {
     public CompletionStage<MqttMessage> send() {
         CompletableFuture<MqttMessage> future = new CompletableFuture<>();
         delay(() -> {
-            System.out.println("Sending message on dynamic topic: hello");
-            future.complete(MqttMessage.of("mqtt-" + LocalDate.now().toString(), "hello from dynamic topic",
+            System.out.println("Sending message on topic: hello");
+            future.complete(MqttMessage.of("hello", "hello from dynamic topic",
                     null, true));
         });
         return future;

--- a/examples/mqtt-quickstart/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/mqtt-quickstart/src/main/resources/META-INF/microprofile-config.properties
@@ -15,7 +15,7 @@ smallrye.messaging.sink.my-channel.auto-generated-client-id=true
 
 # MQTT source (we read from)
 smallrye.messaging.source.my-topic.connector=smallrye-mqtt
-smallrye.messaging.source.my-topic.topic=#
+smallrye.messaging.source.my-topic.topic=hello
 smallrye.messaging.source.my-topic.host=localhost
 smallrye.messaging.source.my-topic.port=1883
 smallrye.messaging.source.my-topic.auto-generated-client-id=true

--- a/examples/mqtt-server-quickstart/pom.xml
+++ b/examples/mqtt-server-quickstart/pom.xml
@@ -11,8 +11,8 @@
 
   <artifactId>mqtt-server-quickstart</artifactId>
 
-  <name>SmallRye Reactive Messaging : Quickstart :: MQTT Server</name>    
-  
+  <name>SmallRye Reactive Messaging : Quickstart :: MQTT Server</name>
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -22,6 +22,8 @@
     <weld-core.version>3.1.2.Final</weld-core.version>
     <slf4j.version>1.7.28</slf4j.version>
     <mutiny.version>0.5.3</mutiny.version>
+
+    <mainClass>acme.Main</mainClass>
   </properties>
 
   <dependencies>
@@ -87,6 +89,23 @@
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <configuration>
           <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>start-example</id>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>${mainClass}</mainClass>
+          <classpathScope>compile</classpathScope>
         </configuration>
       </plugin>
     </plugins>

--- a/examples/mqtt-server-quickstart/src/main/java/acme/MqttServerQuickstart.java
+++ b/examples/mqtt-server-quickstart/src/main/java/acme/MqttServerQuickstart.java
@@ -17,7 +17,7 @@ public class MqttServerQuickstart {
 
     @Incoming("my-server")
     public CompletionStage<Void> source(MqttMessage message) {
-        LOGGER.info("MQTT Message received {}", message);
+        LOGGER.info("MQTT Message received {}", new String(message.getPayload()));
         return message.ack();
     }
 }


### PR DESCRIPTION
The examples were missing the classpath configuration in the maven-exec-plugin (change in the plugin itself).
It also fixes the MQTT quickstart to not use a dynamic topic (see #615)
