### PR TITLE
Implement readiness and liveness health check support for the Kafka connector

### DIFF
--- a/documentation/src/main/doc/modules/ROOT/pages/advanced/advanced.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/advanced/advanced.adoc
@@ -74,7 +74,7 @@ They are all prefixed with `SRMSG`, followed with the numeric code.
 
 In the following output, the code is `SRMSG00229`:
 
-[code]
+[source]
 ----
 [2020-06-15 13:35:07] [INFO   ] SRMSG00229: Channel manager initializing...
 ----

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -13,6 +13,10 @@ Type: _string_ | false | `localhost:9092`
 
 Type: _string_ | false | 
 
+| *health-enabled* | Whether health reporting is enabled (default) or disabled
+
+Type: _boolean_ | false | `true`
+
 | *key.deserializer* | The deserializer classname used to deserialize the record's key
 
 Type: _string_ | false | `org.apache.kafka.common.serialization.StringDeserializer`

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
@@ -17,6 +17,10 @@ Type: _string_ | false | `localhost:9092`
 
 Type: _long_ | false | `33554432`
 
+| *health-enabled* | Whether health reporting is enabled (default) or disabled
+
+Type: _boolean_ | false | `true`
+
 | *key* | A key to used when writing the record
 
 Type: _string_ | false | 

