### PR TITLE
Provide the infrastructure to support health reporting

### DIFF
--- a/api/src/main/java/io/smallrye/reactive/messaging/health/HealthReport.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/health/HealthReport.java
@@ -1,0 +1,147 @@
+package io.smallrye.reactive.messaging.health;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represent an health status and its set of attached data.
+ */
+public class HealthReport {
+
+    /**
+     * A report used when there are no channels.
+     */
+    public static final HealthReport OK_INSTANCE = new HealthReport(Collections.emptyList());
+
+    /**
+     * The general status. {@code true} is everything is fine, {@code false} otherwise
+     */
+    private final boolean ok;
+
+    /**
+     * Contains the details for each channel.
+     */
+    private final List<ChannelInfo> channels;
+
+    public HealthReport(List<ChannelInfo> channels) {
+        this.channels = Collections.unmodifiableList(channels);
+        for (ChannelInfo info : channels) {
+            if (!info.isOk()) {
+                ok = false;
+                return;
+            }
+        }
+        ok = true;
+    }
+
+    public boolean isOk() {
+        return ok;
+    }
+
+    public List<ChannelInfo> getChannels() {
+        return channels;
+    }
+
+    public static HealthReportBuilder builder() {
+        return new HealthReportBuilder();
+    }
+
+    /**
+     * Structure storing the health detail of a specific channel.
+     */
+    public static class ChannelInfo {
+
+        /**
+         * The name of the channel, must not be {@code null}
+         */
+        private final String channel;
+
+        /**
+         * An optional message.
+         */
+        private final String message;
+
+        /**
+         * Whether the channel is ready or alive (depending on the check).
+         */
+        private final boolean ok;
+
+        public ChannelInfo(String channel, boolean ok, String message) {
+            this.channel = channel;
+            this.message = message;
+            this.ok = ok;
+        }
+
+        public ChannelInfo(String channel, boolean ok) {
+            this(channel, ok, null);
+        }
+
+        public String getChannel() {
+            return channel;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public boolean isOk() {
+            return ok;
+        }
+    }
+
+    /**
+     * A builder to ease the creation of {@link HealthReport}.
+     * Instances are not thread-safe.
+     */
+    public static class HealthReportBuilder {
+
+        private final List<ChannelInfo> channels = new ArrayList<>();
+
+        private HealthReportBuilder() {
+            // avoid direct instantiation.
+        }
+
+        /**
+         * Adds a channel info to the report.
+         *
+         * @param info the info, must not be {@code null}
+         * @return this builder
+         */
+        public HealthReportBuilder add(ChannelInfo info) {
+            this.channels.add(info);
+            return this;
+        }
+
+        /**
+         * Adds a channel info to the report.
+         *
+         * @param channel the channel, must not be {@code null}
+         * @param ok if the channel is ok
+         * @return this builder
+         */
+        public HealthReportBuilder add(String channel, boolean ok) {
+            return add(new ChannelInfo(channel, ok));
+        }
+
+        /**
+         * Adds a channel info to the report.
+         *
+         * @param channel the channel, must not be {@code null}
+         * @param ok if the channel is ok
+         * @param message an optional message
+         * @return this builder
+         */
+        public HealthReportBuilder add(String channel, boolean ok, String message) {
+            return add(new ChannelInfo(channel, ok, message));
+        }
+
+        /**
+         * @return the built report
+         */
+        public HealthReport build() {
+            return new HealthReport(channels);
+        }
+    }
+
+}

--- a/api/src/main/java/io/smallrye/reactive/messaging/health/HealthReporter.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/health/HealthReporter.java
@@ -1,0 +1,16 @@
+package io.smallrye.reactive.messaging.health;
+
+/**
+ * Interface implemented by connector to participate to the health data collection.
+ */
+public interface HealthReporter {
+
+    default HealthReport getReadiness() {
+        return HealthReport.OK_INSTANCE;
+    }
+
+    default HealthReport getLiveness() {
+        return HealthReport.OK_INSTANCE;
+    }
+
+}

--- a/api/src/test/java/io/smallrye/reactive/messaging/health/HealthReportTest.java
+++ b/api/src/test/java/io/smallrye/reactive/messaging/health/HealthReportTest.java
@@ -1,0 +1,51 @@
+package io.smallrye.reactive.messaging.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class HealthReportTest {
+
+    @Test
+    public void testBuilderAndReport() {
+        assertThat(HealthReport.builder().add("my-channel", false).build().isOk()).isFalse();
+        assertThat(HealthReport.builder().add("my-channel", true).build().isOk()).isTrue();
+
+        HealthReport report = HealthReport.builder()
+                .add("my-channel-1", true, "everything ok")
+                .add("my-channel-2", false, "oh no!")
+                .add("my-channel-3", true)
+                .build();
+
+        assertThat(report.isOk()).isFalse();
+        assertThat(report.getChannels()).hasSize(3);
+        assertThat(report.getChannels().get(0).getChannel()).isEqualTo("my-channel-1");
+        assertThat(report.getChannels().get(0).getMessage()).isEqualTo("everything ok");
+        assertThat(report.getChannels().get(0).isOk()).isTrue();
+        assertThat(report.getChannels().get(1).getChannel()).isEqualTo("my-channel-2");
+        assertThat(report.getChannels().get(1).getMessage()).isEqualTo("oh no!");
+        assertThat(report.getChannels().get(1).isOk()).isFalse();
+        assertThat(report.getChannels().get(2).getChannel()).isEqualTo("my-channel-3");
+        assertThat(report.getChannels().get(2).getMessage()).isNull();
+        assertThat(report.getChannels().get(2).isOk()).isTrue();
+
+        HealthReport report2 = HealthReport.builder()
+                .add("my-channel-1", true, "everything ok")
+                .add("my-channel-2", true, "back on track")
+                .add("my-channel-3", true)
+                .build();
+
+        assertThat(report2.isOk()).isTrue();
+        assertThat(report2.getChannels()).hasSize(3);
+    }
+
+    @Test
+    public void testOkInstance() {
+        assertThat(HealthReport.OK_INSTANCE.isOk()).isTrue();
+        assertThat(HealthReport.OK_INSTANCE.getChannels()).isEmpty();
+
+        assertThatThrownBy(() -> HealthReport.OK_INSTANCE.getChannels().add(new HealthReport.ChannelInfo("boom", false)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/api/src/test/java/io/smallrye/reactive/messaging/health/HealthReporterTest.java
+++ b/api/src/test/java/io/smallrye/reactive/messaging/health/HealthReporterTest.java
@@ -1,0 +1,20 @@
+package io.smallrye.reactive.messaging.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class HealthReporterTest {
+
+    @Test
+    public void testDefaults() {
+        HealthReporter reporter = new HealthReporter() {
+            // use default implementation.
+        };
+
+        assertThat(reporter.getLiveness().isOk()).isTrue();
+        assertThat(reporter.getReadiness().isOk()).isTrue();
+        assertThat(reporter.getReadiness().getChannels()).isEmpty();
+        assertThat(reporter.getLiveness().getChannels()).isEmpty();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,12 @@
     <microprofile-reactive-streams.version>1.0.1</microprofile-reactive-streams.version>
     <microprofile-config.version>1.4</microprofile-config.version>
     <microprofile-metrics-api.version>2.3.2</microprofile-metrics-api.version>
+    <microprofile-health-api.version>2.2</microprofile-health-api.version>
 
     <smallrye-config.version>1.8.1</smallrye-config.version>
     <smallrye-metrics.version>2.4.2</smallrye-metrics.version>
     <smallrye-common.version>1.0.2</smallrye-common.version>
+    <smallrye-health.version>2.2.1</smallrye-health.version>
 
     <mutiny.version>0.5.4</mutiny.version>
 
@@ -95,6 +97,7 @@
     <module>smallrye-reactive-messaging-cloud-events</module>
     <module>smallrye-reactive-messaging-jms</module>
     <module>smallrye-reactive-messaging-gcp-pubsub</module>
+    <module>smallrye-reactive-messaging-health</module>
 
     <module>examples/quickstart</module>
     <module>examples/cloud-events</module>
@@ -168,6 +171,19 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-metrics</artifactId>
         <version>${smallrye-metrics.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.microprofile.health</groupId>
+        <artifactId>microprofile-health-api</artifactId>
+        <version>${microprofile-health-api.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-health</artifactId>
+        <version>${smallrye-health.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/smallrye-reactive-messaging-aws-sns/src/test/java/io/smallrye/reactive/messaging/aws/sns/AwsSnsTestBase.java
+++ b/smallrye-reactive-messaging-aws-sns/src/test/java/io/smallrye/reactive/messaging/aws/sns/AwsSnsTestBase.java
@@ -16,6 +16,7 @@ import io.smallrye.reactive.messaging.MediatorFactory;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.extension.ChannelProducer;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
@@ -68,6 +69,7 @@ public class AwsSnsTestBase {
         weld.addBeanClass(ChannelProducer.class);
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
+        weld.addBeanClass(HealthCenter.class);
         weld.addExtension(new ReactiveMessagingExtension());
 
         weld.addBeanClass(SnsConnector.class);

--- a/smallrye-reactive-messaging-gcp-pubsub/src/test/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubTestBase.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/test/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubTestBase.java
@@ -17,6 +17,7 @@ import io.smallrye.reactive.messaging.MediatorFactory;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.extension.ChannelProducer;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
@@ -50,6 +51,7 @@ public class PubSubTestBase {
         weld.addBeanClass(ChannelProducer.class);
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
+        weld.addBeanClass(HealthCenter.class);
         weld.addExtension(new ReactiveMessagingExtension());
 
         weld.addBeanClass(PubSubManager.class);

--- a/smallrye-reactive-messaging-health/pom.xml
+++ b/smallrye-reactive-messaging-health/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.smallrye.reactive</groupId>
+    <artifactId>smallrye-reactive-messaging</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
+
+
+  <artifactId>smallrye-reactive-messaging-health</artifactId>
+
+  <name>SmallRye Reactive Messaging : Health</name>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.microprofile.health</groupId>
+      <artifactId>microprofile-health-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-health</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/HealthChecks.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/HealthChecks.java
@@ -1,0 +1,27 @@
+package io.smallrye.reactive.messaging.health;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+
+public class HealthChecks {
+    public static HealthCheckResponse getHealthCheck(HealthReport report) {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.builder()
+                .name("SmallRye Reactive Messaging")
+                .state(report.isOk());
+
+        report.getChannels().forEach(ci -> {
+            String msg = "";
+            if (ci.getMessage() != null) {
+                msg = " - " + ci.getMessage();
+            }
+            if (ci.isOk()) {
+                msg = "[OK]" + msg;
+            } else {
+                msg = "[KO]" + msg;
+            }
+            builder.withData(ci.getChannel(), msg);
+        });
+
+        return builder.build();
+    }
+}

--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheck.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheck.java
@@ -1,0 +1,23 @@
+package io.smallrye.reactive.messaging.health;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.health.*;
+
+import io.smallrye.reactive.messaging.extension.HealthCenter;
+
+@ApplicationScoped
+@Liveness
+public class SmallRyeReactiveMessagingLivenessCheck implements HealthCheck {
+
+    @Inject
+    HealthCenter health;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthReport report = health.getLiveness();
+        return HealthChecks.getHealthCheck(report);
+    }
+
+}

--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingReadinessCheck.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingReadinessCheck.java
@@ -1,0 +1,24 @@
+package io.smallrye.reactive.messaging.health;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+import io.smallrye.reactive.messaging.extension.HealthCenter;
+
+@ApplicationScoped
+@Readiness
+public class SmallRyeReactiveMessagingReadinessCheck implements HealthCheck {
+
+    @Inject
+    HealthCenter health;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthReport report = health.getReadiness();
+        return HealthChecks.getHealthCheck(report);
+    }
+}

--- a/smallrye-reactive-messaging-health/src/test/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheckTest.java
+++ b/smallrye-reactive-messaging-health/src/test/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheckTest.java
@@ -1,0 +1,92 @@
+package io.smallrye.reactive.messaging.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.reactive.messaging.spi.Connector;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
+import org.junit.Test;
+
+import io.smallrye.reactive.messaging.extension.HealthCenter;
+
+public class SmallRyeReactiveMessagingLivenessCheckTest {
+
+    @Test
+    public void testWithTwoConnectors() {
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance().disableDiscovery();
+        initializer.addBeanClasses(HealthCenter.class, MyReporterA.class, MyReporterB.class,
+                SmallRyeReactiveMessagingLivenessCheck.class);
+        SeContainer container = initializer.initialize();
+        SmallRyeReactiveMessagingLivenessCheck check = container.getBeanManager().createInstance()
+                .select(SmallRyeReactiveMessagingLivenessCheck.class, Liveness.Literal.INSTANCE).get();
+
+        assertThat(check.call().getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(check.call().getData().orElse(null)).containsExactly(entry("my-channel", "[OK]"));
+
+        MyReporterA a = container.getBeanManager().createInstance()
+                .select(MyReporterA.class, ConnectorLiteral.of("connector-a")).get();
+
+        MyReporterB b = container.getBeanManager().createInstance()
+                .select(MyReporterB.class, ConnectorLiteral.of("connector-b")).get();
+
+        a.toggle();
+
+        assertThat(check.call().getState()).isEqualTo(HealthCheckResponse.State.UP);
+
+        b.toggle();
+
+        assertThat(check.call().getState()).isEqualTo(HealthCheckResponse.State.DOWN);
+        assertThat(check.call().getData().orElse(null)).containsExactly(entry("my-channel", "[KO]"));
+    }
+
+    @Test
+    public void testWithNoConnector() {
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance().disableDiscovery();
+        initializer.addBeanClasses(HealthCenter.class, SmallRyeReactiveMessagingLivenessCheck.class);
+        SeContainer container = initializer.initialize();
+        SmallRyeReactiveMessagingLivenessCheck check = container.getBeanManager().createInstance()
+                .select(SmallRyeReactiveMessagingLivenessCheck.class, Liveness.Literal.INSTANCE).get();
+
+        assertThat(check.call().getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(check.call().getData()).isEmpty();
+    }
+
+    @ApplicationScoped
+    @Connector("connector-a")
+    private static class MyReporterA implements HealthReporter {
+
+        boolean ok = true;
+
+        @Override
+        public HealthReport getReadiness() {
+            return HealthReport.builder().add("my-channel", ok).build();
+        }
+
+        public void toggle() {
+            ok = !ok;
+        }
+    }
+
+    @ApplicationScoped
+    @Connector("connector-b")
+    private static class MyReporterB implements HealthReporter {
+
+        boolean ok = true;
+
+        @Override
+        public HealthReport getLiveness() {
+            return HealthReport.builder().add("my-channel", ok).build();
+        }
+
+        public void toggle() {
+            ok = !ok;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-health/src/test/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingReadinessCheckTest.java
+++ b/smallrye-reactive-messaging-health/src/test/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingReadinessCheckTest.java
@@ -1,0 +1,97 @@
+package io.smallrye.reactive.messaging.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+import org.eclipse.microprofile.reactive.messaging.spi.Connector;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
+import org.junit.Test;
+
+import io.smallrye.reactive.messaging.extension.HealthCenter;
+
+public class SmallRyeReactiveMessagingReadinessCheckTest {
+
+    @Test
+    public void testWithTwoConnectors() {
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance().disableDiscovery();
+        initializer.addBeanClasses(HealthCenter.class, MyReporterA.class, MyReporterB.class,
+                SmallRyeReactiveMessagingReadinessCheck.class);
+        SeContainer container = initializer.initialize();
+        SmallRyeReactiveMessagingReadinessCheck check = container.getBeanManager().createInstance()
+                .select(SmallRyeReactiveMessagingReadinessCheck.class, Readiness.Literal.INSTANCE).get();
+
+        assertThat(check.call().getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(check.call().getData().orElse(null)).containsExactly(entry("my-channel", "[OK] - test"));
+
+        MyReporterA a = container.getBeanManager().createInstance()
+                .select(MyReporterA.class, ConnectorLiteral.of("connector-a")).get();
+
+        MyReporterB b = container.getBeanManager().createInstance()
+                .select(MyReporterB.class, ConnectorLiteral.of("connector-b")).get();
+
+        a.toggle();
+
+        assertThat(check.call().getState()).isEqualTo(HealthCheckResponse.State.DOWN);
+
+        b.toggle();
+
+        assertThat(check.call().getState()).isEqualTo(HealthCheckResponse.State.DOWN);
+        assertThat(check.call().getData().orElse(null)).containsExactly(entry("my-channel", "[KO] - test"));
+
+        a.toggle();
+
+        assertThat(check.call().getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(check.call().getData().orElse(null)).containsExactly(entry("my-channel", "[OK] - test"));
+    }
+
+    @Test
+    public void testWithNoConnector() {
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance().disableDiscovery();
+        initializer.addBeanClasses(HealthCenter.class, SmallRyeReactiveMessagingReadinessCheck.class);
+        SeContainer container = initializer.initialize();
+        SmallRyeReactiveMessagingReadinessCheck check = container.getBeanManager().createInstance()
+                .select(SmallRyeReactiveMessagingReadinessCheck.class, Readiness.Literal.INSTANCE).get();
+
+        assertThat(check.call().getState()).isEqualTo(HealthCheckResponse.State.UP);
+        assertThat(check.call().getData()).isEmpty();
+    }
+
+    @ApplicationScoped
+    @Connector("connector-a")
+    private static class MyReporterA implements HealthReporter {
+
+        boolean ok = true;
+
+        @Override
+        public HealthReport getReadiness() {
+            return HealthReport.builder().add("my-channel", ok, "test").build();
+        }
+
+        public void toggle() {
+            ok = !ok;
+        }
+    }
+
+    @ApplicationScoped
+    @Connector("connector-b")
+    private static class MyReporterB implements HealthReporter {
+
+        boolean ok = true;
+
+        @Override
+        public HealthReport getLiveness() {
+            return HealthReport.builder().add("my-channel", ok).build();
+        }
+
+        public void toggle() {
+            ok = !ok;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/WeldTestBase.java
+++ b/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/WeldTestBase.java
@@ -17,6 +17,7 @@ import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.reactive.messaging.ChannelRegistry;
 import io.smallrye.reactive.messaging.MediatorFactory;
 import io.smallrye.reactive.messaging.extension.ChannelProducer;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
@@ -70,6 +71,7 @@ public class WeldTestBase {
                 ConfiguredChannelFactory.class,
                 LegacyConfiguredChannelFactory.class,
                 MetricDecorator.class,
+                HealthCenter.class,
 
                 // In memory connector
                 InMemoryConnector.class,

--- a/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/jms/support/JmsTestBase.java
+++ b/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/jms/support/JmsTestBase.java
@@ -12,6 +12,7 @@ import io.smallrye.reactive.messaging.MediatorFactory;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.extension.ChannelProducer;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
@@ -77,6 +78,7 @@ public class JmsTestBase {
         weld.addBeanClass(ChannelProducer.class);
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
+        weld.addBeanClass(HealthCenter.class);
         weld.addExtension(new ReactiveMessagingExtension());
         weld.addBeanClass(JmsConnector.class);
         weld.disableDiscovery();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaTestBase.java
@@ -19,6 +19,7 @@ import io.smallrye.reactive.messaging.MediatorFactory;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.extension.ChannelProducer;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
@@ -92,6 +93,7 @@ public class KafkaTestBase {
         weld.addBeanClass(ChannelProducer.class);
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
+        weld.addBeanClass(HealthCenter.class);
         weld.addExtension(new ReactiveMessagingExtension());
 
         weld.addBeanClass(KafkaConnector.class);

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
@@ -18,6 +18,7 @@ import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.smallrye.reactive.messaging.helpers.BroadcastHelper;
 
 public abstract class AbstractMediator {
@@ -26,6 +27,7 @@ public abstract class AbstractMediator {
     protected WorkerPoolRegistry workerPoolRegistry;
     private Invoker invoker;
     private Instance<PublisherDecorator> decorators;
+    protected HealthCenter health;
 
     public AbstractMediator(MediatorConfiguration configuration) {
         this.configuration = configuration;
@@ -150,4 +152,7 @@ public abstract class AbstractMediator {
         }
     }
 
+    public void setHealth(HealthCenter health) {
+        this.health = health;
+    }
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/SubscriberMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/SubscriberMediator.java
@@ -135,6 +135,7 @@ public class SubscriberMediator extends AbstractMediator {
                             .onItem().produceUni(msg -> invokeBlocking(msg.getPayload()))
                             .onItemOrFailure().produceUni(handleInvocationResult(m))
                             .subscribeAsCompletionStage())
+                    .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
                     .ignore();
         } else {
             this.subscriber = ReactiveStreams.<Message<?>> builder()
@@ -142,6 +143,7 @@ public class SubscriberMediator extends AbstractMediator {
                             .onItem().apply(msg -> invoke(msg.getPayload()))
                             .onItemOrFailure().produceUni(handleInvocationResult(m))
                             .subscribeAsCompletionStage())
+                    .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
                     .ignore();
         }
     }
@@ -182,6 +184,7 @@ public class SubscriberMediator extends AbstractMediator {
                         })
                         .onItemOrFailure().produceUni(handleInvocationResult(message))
                         .subscribeAsCompletionStage())
+                .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
                 .ignore();
     }
 
@@ -199,6 +202,7 @@ public class SubscriberMediator extends AbstractMediator {
                         })
                         .onItemOrFailure().produceUni(handleInvocationResult(message))
                         .subscribeAsCompletionStage())
+                .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
                 .ignore();
     }
 
@@ -238,6 +242,7 @@ public class SubscriberMediator extends AbstractMediator {
             this.subscriber = ReactiveStreams.<Message<?>> builder()
                     .flatMapCompletionStage(this::handlePreProcessingAck)
                     .via(wrapper)
+                    .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
                     .ignore();
         } else {
             Subscriber<Message<?>> sub;
@@ -250,6 +255,7 @@ public class SubscriberMediator extends AbstractMediator {
             this.subscriber = ReactiveStreams.<Message<?>> builder()
                     .flatMapCompletionStage(this::handlePreProcessingAck)
                     .via(new SubscriberWrapper<>(casted, Function.identity(), null))
+                    .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
                     .ignore();
         }
     }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/HealthCenter.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/HealthCenter.java
@@ -1,0 +1,54 @@
+package io.smallrye.reactive.messaging.extension;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.health.HealthReporter;
+
+/**
+ * Component responsible to compute the current state of the reactive messaging application.
+ */
+@ApplicationScoped
+public class HealthCenter {
+
+    @Inject
+    @Any
+    Instance<HealthReporter> reporters;
+
+    List<ReportedFailure> failures = new CopyOnWriteArrayList<>();
+
+    public HealthReport getReadiness() {
+        HealthReport.HealthReportBuilder builder = HealthReport.builder();
+        reporters.forEach(r -> r.getReadiness().getChannels().forEach(builder::add));
+        failures.forEach(rf -> builder.add(rf.source, false, rf.failure.getMessage()));
+        return builder.build();
+    }
+
+    public HealthReport getLiveness() {
+        HealthReport.HealthReportBuilder builder = HealthReport.builder();
+        reporters.forEach(r -> r.getLiveness().getChannels().forEach(builder::add));
+        failures.forEach(rf -> builder.add(rf.source, false, rf.failure.getMessage()));
+        return builder.build();
+    }
+
+    public void report(String source, Throwable cause) {
+        failures.add(new ReportedFailure(source, cause));
+    }
+
+    public static class ReportedFailure {
+        final String source;
+        final Throwable failure;
+
+        public ReportedFailure(String source, Throwable failure) {
+            this.source = source;
+            this.failure = failure;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
@@ -95,6 +95,9 @@ public class MediatorManager {
     @Inject
     Instance<PublisherDecorator> decorators;
 
+    @Inject
+    HealthCenter health;
+
     private volatile boolean initialized;
 
     public MediatorManager() {
@@ -166,6 +169,7 @@ public class MediatorManager {
                     log.initializingMethod(mediator.getMethodAsString());
 
                     mediator.setDecorators(decorators);
+                    mediator.setHealth(health);
                     mediator.setWorkerPoolRegistry(workerPoolRegistry);
 
                     try {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ReactiveMessagingExtension.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ReactiveMessagingExtension.java
@@ -9,6 +9,7 @@ import java.util.*;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.*;
+import javax.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.*;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
@@ -26,6 +27,9 @@ public class ReactiveMessagingExtension implements Extension {
     private final List<InjectionPoint> streamInjectionPoints = new ArrayList<>();
     private final List<InjectionPoint> emitterInjectionPoints = new ArrayList<>();
     private final List<WorkerPoolBean<?>> workerPoolBeans = new ArrayList<>();
+
+    @Inject
+    HealthCenter health;
 
     <T> void processClassesContainingMediators(@Observes ProcessManagedBean<T> event) {
         AnnotatedType<?> annotatedType = event.getAnnotatedBeanClass();
@@ -133,6 +137,9 @@ public class ReactiveMessagingExtension implements Extension {
 
         } catch (Exception e) {
             done.addDeploymentProblem(e);
+            if (health != null) {
+                health.report("deployment", e);
+            }
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
@@ -22,6 +22,7 @@ import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.connectors.MyDummyConnector;
 import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.extension.ChannelProducer;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
@@ -105,6 +106,7 @@ public class WeldTestBaseWithoutTails {
                 ConfiguredChannelFactory.class,
                 LegacyConfiguredChannelFactory.class,
                 MetricDecorator.class,
+                HealthCenter.class,
                 // Messaging provider
                 MyDummyConnector.class,
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/extension/HealthCenterTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/extension/HealthCenterTest.java
@@ -1,0 +1,113 @@
+package io.smallrye.reactive.messaging.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.eclipse.microprofile.reactive.messaging.spi.Connector;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
+import org.junit.Test;
+
+import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.health.HealthReporter;
+
+public class HealthCenterTest {
+
+    @Test
+    public void testWithTwoConnectors() {
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance().disableDiscovery();
+        initializer.addBeanClasses(HealthCenter.class, MyReporterA.class, MyReporterB.class);
+        SeContainer container = initializer.initialize();
+        HealthCenter center = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+
+        assertThat(center.getLiveness().isOk()).isTrue();
+        assertThat(center.getLiveness().getChannels()).hasSize(1);
+        assertThat(center.getReadiness().isOk()).isTrue();
+        assertThat(center.getReadiness().getChannels()).hasSize(1);
+
+        MyReporterA a = container.getBeanManager().createInstance()
+                .select(MyReporterA.class, ConnectorLiteral.of("connector-a")).get();
+
+        MyReporterB b = container.getBeanManager().createInstance()
+                .select(MyReporterB.class, ConnectorLiteral.of("connector-b")).get();
+
+        a.toggle();
+
+        assertThat(center.getReadiness().isOk()).isFalse();
+        assertThat(center.getLiveness().isOk()).isTrue();
+
+        b.toggle();
+
+        assertThat(center.getLiveness().isOk()).isFalse();
+        assertThat(center.getReadiness().isOk()).isFalse();
+    }
+
+    @Test
+    public void testWithNoConnector() {
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance().disableDiscovery();
+        initializer.addBeanClasses(HealthCenter.class);
+        SeContainer container = initializer.initialize();
+        HealthCenter center = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+
+        assertThat(center.getLiveness().isOk()).isTrue();
+        assertThat(center.getLiveness().getChannels()).isEmpty();
+        assertThat(center.getReadiness().isOk()).isTrue();
+        assertThat(center.getReadiness().getChannels()).isEmpty();
+    }
+
+    @Test
+    public void testWithFailureReporting() {
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance().disableDiscovery();
+        initializer.addBeanClasses(HealthCenter.class);
+        SeContainer container = initializer.initialize();
+        HealthCenter center = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+
+        assertThat(center.getLiveness().isOk()).isTrue();
+        assertThat(center.getLiveness().getChannels()).isEmpty();
+        assertThat(center.getReadiness().isOk()).isTrue();
+        assertThat(center.getReadiness().getChannels()).isEmpty();
+
+        center.report("my-channel", new IOException("boom"));
+
+        assertThat(center.getLiveness().isOk()).isFalse();
+        assertThat(center.getLiveness().getChannels()).hasSize(1);
+        assertThat(center.getReadiness().isOk()).isFalse();
+        assertThat(center.getReadiness().getChannels()).hasSize(1);
+    }
+
+    @ApplicationScoped
+    @Connector("connector-a")
+    private static class MyReporterA implements HealthReporter {
+
+        boolean ok = true;
+
+        @Override
+        public HealthReport getReadiness() {
+            return HealthReport.builder().add("my-channel", ok).build();
+        }
+
+        public void toggle() {
+            ok = !ok;
+        }
+    }
+
+    @ApplicationScoped
+    @Connector("connector-b")
+    private static class MyReporterB implements HealthReporter {
+
+        boolean ok = true;
+
+        @Override
+        public HealthReport getLiveness() {
+            return HealthReport.builder().add("my-channel", ok).build();
+        }
+
+        public void toggle() {
+            ok = !ok;
+        }
+    }
+}

--- a/smallrye-reactive-messaging-vertx-eventbus/src/test/java/io/smallrye/reactive/messaging/eventbus/EventbusTestBase.java
+++ b/smallrye-reactive-messaging-vertx-eventbus/src/test/java/io/smallrye/reactive/messaging/eventbus/EventbusTestBase.java
@@ -11,6 +11,7 @@ import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.reactive.messaging.MediatorFactory;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
@@ -30,6 +31,7 @@ public class EventbusTestBase {
         weld.addBeanClass(ConfiguredChannelFactory.class);
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
+        weld.addBeanClass(HealthCenter.class);
         weld.addExtension(new ReactiveMessagingExtension());
         weld.addBeanClass(VertxEventBusConnector.class);
 


### PR DESCRIPTION
Preliminary work to support health support.

What's not covered by this PR:

* the module exposing the reports to MP Metrics
* the update of the existing connectors to support readiness and liveness health checks

The implemented approach avoids having the provider and connectors depending on MP Health directly.  

