### PR TITLE
Add health check support to the AMQP connector

### DIFF
--- a/documentation/src/main/doc/modules/amqp/pages/amqp.adoc
+++ b/documentation/src/main/doc/modules/amqp/pages/amqp.adoc
@@ -15,6 +15,7 @@ include::installation.adoc[]
 include::inbound.adoc[]
 include::outbound.adoc[]
 include::client-customization.adoc[]
+include::health.adoc[]
 
 
 

--- a/documentation/src/main/doc/modules/amqp/pages/health.adoc
+++ b/documentation/src/main/doc/modules/amqp/pages/health.adoc
@@ -1,0 +1,14 @@
+[#amqp-health]
+== Health reporting
+
+The AMQP connector reports the readiness and liveness of each channel managed by the connector.
+The AMQP connector uses the same logic for the readiness and liveness checks.
+
+NOTE: To disable health reporting, set the `health-enabled` attribute for the channel to `false`.
+
+On the inbound side (receiving messages from AMQP), the check verifies that the receiver is attached to the broker.
+On the outbound side (sending records to AMQP), the check verifies that the sender is attached to the broker.
+
+Note that a message processing failures _nacks_ the message, which is then handled by the failure-strategy.
+It the responsibility of the failure-strategy to report the failure and influence the outcome of the checks.
+The `fail` failure strategy reports the failure, and so the check will report the fault.

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/fault/AmqpFailStop.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/fault/AmqpFailStop.java
@@ -4,6 +4,7 @@ import static io.smallrye.reactive.messaging.amqp.i18n.AMQPLogging.log;
 
 import java.util.concurrent.CompletionStage;
 
+import io.smallrye.reactive.messaging.amqp.AmqpConnector;
 import io.smallrye.reactive.messaging.amqp.AmqpMessage;
 import io.smallrye.reactive.messaging.amqp.ConnectionHolder;
 import io.vertx.mutiny.core.Context;
@@ -11,8 +12,10 @@ import io.vertx.mutiny.core.Context;
 public class AmqpFailStop implements AmqpFailureHandler {
 
     private final String channel;
+    private final AmqpConnector connector;
 
-    public AmqpFailStop(String channel) {
+    public AmqpFailStop(AmqpConnector connector, String channel) {
+        this.connector = connector;
         this.channel = channel;
     }
 
@@ -20,6 +23,9 @@ public class AmqpFailStop implements AmqpFailureHandler {
     public <V> CompletionStage<Void> handle(AmqpMessage<V> msg, Context context, Throwable reason) {
         // We mark the message as rejected and fail.
         log.nackedFailMessage(channel);
-        return ConnectionHolder.runOnContextAndReportFailure(context, reason, () -> msg.getAmqpMessage().rejected());
+        connector.reportFailure(channel, reason);
+        return ConnectionHolder.runOnContextAndReportFailure(context, reason, () -> {
+            msg.getAmqpMessage().rejected();
+        });
     }
 }

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/i18n/AMQPLogging.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/i18n/AMQPLogging.java
@@ -116,4 +116,7 @@ public interface AMQPLogging extends BasicLogger {
     @Message(id = 16224, value = "The AMQP message to address `%s` has not been sent, the client is closed")
     void messageNoSend(String actualAddress);
 
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 16225, value = "Failure reported for channel `%s`, closing client")
+    void failureReported(String channel, @Cause Throwable reason);
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpLinkTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpLinkTest.java
@@ -14,7 +14,6 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.After;
@@ -63,9 +62,8 @@ public class AmqpLinkTest extends AmqpTestBase {
                 .write();
 
         container = weld.initialize();
-        AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
-                ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
-        await().until(() -> connector.isReady("people-in"));
+        await().until(() -> isAmqpConnectorReady(container));
+        await().until(() -> isAmqpConnectorAlive(container));
 
         MyProducer producer = container.getBeanManager().createInstance().select(MyProducer.class).get();
         producer.run();

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
@@ -82,7 +82,8 @@ public class AmqpSourceTest extends AmqpTestBase {
         builder.buildRs().subscribe(createSubscriber(messages, opened));
         await().until(opened::get);
 
-        await().until(() -> provider.isReady(config.get(CHANNEL_NAME_ATTRIBUTE).toString()));
+        await().until(() -> isAmqpConnectorReady(provider));
+        await().until(() -> isAmqpConnectorAlive(provider));
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceTenIntegers(topic,
@@ -113,7 +114,8 @@ public class AmqpSourceTest extends AmqpTestBase {
         builder.buildRs().subscribe(createSubscriber(messages, opened));
         await().until(opened::get);
 
-        await().until(() -> provider.isReady(config.get(CHANNEL_NAME_ATTRIBUTE).toString()));
+        await().until(() -> isAmqpConnectorReady(provider));
+        await().until(() -> isAmqpConnectorAlive(provider));
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceTenIntegers(topic,
@@ -185,6 +187,8 @@ public class AmqpSourceTest extends AmqpTestBase {
         rs.subscribe(createSubscriber(messages1, o1));
         rs.subscribe(createSubscriber(messages2, o2));
 
+        await().until(() -> isAmqpConnectorReady(provider));
+
         await()
                 .pollDelay(5, TimeUnit.SECONDS)
                 .until(() -> o1.get() && o2.get());
@@ -218,6 +222,10 @@ public class AmqpSourceTest extends AmqpTestBase {
                 .write();
 
         ConsumptionBean bean = deploy();
+
+        await().until(() -> isAmqpConnectorReady(container));
+        await().until(() -> isAmqpConnectorAlive(container));
+
         List<Integer> list = bean.getResults();
         assertThat(list).isEmpty();
 
@@ -251,7 +259,8 @@ public class AmqpSourceTest extends AmqpTestBase {
         builder.to(createSubscriber(messages, opened)).run();
         await().until(opened::get);
 
-        await().until(() -> provider.isReady(config.get(CHANNEL_NAME_ATTRIBUTE).toString()));
+        await().until(() -> isAmqpConnectorReady(provider));
+        await().until(() -> isAmqpConnectorAlive(provider));
 
         usage.produce(topic, 1, () -> AmqpMessage.create().withBufferAsBody(Buffer.buffer("foo".getBytes())).build());
 
@@ -275,7 +284,8 @@ public class AmqpSourceTest extends AmqpTestBase {
         builder.to(createSubscriber(messages, opened)).run();
         await().until(opened::get);
 
-        await().until(() -> provider.isReady(config.get(CHANNEL_NAME_ATTRIBUTE).toString()));
+        await().until(() -> isAmqpConnectorReady(provider));
+        await().until(() -> isAmqpConnectorAlive(provider));
 
         JsonObject json = new JsonObject();
         String id = UUID.randomUUID().toString();
@@ -303,7 +313,8 @@ public class AmqpSourceTest extends AmqpTestBase {
         builder.to(createSubscriber(messages, opened)).run();
         await().until(opened::get);
 
-        await().until(() -> provider.isReady(config.get(CHANNEL_NAME_ATTRIBUTE).toString()));
+        await().until(() -> isAmqpConnectorReady(provider));
+        await().until(() -> isAmqpConnectorAlive(provider));
 
         JsonArray list = new JsonArray();
         String id = UUID.randomUUID().toString();
@@ -331,7 +342,8 @@ public class AmqpSourceTest extends AmqpTestBase {
         builder.to(createSubscriber(messages, opened)).run();
         await().until(opened::get);
 
-        await().until(() -> provider.isReady(config.get(CHANNEL_NAME_ATTRIBUTE).toString()));
+        await().until(() -> isAmqpConnectorReady(provider));
+        await().until(() -> isAmqpConnectorAlive(provider));
 
         List<String> list = new ArrayList<>();
         list.add("tag");
@@ -358,7 +370,8 @@ public class AmqpSourceTest extends AmqpTestBase {
         builder.to(createSubscriber(messages, opened)).run();
         await().until(opened::get);
 
-        await().until(() -> provider.isReady(config.get(CHANNEL_NAME_ATTRIBUTE).toString()));
+        await().until(() -> isAmqpConnectorReady(provider));
+        await().until(() -> isAmqpConnectorAlive(provider));
 
         List<String> list = new ArrayList<>();
         list.add("hello");

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpTestBase.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpTestBase.java
@@ -1,10 +1,12 @@
 package io.smallrye.reactive.messaging.amqp;
 
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.*;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.vertx.mutiny.core.Vertx;
 import repeat.RepeatRule;
 
@@ -49,11 +51,28 @@ public class AmqpTestBase {
 
     @After
     public void tearDown() {
-
         usage.close();
         executionHolder.terminate(null);
         SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
         MapBasedConfig.clear();
+    }
+
+    public boolean isAmqpConnectorReady(WeldContainer container) {
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        return health.getReadiness().isOk();
+    }
+
+    public boolean isAmqpConnectorReady(AmqpConnector connector) {
+        return connector.getReadiness().isOk();
+    }
+
+    public boolean isAmqpConnectorAlive(WeldContainer container) {
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        return health.getLiveness().isOk();
+    }
+
+    public boolean isAmqpConnectorAlive(AmqpConnector connector) {
+        return connector.getLiveness().isOk();
     }
 
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ObjectExchangeTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ObjectExchangeTest.java
@@ -63,7 +63,8 @@ public class ObjectExchangeTest extends AmqpTestBase {
         AmqpConnector connector = container.getBeanManager().createInstance()
                 .select(AmqpConnector.class, ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
 
-        await().until(() -> connector.isReady("from-amqp") && connector.isReady("to-amqp"));
+        await().until(() -> isAmqpConnectorReady(container));
+        await().until(() -> isAmqpConnectorAlive(container));
 
         Generator generator = container.getBeanManager().createInstance().select(Generator.class).get();
         Consumer consumer = container.getBeanManager().createInstance().select(Consumer.class).get();


### PR DESCRIPTION
The check verifies the that sender/receiver is attached to the broker. 