--- a/documentation/src/main/doc/modules/kafka/pages/health.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/health.adoc
@@ -1,0 +1,34 @@
+[#kafka-health]
+== Health reporting
+
+The Kafka connector reports the readiness and liveness of each channel managed by the connector.
+
+NOTE: To disable health reporting, set the `health-enabled` attribute for the channel to `false`.
+
+=== Readiness
+
+On the inbound side (receiving records from Kafka), the readiness check verifies that:
+
+* the broker is available
+* the Kafka topic is created (available in the broker).
+* no failures have been caught
+
+On the outbound side (writing records to Kafka), the readiness check verifies that:
+
+* the broker is available
+* the Kafka topic is created (available in the broker).
+
+=== Liveness
+
+On the inbound side (receiving records from Kafka), the liveness check verifies that:
+
+* no failures have been caught
+* the client is connected to the broker
+
+On the outbound side (writing records to Kafka), the liveness check verifies that:
+
+* no failures have been caught
+
+Note that a message processing failures _nacks_ the message which is then handled by the failure-strategy.
+It the responsibility of the failure-strategy to report the failure and influence the outcome of the liveness checks.
+The `fail` failure strategy reports the failure and so the liveness check will report the failure.

--- a/documentation/src/main/doc/modules/kafka/pages/kafka.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/kafka.adoc
@@ -24,6 +24,7 @@ include::inbound.adoc[]
 include::outbound.adoc[]
 include::default-configuration.adoc[]
 include::avro-configuration.adoc[]
+include::health.adoc[]
 
 
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaFailStop.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaFailStop.java
@@ -6,13 +6,16 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
 
 public class KafkaFailStop implements KafkaFailureHandler {
 
     private final String channel;
+    private final KafkaSource<?, ?> source;
 
-    public KafkaFailStop(String channel) {
+    public <K, V> KafkaFailStop(String channel, KafkaSource<?, ?> source) {
         this.channel = channel;
+        this.source = source;
     }
 
     @Override
@@ -22,6 +25,8 @@ public class KafkaFailStop implements KafkaFailureHandler {
         log.messageNackedFailStop(channel);
         CompletableFuture<Void> future = new CompletableFuture<>();
         future.completeExceptionally(reason);
+        // report failure to the connector for health check
+        source.reportFailure(reason);
         return future;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -130,4 +130,8 @@ public interface KafkaLogging extends BasicLogger {
     @Message(id = 18227, value = "Re-enabling consumer for group '%s'. This consumer was paused because of a re-balance failure.")
     void reEnablingConsumerforGroup(String consumerGroup);
 
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 18228, value = "A failure has been reported for Kafka topic '%s'")
+    void failureReported(String topic, @Cause Throwable t);
+
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaAdminHelper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaAdminHelper.java
@@ -1,0 +1,35 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorCommonConfiguration;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.kafka.admin.KafkaAdminClient;
+
+public class KafkaAdminHelper {
+
+    private KafkaAdminHelper() {
+        // avoid direct instantiation
+    }
+
+    public static KafkaAdminClient createAdminClient(KafkaConnectorCommonConfiguration configuration, Vertx vertx,
+            Map<String, Object> kafkaConfigurationMap) {
+        if (configuration.getHealthEnabled()) {
+            Map<String, String> copy = new HashMap<>();
+            for (Map.Entry<String, Object> entry : kafkaConfigurationMap.entrySet()) {
+                copy.put(entry.getKey(), entry.getValue().toString());
+            }
+            Map<String, String> adminConfiguration = new HashMap<>(copy);
+            adminConfiguration.remove("key.serializer");
+            adminConfiguration.remove("value.serializer");
+            adminConfiguration.remove("key.deserializer");
+            adminConfiguration.remove("value.deserializer");
+            adminConfiguration.remove("acks");
+            adminConfiguration.remove("max.in.flight.requests.per.connection");
+            return KafkaAdminClient.create(vertx, adminConfiguration);
+        } else {
+            return null;
+        }
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSenderProcessor.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSenderProcessor.java
@@ -1,0 +1,115 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import static io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions.ex;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.Subscriptions;
+
+class KafkaSenderProcessor
+        implements Processor<Message<?>, Message<?>>, Subscription {
+
+    private final long inflights;
+    private final boolean waitForCompletion;
+    private final Function<Message<?>, Uni<Void>> send;
+    private final AtomicReference<Subscription> subscription = new AtomicReference<>();
+    private final AtomicReference<Subscriber<? super Message<?>>> downstream = new AtomicReference<>();
+
+    public KafkaSenderProcessor(int inflights, boolean waitForCompletion, Function<Message<?>, Uni<Void>> send) {
+        this.inflights = inflights;
+        this.waitForCompletion = waitForCompletion;
+        this.send = send;
+    }
+
+    @Override
+    public void subscribe(
+            Subscriber<? super Message<?>> subscriber) {
+        if (!downstream.compareAndSet(null, subscriber)) {
+            Subscriptions.fail(subscriber, ex.illegalStateOnlyOneSubscriber());
+        } else {
+            if (subscription.get() != null) {
+                subscriber.onSubscribe(this);
+            }
+        }
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        if (this.subscription.compareAndSet(null, subscription)) {
+            Subscriber<? super Message<?>> subscriber = downstream.get();
+            if (subscriber != null) {
+                subscriber.onSubscribe(this);
+            }
+        } else {
+            Subscriber<? super Message<?>> subscriber = downstream.get();
+            if (subscriber != null) {
+                subscriber.onSubscribe(Subscriptions.CANCELLED);
+            }
+        }
+    }
+
+    @Override
+    public void onNext(Message<?> message) {
+        if (waitForCompletion) {
+            send.apply(message)
+                    .subscribe().with(
+                            x -> requestNext(message),
+                            this::onError);
+        } else {
+            send.apply(message)
+                    .subscribe().with(x -> {
+                    }, this::onError);
+            requestNext(message);
+        }
+    }
+
+    @Override
+    public void request(long l) {
+        if (l != Long.MAX_VALUE) {
+            throw ex.illegalStateConsumeWithoutBackPressure();
+        }
+        subscription.get().request(inflights);
+    }
+
+    @Override
+    public void cancel() {
+        Subscription s = KafkaSenderProcessor.this.subscription.getAndSet(Subscriptions.CANCELLED);
+        if (s != null) {
+            s.cancel();
+        }
+    }
+
+    private void requestNext(Message<?> message) {
+        Subscriber<? super Message<?>> down = downstream.get();
+        if (down != null) {
+            down.onNext(message);
+        }
+        Subscription up = this.subscription.get();
+        if (up != null) {
+            up.request(1);
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        Subscriber<? super Message<?>> subscriber = downstream.getAndSet(null);
+        if (subscriber != null) {
+            subscriber.onError(throwable);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        Subscriber<? super Message<?>> subscriber = downstream.getAndSet(null);
+        if (subscriber != null) {
+            subscriber.onComplete();
+        }
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -4,9 +4,8 @@ import static io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions.ex;
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.literal.NamedLiteral;
@@ -14,6 +13,7 @@ import javax.enterprise.inject.literal.NamedLiteral;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
@@ -22,6 +22,7 @@ import io.smallrye.reactive.messaging.kafka.fault.KafkaFailStop;
 import io.smallrye.reactive.messaging.kafka.fault.KafkaFailureHandler;
 import io.smallrye.reactive.messaging.kafka.fault.KafkaIgnoreFailure;
 import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.kafka.admin.KafkaAdminClient;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumerRecord;
 
@@ -29,6 +30,10 @@ public class KafkaSource<K, V> {
     private final Multi<IncomingKafkaRecord<K, V>> stream;
     private final KafkaConsumer<K, V> consumer;
     private final KafkaFailureHandler failureHandler;
+    private final KafkaConnectorIncomingConfiguration configuration;
+    private final KafkaAdminClient admin;
+    private final List<Throwable> failures = new ArrayList<>();
+    private final String topic;
 
     public KafkaSource(Vertx vertx,
             String group,
@@ -36,6 +41,7 @@ public class KafkaSource<K, V> {
             Instance<KafkaConsumerRebalanceListener> consumerRebalanceListeners) {
 
         Map<String, String> kafkaConfiguration = new HashMap<>();
+        this.configuration = config;
 
         JsonHelper.asJsonObject(config.config())
                 .forEach(e -> kafkaConfiguration.put(e.getKey(), e.getValue().toString()));
@@ -60,8 +66,13 @@ public class KafkaSource<K, V> {
         kafkaConfiguration.remove("broadcast");
         kafkaConfiguration.remove("partitions");
         kafkaConfiguration.remove("consumer-rebalance-listener.name");
+        kafkaConfiguration.remove("health.enabled");
 
         final KafkaConsumer<K, V> kafkaConsumer = KafkaConsumer.create(vertx, kafkaConfiguration);
+
+        Map<String, Object> adminConfiguration = new HashMap<>(kafkaConfiguration);
+        this.admin = KafkaAdminHelper.createAdminClient(this.configuration, vertx, adminConfiguration);
+
         config
                 .getConsumerRebalanceListenerName()
                 .map(name -> {
@@ -128,12 +139,15 @@ public class KafkaSource<K, V> {
                 });
         this.consumer = kafkaConsumer;
 
-        String topic = config.getTopic().orElseGet(config::getChannel);
+        topic = configuration.getTopic().orElseGet(configuration::getChannel);
 
         failureHandler = createFailureHandler(config, vertx, kafkaConfiguration);
 
         Multi<KafkaConsumerRecord<K, V>> multi = consumer.toMulti()
-                .onFailure().invoke(t -> log.unableToReadRecord(topic, t));
+                .onFailure().invoke(t -> {
+                    log.unableToReadRecord(topic, t);
+                    reportFailure(t);
+                });
 
         boolean retry = config.getRetry();
         if (retry) {
@@ -153,10 +167,21 @@ public class KafkaSource<K, V> {
 
         this.stream = multi
                 .on().subscribed(s -> {
+                    this.consumer.exceptionHandler(this::reportFailure);
                     // The Kafka subscription must happen on the subscription.
                     this.consumer.subscribeAndAwait(topic);
                 })
-                .map(rec -> new IncomingKafkaRecord<>(consumer, rec, failureHandler));
+                .map(rec -> new IncomingKafkaRecord<>(consumer, rec, failureHandler))
+                .onFailure().invoke(this::reportFailure);
+    }
+
+    public synchronized void reportFailure(Throwable failure) {
+        log.failureReported(topic, failure);
+        // Don't keep all the failures, there are only there for reporting.
+        if (failures.size() == 10) {
+            failures.remove(0);
+        }
+        failures.add(failure);
     }
 
     private KafkaFailureHandler createFailureHandler(KafkaConnectorIncomingConfiguration config, Vertx vertx,
@@ -165,11 +190,11 @@ public class KafkaSource<K, V> {
         KafkaFailureHandler.Strategy actualStrategy = KafkaFailureHandler.Strategy.from(strategy);
         switch (actualStrategy) {
             case FAIL:
-                return new KafkaFailStop(config.getChannel());
+                return new KafkaFailStop(config.getChannel(), this);
             case IGNORE:
                 return new KafkaIgnoreFailure(config.getChannel());
             case DEAD_LETTER_QUEUE:
-                return KafkaDeadLetterQueue.create(vertx, kafkaConfiguration, config);
+                return KafkaDeadLetterQueue.create(vertx, kafkaConfiguration, config, this);
             default:
                 throw ex.illegalArgumentInvalidStrategy(strategy);
         }
@@ -186,5 +211,43 @@ public class KafkaSource<K, V> {
         } catch (Throwable e) {
             log.exceptionOnClose(e);
         }
+    }
+
+    public void isAlive(HealthReport.HealthReportBuilder builder) {
+        if (configuration.getHealthEnabled()) {
+            List<Throwable> actualFailures;
+            synchronized (this) {
+                actualFailures = new ArrayList<>(failures);
+            }
+            if (!actualFailures.isEmpty()) {
+                builder.add(configuration.getChannel(), false,
+                        actualFailures.stream().map(Throwable::getMessage).collect(Collectors.joining()));
+            } else {
+                builder.add(configuration.getChannel(), true);
+            }
+        }
+
+        // If health is disable do not add anything to the builder.
+    }
+
+    public void isReady(HealthReport.HealthReportBuilder builder) {
+        // This method must not be called from the event loop.
+        if (configuration.getHealthEnabled()) {
+            Set<String> topics;
+            try {
+                topics = admin.listTopics()
+                        .await().atMost(Duration.ofSeconds(2));
+                if (topics.contains(topic)) {
+                    builder.add(configuration.getChannel(), true);
+                } else {
+                    builder.add(configuration.getChannel(), false, "Unable to find topic " + topic);
+                }
+            } catch (Exception failed) {
+                builder.add(configuration.getChannel(), false, "No response from broker for topic "
+                        + topic + " : " + failed);
+            }
+        }
+
+        // If health is disable do not add anything to the builder.
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaTestBase.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -107,6 +108,10 @@ public class KafkaTestBase {
         } else {
             MapBasedConfig.clear();
         }
+    }
+
+    public HealthCenter getHealth(WeldContainer container) {
+        return container.getBeanManager().createInstance().select(HealthCenter.class).get();
     }
 
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MetadataPropagationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MetadataPropagationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.awaitility.Awaitility.await;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +195,7 @@ public class MetadataPropagationTest extends KafkaTestBase {
 
     @ApplicationScoped
     public static class MyAppWithKafkaMetadata {
-        private final List<Integer> received = new ArrayList<>();
+        private final List<Integer> received = new CopyOnWriteArrayList<>();
         private Metadata metadata;
         private final MetadataValue original = new MetadataValue("important");
 


### PR DESCRIPTION
The Kafka connector reports the readiness and liveness of each channel managed by the connector.

### Readiness

On the inbound side (receiving records from Kafka), the readiness check verifies that:

* the broker is available
* the Kafka topic is created (available in the broker).
* no failures have been caught

On the outbound side (writing records to Kafka), the readiness check verifies that:

* the broker is available
* the Kafka topic is created (available in the broker).


### Liveness

On the inbound side (receiving records from Kafka), the liveness check verifies that:

* no failures have been caught
* the client is connected to the broker

On the outbound side (writing records to Kafka), the liveness check verifies that:

* no failures have been caught

Note that a message processing failures _nacks_ the message which is then handled by the failure-strategy.
It the responsibility of the failure-strategy to report the failure and influence the outcome of the liveness checks.
The `fail` failure strategy reports the failure and so the liveness check will report the failure.
