### PR TITLE
Update to Mutiny 0.6.0 and new Mutiny API usage

### DIFF
--- a/documentation/src/main/doc/antora.yml
+++ b/documentation/src/main/doc/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
         project-version: '2.2.0-SNAPSHOT'
         weld-version: '3.1.3.Final'
         smallrye-config-version: '1.8.2'
-        mutiny-version: '0.5.4'
+        mutiny-version: '0.6.0'
         camel-version: '3.4.0'
         spec-version: '1.0'
         javadoc-base: 'https://smallrye.io/smallrye-reactive-messaging/2.2.0-SNAPSHOT/apidocs'

--- a/documentation/src/main/doc/modules/ROOT/examples/consumption/ConsumptionExamples.java
+++ b/documentation/src/main/doc/modules/ROOT/examples/consumption/ConsumptionExamples.java
@@ -54,6 +54,7 @@ public class ConsumptionExamples {
         return CompletableFuture.completedFuture(null);
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     private Price handle(Price price) {
         return price;
     }

--- a/documentation/src/main/doc/modules/ROOT/examples/consumption/ConsumptionExamples.java
+++ b/documentation/src/main/doc/modules/ROOT/examples/consumption/ConsumptionExamples.java
@@ -46,7 +46,7 @@ public class ConsumptionExamples {
     public Uni<Void> consumeMessageUni(Message<Price> message) {
         return Uni.createFrom().item(message)
             .onItem().invoke(m -> handle(m.getPayload()))
-            .onItem().produceCompletionStage(x -> message.ack());
+            .onItem().transformToUni(x -> Uni.createFrom().completionStage(message.ack()));
     }
     //end::message-uni[]
 

--- a/documentation/src/main/doc/modules/ROOT/examples/processing/StreamExamples.java
+++ b/documentation/src/main/doc/modules/ROOT/examples/processing/StreamExamples.java
@@ -14,10 +14,10 @@ public class StreamExamples {
     public Multi<Message<String>> processMessageStream(Multi<Message<Integer>> stream) {
         return
             stream
-                .onItem().produceUni(message ->
+                .onItem().transformToUni(message ->
                 invokeService(message.getPayload())
                     .onFailure().recoverWithItem("fallback")
-                    .onItem().apply(message::withPayload)
+                    .onItem().transform(message::withPayload)
             )
                 .concatenate();
 
@@ -30,7 +30,7 @@ public class StreamExamples {
     public Multi<String> processPayloadStream(Multi<Integer> stream) {
         return
             stream
-                .onItem().produceUni(payload ->
+                .onItem().transformToUni(payload ->
                 invokeService(payload)
                     .onFailure().recoverWithItem("fallback")
             )

--- a/documentation/src/main/doc/modules/ROOT/examples/skip/StreamSkip.java
+++ b/documentation/src/main/doc/modules/ROOT/examples/skip/StreamSkip.java
@@ -32,7 +32,7 @@ public class StreamSkip {
     public Multi<String> processPayloadStream(Multi<String> stream) {
         return stream
             .transform().byFilteringItemsWith(s -> !s.equalsIgnoreCase("skip"))
-            .onItem().apply(String::toUpperCase);
+            .onItem().transform(String::toUpperCase);
     }
 
     @Incoming("in")
@@ -40,7 +40,7 @@ public class StreamSkip {
     public Multi<Message<String>> processMessageStream(Multi<Message<String>> stream) {
         return stream
             .transform().byFilteringItemsWith(m -> !m.getPayload().equalsIgnoreCase("skip"))
-            .onItem().apply(m -> m.withPayload(m.getPayload().toUpperCase()));
+            .onItem().transform(m -> m.withPayload(m.getPayload().toUpperCase()));
     }
     // end::skip[]
 

--- a/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaMetadataExample.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaMetadataExample.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 public class KafkaMetadataExample {
 
 
+    @SuppressWarnings("unchecked")
     public void metadata() {
         Message<Double> incoming = Message.of(12.0);
         // tag::code[]

--- a/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumerRebalanceListener.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumerRebalanceListener.java
@@ -41,7 +41,7 @@ public class KafkaRebalancedConsumerRebalanceListener implements KafkaConsumerRe
                         .onItem()
                         .invoke(o -> LOGGER.info("Seeking to " + o))
                         .onItem()
-                        .produceUni(o -> consumer
+                        .transformToUni(o -> consumer
                             .seek(topicPartition, o == null ? 0L : o.getOffset())
                             .onItem()
                             .invoke(v -> LOGGER.info("Seeked to " + o))

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <smallrye-health.version>2.2.2</smallrye-health.version>
     <smallrye-testing.version>0.1.0</smallrye-testing.version>
 
-    <mutiny.version>0.5.4</mutiny.version>
+    <mutiny.version>0.6.0</mutiny.version>
     <artemis.version>2.12.0</artemis.version>
 
     <jboss-log-manager.version>2.1.17.Final</jboss-log-manager.version>

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -133,12 +133,12 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
         AmqpFailureHandler onNack = createFailureHandler(ic);
 
         Multi<? extends Message<?>> multi = holder.getOrEstablishConnection()
-                .onItem().produceUni(connection -> connection.createReceiver(address, new AmqpReceiverOptions()
+                .onItem().transformToUni(connection -> connection.createReceiver(address, new AmqpReceiverOptions()
                         .setAutoAcknowledgement(autoAck)
                         .setDurable(durable)
                         .setLinkName(link)))
                 .onItem().invoke(r -> opened.put(ic.getChannel(), true))
-                .onItem().produceMulti(r -> getStreamOfMessages(r, holder, address, onNack));
+                .onItem().transformToMulti(r -> getStreamOfMessages(r, holder, address, onNack));
 
         Integer interval = ic.getReconnectInterval();
         Integer attempts = ic.getReconnectAttempts();
@@ -181,7 +181,7 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
                     }
 
                     return holder.getOrEstablishConnection()
-                            .onItem().produceUni(connection -> {
+                            .onItem().transformToUni(connection -> {
                                 if (useAnonymousSender) {
                                     return connection.createAnonymousSender();
                                 } else {

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
@@ -23,6 +23,7 @@ public class AmqpMessage<T> implements org.eclipse.microprofile.reactive.messagi
     private final Context context;
     protected final AmqpFailureHandler onNack;
 
+    @Deprecated
     public static <T> AmqpMessageBuilder<T> builder() {
         return new AmqpMessageBuilder<>();
     }

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/ConnectionHolder.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/ConnectionHolder.java
@@ -81,8 +81,8 @@ public class ConnectionHolder {
                     }
 
                     return client.connect()
-                            .on().subscribed(s -> log.establishingConnection())
-                            .onItem().apply(conn -> {
+                            .onSubscribe().invoke(s -> log.establishingConnection())
+                            .onItem().transform(conn -> {
                                 log.connectionEstablished();
                                 holder.set(new CurrentConnection(conn, Vertx.currentContext()));
                                 conn

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/OutgoingAmqpMetadata.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/OutgoingAmqpMetadata.java
@@ -239,7 +239,9 @@ public class OutgoingAmqpMetadata {
             this.groupSequence = existing.getGroupSequence();
             this.replyToGroupId = existing.getReplyToGroupId();
 
-            this.footer.putAll(existing.getFooter().getValue());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> footer = existing.getFooter().getValue();
+            this.footer.putAll(footer);
         }
 
         public OutgoingAmqpMetadataBuilder withAddress(String address) {

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpMessageTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpMessageTest.java
@@ -72,6 +72,7 @@ public class AmqpMessageTest {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testBuilder() {
         AmqpMessageBuilder<String> builder = AmqpMessage.builder();

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkTest.java
@@ -346,6 +346,7 @@ public class AmqpSinkTest extends AmqpTestBase {
         assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSinkUsingAmqpMessage() {
         String topic = UUID.randomUUID().toString();
@@ -486,6 +487,7 @@ public class AmqpSinkTest extends AmqpTestBase {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSinkUsingAmqpMessageWithNonAnonymousSender() {
         String topic = UUID.randomUUID().toString();
@@ -551,6 +553,7 @@ public class AmqpSinkTest extends AmqpTestBase {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSinkUsingAmqpMessageAndChannelNameProperty() {
         String topic = UUID.randomUUID().toString();

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/HeaderPropagationAmqpToAmqpTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/HeaderPropagationAmqpToAmqpTest.java
@@ -73,12 +73,12 @@ public class HeaderPropagationAmqpToAmqpTest extends AmqpTestBase {
         @Incoming("source")
         @Outgoing("p1")
         public Message<Integer> processMessage(Message<Integer> input) {
-            return AmqpMessage.<Integer> builder()
+            OutgoingAmqpMetadata metadata = OutgoingAmqpMetadata.builder()
                     .withAddress("my-address")
-                    .withIntegerAsBody(input.getPayload())
                     .withApplicationProperties(new JsonObject().put("X-Header", "value"))
                     .withSubject("test")
                     .build();
+            return input.addMetadata(metadata);
         }
 
         @Incoming("p1")

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/HeaderPropagationAmqpToAppToAmqpTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/HeaderPropagationAmqpToAppToAmqpTest.java
@@ -94,11 +94,11 @@ public class HeaderPropagationAmqpToAppToAmqpTest extends AmqpTestBase {
         @Incoming("source")
         @Outgoing("p1")
         public Message<Integer> processMessage(Message<Integer> input) {
-            return AmqpMessage.<Integer> builder()
-                    .withIntegerAsBody(input.getPayload())
-                    .withApplicationProperties(new JsonObject().put("X-Header", "value"))
-                    .withSubject("test")
-                    .build();
+            return input.addMetadata(
+                    OutgoingAmqpMetadata.builder()
+                            .withApplicationProperties(new JsonObject().put("X-Header", "value"))
+                            .withSubject("test")
+                            .build());
         }
 
         @Incoming("p1")

--- a/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubConnector.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubConnector.java
@@ -29,10 +29,7 @@ import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.protobuf.ByteString;
-import com.google.pubsub.v1.ProjectSubscriptionName;
-import com.google.pubsub.v1.ProjectTopicName;
-import com.google.pubsub.v1.PubsubMessage;
-import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.*;
 
 import io.smallrye.mutiny.Multi;
 
@@ -109,7 +106,7 @@ public class PubSubConnector implements IncomingConnectorFactory, OutgoingConnec
     private void createTopic(final PubSubConfig config) {
         final TopicAdminClient topicAdminClient = pubSubManager.topicAdminClient(config);
 
-        final ProjectTopicName topicName = ProjectTopicName.of(config.getProjectId(), config.getTopic());
+        final TopicName topicName = TopicName.of(config.getProjectId(), config.getTopic());
 
         try {
             topicAdminClient.getTopic(topicName);
@@ -134,7 +131,7 @@ public class PubSubConnector implements IncomingConnectorFactory, OutgoingConnec
             final PushConfig pushConfig = PushConfig.newBuilder()
                     .build();
 
-            final ProjectTopicName topicName = ProjectTopicName.of(config.getProjectId(), config.getTopic());
+            final TopicName topicName = TopicName.of(config.getProjectId(), config.getTopic());
 
             subscriptionAdminClient.createSubscription(subscriptionName, topicName, pushConfig, 0);
         }

--- a/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/i18n/PubSubLogging.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/i18n/PubSubLogging.java
@@ -7,8 +7,8 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
-import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.TopicName;
 
 /**
  * Logging for GCP Pub/Sub Connector
@@ -21,7 +21,7 @@ public interface PubSubLogging extends BasicLogger {
 
     @LogMessage(level = Logger.Level.TRACE)
     @Message(id = 14800, value = "Topic %s already exists")
-    void topicExistAlready(ProjectTopicName topic, @Cause Throwable t);
+    void topicExistAlready(TopicName topic, @Cause Throwable t);
 
     @LogMessage(level = Logger.Level.TRACE)
     @Message(id = 14801, value = "Received pub/sub message %s")

--- a/smallrye-reactive-messaging-gcp-pubsub/src/test/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubTest.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/test/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.TopicName;
 
 import io.smallrye.mutiny.Multi;
 
@@ -55,7 +56,7 @@ public class PubSubTest extends PubSubTestBase {
         await().until(() -> manager
                 .topicAdminClient(
                         new PubSubConfig(PROJECT_ID, topic, null, true, "localhost", CONTAINER.getMappedPort(PUBSUB_PORT)))
-                .listTopicSubscriptions(ProjectTopicName.of(PROJECT_ID, topic))
+                .listTopicSubscriptions((TopicName) ProjectTopicName.of(PROJECT_ID, topic))
                 .getPage()
                 .getPageElementCount() > 0);
 

--- a/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/connectors/InMemoryConnector.java
+++ b/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/connectors/InMemoryConnector.java
@@ -165,7 +165,7 @@ public class InMemoryConnector implements IncomingConnectorFactory, OutgoingConn
      * @return the source
      * @throws IllegalArgumentException if the channel name is {@code null} or if the channel is not associated with the
      *         in-memory connector.
-     * @see #switchChannelToInMemory(String...)
+     * @see #switchIncomingChannelsToInMemory(String...)
      */
     public <T> InMemorySource<T> source(String channel) {
         if (channel == null) {
@@ -190,7 +190,7 @@ public class InMemoryConnector implements IncomingConnectorFactory, OutgoingConn
      * @return the sink
      * @throws IllegalArgumentException if the channel name is {@code null} or if the channel is not associated with the
      *         in-memory connector.
-     * @see #switchChannelToInMemory(String...)
+     * @see #switchOutgoingChannelsToInMemory(String...)
      */
     public <T> InMemorySink<T> sink(String channel) {
         if (channel == null) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -166,10 +166,9 @@ public class KafkaSource<K, V> {
         }
 
         this.stream = multi
-                .on().subscribed(s -> {
+                .onSubscribe().invokeUni(s -> {
                     this.consumer.exceptionHandler(this::reportFailure);
-                    // The Kafka subscription must happen on the subscription.
-                    this.consumer.subscribeAndAwait(topic);
+                    return this.consumer.subscribe(topic);
                 })
                 .map(rec -> new IncomingKafkaRecord<>(consumer, rec, failureHandler))
                 .onFailure().invoke(this::reportFailure);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MetadataPropagationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MetadataPropagationTest.java
@@ -156,6 +156,7 @@ public class MetadataPropagationTest extends KafkaTestBase {
         return new MapBasedConfig(config);
     }
 
+    @SuppressWarnings("deprecation")
     @ApplicationScoped
     public static class MyAppGeneratingData {
 
@@ -177,6 +178,7 @@ public class MetadataPropagationTest extends KafkaTestBase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @ApplicationScoped
     public static class MyAppProcessingData {
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
@@ -22,7 +22,7 @@ public class StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListen
         // will perform the underlying operation but simulate an error on the first attempt
         return super.onPartitionsAssigned(consumer, set)
                 .onItem()
-                .produceUni(a -> {
+                .transformToUni(a -> {
                     if (!set.isEmpty() && failOnFirstAttempt.getAndSet(false)) {
                         return Uni
                                 .createFrom()

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
@@ -78,7 +78,7 @@ public class MqttSink {
                         c.disconnectAndForget();
                     }
                 })
-                .onError(t -> log.errorWhileSendingMessageToBroker(t))
+                .onError(log::errorWhileSendingMessageToBroker)
                 .ignore();
     }
 
@@ -101,7 +101,7 @@ public class MqttSink {
         }
 
         return client.publish(actualTopicToBeUsed, convert(msg.getPayload()), actualQoS, false, isRetain)
-                .onItemOrFailure().produceUni((s, f) -> {
+                .onItemOrFailure().transformToUni((s, f) -> {
                     if (f != null) {
                         return Uni.createFrom().completionStage(msg.nack(f).thenApply(x -> msg));
                     } else {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/ProcessorMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/ProcessorMediator.java
@@ -5,6 +5,7 @@ import static io.smallrye.reactive.messaging.i18n.ProviderMessages.msg;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
@@ -245,36 +246,36 @@ public class ProcessorMediator extends AbstractMediator {
             if (configuration.isBlocking()) {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().produceUni(x -> invokeBlocking(message.getPayload()))
-                                .onItem().apply(x -> (Message<?>) x)
-                                .onItemOrFailure().<Message<Object>> produceUni(this::handlePostInvocationWithMessage)
-                                .onItem().produceMulti(this::handleSkip))
+                                .onItem().transformToUni(x -> invokeBlocking(message.getPayload()))
+                                .onItem().transform(x -> (Message<?>) x)
+                                .onItemOrFailure().<Message<Object>> transformToUni(this::handlePostInvocationWithMessage)
+                                .onItem().transformToMulti(this::handleSkip))
                         .buildRs();
             } else {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().apply(x -> invoke(message.getPayload()))
-                                .onItem().apply(x -> (Message<?>) x)
-                                .onItemOrFailure().<Message<Object>> produceUni(this::handlePostInvocationWithMessage)
-                                .onItem().produceMulti(this::handleSkip))
+                                .onItem().transform(x -> invoke(message.getPayload()))
+                                .onItem().transform(x -> (Message<?>) x)
+                                .onItemOrFailure().<Message<Object>> transformToUni(this::handlePostInvocationWithMessage)
+                                .onItem().transformToMulti(this::handleSkip))
                         .buildRs();
             }
         } else {
             if (configuration.isBlocking()) {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().produceUni(x -> invokeBlocking(message))
-                                .onItem().apply(x -> (Message<?>) x)
-                                .onItemOrFailure().<Message<Object>> produceUni(this::handlePostInvocationWithMessage)
-                                .onItem().produceMulti(this::handleSkip))
+                                .onItem().transformToUni(x -> invokeBlocking(message))
+                                .onItem().transform(x -> (Message<?>) x)
+                                .onItemOrFailure().<Message<Object>> transformToUni(this::handlePostInvocationWithMessage)
+                                .onItem().transformToMulti(this::handleSkip))
                         .buildRs();
             } else {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().apply(x -> invoke(message))
-                                .onItem().apply(x -> (Message<?>) x)
-                                .onItemOrFailure().<Message<Object>> produceUni(this::handlePostInvocationWithMessage)
-                                .onItem().produceMulti(this::handleSkip))
+                                .onItem().transform(x -> invoke(message))
+                                .onItem().transform(x -> (Message<?>) x)
+                                .onItemOrFailure().<Message<Object>> transformToUni(this::handlePostInvocationWithMessage)
+                                .onItem().transformToMulti(this::handleSkip))
                         .buildRs();
             }
         }
@@ -290,18 +291,18 @@ public class ProcessorMediator extends AbstractMediator {
             if (configuration.isBlocking()) {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().produceUni(x -> (Uni<?>) invokeBlocking(message.getPayload()))
+                                .onItem().transformToUni(x -> (Uni<?>) invokeBlocking(message.getPayload()))
                                 .onItemOrFailure()
-                                .<Message<Object>> produceUni((res, fail) -> handlePostInvocation(message, res, fail))
-                                .onItem().produceMulti(this::handleSkip))
+                                .<Message<Object>> transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
+                                .onItem().transformToMulti(this::handleSkip))
                         .buildRs();
             } else {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().apply(input -> invoke(input.getPayload()))
+                                .onItem().transform(input -> invoke(input.getPayload()))
                                 .onItemOrFailure()
-                                .<Message<Object>> produceUni((res, fail) -> handlePostInvocation(message, res, fail))
-                                .onItem().produceMulti(this::handleSkip))
+                                .<Message<Object>> transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
+                                .onItem().transformToMulti(this::handleSkip))
                         .buildRs();
             }
         } else {
@@ -309,18 +310,18 @@ public class ProcessorMediator extends AbstractMediator {
             if (configuration.isBlocking()) {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().produceUni(x -> (Uni<?>) invokeBlocking(message))
+                                .onItem().transformToUni(x -> (Uni<?>) invokeBlocking(message))
                                 .onItemOrFailure()
-                                .<Message<Object>> produceUni((res, fail) -> handlePostInvocation(message, res, fail))
-                                .onItem().produceMulti(this::handleSkip))
+                                .<Message<Object>> transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
+                                .onItem().transformToMulti(this::handleSkip))
                         .buildRs();
             } else {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().apply(this::invoke)
+                                .onItem().transform(this::invoke)
                                 .onItemOrFailure()
-                                .<Message<Object>> produceUni((res, fail) -> handlePostInvocation(message, res, fail))
-                                .onItem().produceMulti(this::handleSkip))
+                                .<Message<Object>> transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
+                                .onItem().transformToMulti(this::handleSkip))
                         .buildRs();
             }
         }
@@ -374,36 +375,40 @@ public class ProcessorMediator extends AbstractMediator {
     private void processMethodReturningACompletionStageOfMessageAndConsumingIndividualMessage() {
         this.processor = ReactiveStreams.<Message<?>> builder()
                 .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                        .onItem().produceCompletionStage(x -> invoke(message))
-                        .onItemOrFailure().produceUni((res, fail) -> handlePostInvocationWithMessage((Message) res, fail))
-                        .onItem().produceMulti(this::handleSkip))
+                        .onItem().transformToUni(x -> Uni.createFrom().completionStage((CompletionStage<?>) invoke(message)))
+                        .onItemOrFailure()
+                        .transformToUni((res, fail) -> handlePostInvocationWithMessage((Message<?>) res, fail))
+                        .onItem().transformToMulti(this::handleSkip))
                 .buildRs();
     }
 
     private void processMethodReturningAUniOfMessageAndConsumingIndividualMessage() {
         this.processor = ReactiveStreams.<Message<?>> builder()
                 .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                        .onItem().produceUni(x -> invoke(message))
-                        .onItemOrFailure().produceUni((res, fail) -> handlePostInvocationWithMessage((Message) res, fail))
-                        .onItem().produceMulti(this::handleSkip))
+                        .onItem().transformToUni(x -> invoke(message))
+                        .onItemOrFailure()
+                        .transformToUni((res, fail) -> handlePostInvocationWithMessage((Message<?>) res, fail))
+                        .onItem().transformToMulti(this::handleSkip))
                 .buildRs();
     }
 
     private void processMethodReturningACompletionStageOfPayloadAndConsumingIndividualPayload() {
         this.processor = ReactiveStreams.<Message<?>> builder()
                 .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                        .onItem().produceCompletionStage(x -> invoke(message.getPayload()))
-                        .onItemOrFailure().produceUni((res, fail) -> handlePostInvocation(message, res, fail))
-                        .onItem().produceMulti(this::handleSkip))
+                        .onItem()
+                        .transformToUni(
+                                x -> Uni.createFrom().completionStage((CompletionStage<?>) invoke(message.getPayload())))
+                        .onItemOrFailure().transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
+                        .onItem().transformToMulti(this::handleSkip))
                 .buildRs();
     }
 
     private void processMethodReturningAUniOfPayloadAndConsumingIndividualPayload() {
         this.processor = ReactiveStreams.<Message<?>> builder()
                 .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                        .onItem().produceUni(x -> invoke(message.getPayload()))
-                        .onItemOrFailure().produceUni((res, fail) -> handlePostInvocation(message, res, fail))
-                        .onItem().produceMulti(this::handleSkip))
+                        .onItem().transformToUni(x -> invoke(message.getPayload()))
+                        .onItemOrFailure().transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
+                        .onItem().transformToMulti(this::handleSkip))
                 .buildRs();
     }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/StreamTransformerMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/StreamTransformerMediator.java
@@ -87,6 +87,7 @@ public class StreamTransformerMediator extends AbstractMediator {
         };
     }
 
+    @SuppressWarnings("unchecked")
     private void processMethodConsumingAPublisherOfMessages() {
         function = publisher -> {
             Publisher<Message<?>> prependedWithAck = publisher
@@ -95,7 +96,7 @@ public class StreamTransformerMediator extends AbstractMediator {
             Class<?> parameterType = configuration.getParameterTypes()[0];
             Optional<? extends ReactiveTypeConverter<?>> converter = Registry.lookup(parameterType);
             if (converter.isPresent()) {
-                prependedWithAck = (Publisher) converter.get().fromPublisher(prependedWithAck);
+                prependedWithAck = (Publisher<Message<?>>) converter.get().fromPublisher(prependedWithAck);
             }
             Publisher<Message<?>> result = invoke(prependedWithAck);
             Objects.requireNonNull(result, msg.methodReturnedNull(configuration.methodAsString()));

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ChannelProducer.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ChannelProducer.java
@@ -18,7 +18,6 @@ import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
@@ -170,16 +169,6 @@ public class ChannelProducer {
     }
 
     @SuppressWarnings("rawtypes")
-    private SubscriberBuilder<? extends Message, Void> getSubscriberBuilder(InjectionPoint injectionPoint) {
-        String name = getChannelName(injectionPoint);
-        List<SubscriberBuilder<? extends Message<?>, Void>> list = channelRegistry.getSubscribers(name);
-        if (list.isEmpty()) {
-            throw ex.illegalStateForStream(name, channelRegistry.getOutgoingNames());
-        }
-        return list.get(0);
-    }
-
-    @SuppressWarnings("rawtypes")
     private Emitter getEmitter(InjectionPoint injectionPoint) {
         String name = getChannelName(injectionPoint);
         Emitter emitter = channelRegistry.getEmitter(name);
@@ -196,6 +185,7 @@ public class ChannelProducer {
         return null;
     }
 
+    @SuppressWarnings("deprecation")
     static String getChannelName(InjectionPoint injectionPoint) {
         for (Annotation qualifier : injectionPoint.getQualifiers()) {
             if (qualifier.annotationType().equals(Channel.class)) {
@@ -209,6 +199,7 @@ public class ChannelProducer {
         throw ex.illegalStateForAnnotationNotFound("@Channel", injectionPoint);
     }
 
+    @SuppressWarnings("deprecation")
     static Channel getChannelQualifier(InjectionPoint injectionPoint) {
         for (Annotation qualifier : injectionPoint.getQualifiers()) {
             if (qualifier.annotationType().equals(Channel.class)) {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/LegacyEmitterImpl.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/LegacyEmitterImpl.java
@@ -12,6 +12,7 @@ import io.smallrye.reactive.messaging.annotations.Emitter;
  *
  * @param <T> the type of payload or message
  */
+@SuppressWarnings("deprecation")
 public class LegacyEmitterImpl<T> implements Emitter<T> {
 
     private final org.eclipse.microprofile.reactive.messaging.Emitter<T> delegate;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ReactiveMessagingExtension.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ReactiveMessagingExtension.java
@@ -60,6 +60,7 @@ public class ReactiveMessagingExtension implements Extension {
         }
     }
 
+    @SuppressWarnings("deprecation")
     <T extends io.smallrye.reactive.messaging.annotations.Emitter<?>> void processStreamLegacyEmitterInjectionPoint(
             @Observes ProcessInjectionPoint<?, T> pip) {
         Channel stream = ChannelProducer.getChannelQualifier(pip.getInjectionPoint());
@@ -143,6 +144,7 @@ public class ReactiveMessagingExtension implements Extension {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private OnOverflow createOnOverflowForLegacyAnnotation(InjectionPoint point) {
         io.smallrye.reactive.messaging.annotations.OnOverflow legacy = point.getAnnotated()
                 .getAnnotation(io.smallrye.reactive.messaging.annotations.OnOverflow.class);

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SourceOnly.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SourceOnly.java
@@ -12,6 +12,7 @@ import io.smallrye.mutiny.Multi;
 @ApplicationScoped
 public class SourceOnly {
 
+    @SuppressWarnings("unchecked")
     @Outgoing("count")
     public Publisher<Message<String>> source() {
         return Multi.createFrom().range(1, 11)

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningUni.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningUni.java
@@ -35,7 +35,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
         return Uni.createFrom().item(message)
                 .emitOn(EXECUTOR)
                 .onItem().invoke((m) -> processed(MANUAL_ACKNOWLEDGMENT, message))
-                .onItem().produceCompletionStage(Message::ack);
+                .onItem().transformToUni(m -> Uni.createFrom().completionStage(m.ack()));
     }
 
     @Outgoing(MANUAL_ACKNOWLEDGMENT)
@@ -128,7 +128,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
         return Uni.createFrom().<Void> item(() -> null)
                 .emitOn(EXECUTOR)
                 .onItem().invoke(x -> processed(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message))
-                .onItem().produceCompletionStage(x -> message.ack());
+                .onItem().transformToUni(x -> Uni.createFrom().completionStage(message.ack()));
     }
 
     @Outgoing(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE)

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/acknowledgement/AsynchronousMessageProcessorAckTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/acknowledgement/AsynchronousMessageProcessorAckTest.java
@@ -101,17 +101,17 @@ public class AsynchronousMessageProcessorAckTest extends WeldTestBaseWithoutTail
         CountDownLatch done = new CountDownLatch(1);
         Multi.createFrom().items("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
                 .onItem()
-                .produceCompletionStage(i -> CompletableFuture.runAsync(() -> emitter.send(Message.of(i, Metadata.empty(),
-                        () -> {
-                            acked.add(i);
-                            return CompletableFuture.completedFuture(null);
-                        }, t -> {
-                            reasons.add(t);
-                            nacked.add(i);
-                            return CompletableFuture.completedFuture(null);
-                        })))
-                        .thenApply(x -> i))
-                .merge()
+                .transformToUniAndMerge(i -> Uni.createFrom()
+                        .completionStage(CompletableFuture.runAsync(() -> emitter.send(Message.of(i, Metadata.empty(),
+                                () -> {
+                                    acked.add(i);
+                                    return CompletableFuture.completedFuture(null);
+                                }, t -> {
+                                    reasons.add(t);
+                                    nacked.add(i);
+                                    return CompletableFuture.completedFuture(null);
+                                })))
+                                .thenApply(x -> i)))
                 .subscribe().with(
                         x -> {
                             // noop

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/acknowledgement/AsynchronousPayloadProcessorAckTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/acknowledgement/AsynchronousPayloadProcessorAckTest.java
@@ -101,17 +101,17 @@ public class AsynchronousPayloadProcessorAckTest extends WeldTestBaseWithoutTail
         CountDownLatch done = new CountDownLatch(1);
         Multi.createFrom().items("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
                 .onItem()
-                .produceCompletionStage(i -> CompletableFuture.runAsync(() -> emitter.send(Message.of(i, Metadata.empty(),
-                        () -> {
-                            acked.add(i);
-                            return CompletableFuture.completedFuture(null);
-                        }, t -> {
-                            reasons.add(t);
-                            nacked.add(i);
-                            return CompletableFuture.completedFuture(null);
-                        })))
-                        .thenApply(x -> i))
-                .merge()
+                .transformToUniAndMerge(i -> Uni.createFrom().completionStage(
+                        CompletableFuture.runAsync(() -> emitter.send(Message.of(i, Metadata.empty(),
+                                () -> {
+                                    acked.add(i);
+                                    return CompletableFuture.completedFuture(null);
+                                }, t -> {
+                                    reasons.add(t);
+                                    nacked.add(i);
+                                    return CompletableFuture.completedFuture(null);
+                                })))
+                                .thenApply(x -> i)))
                 .subscribe().with(
                         x -> {
                             // noop

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedNonExistentLegacyChannel.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedNonExistentLegacyChannel.java
@@ -8,6 +8,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.annotations.Channel;
 
+@SuppressWarnings("deprecation")
 @ApplicationScoped
 public class BeanInjectedNonExistentLegacyChannel {
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithDifferentFlavorsOfTheSameChannelLegacy.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithDifferentFlavorsOfTheSameChannelLegacy.java
@@ -13,6 +13,7 @@ import org.reactivestreams.Publisher;
 import io.reactivex.Flowable;
 import io.smallrye.reactive.messaging.annotations.Channel;
 
+@SuppressWarnings("deprecation")
 @ApplicationScoped
 public class BeanInjectedWithDifferentFlavorsOfTheSameChannelLegacy {
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyDefaultOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyDefaultOverflowStrategyTest.java
@@ -61,6 +61,7 @@ public class LegacyDefaultOverflowStrategyTest extends WeldTestBaseWithoutTails 
         assertThat(bean.failure()).isNotNull().isInstanceOf(BackPressureFailure.class);
     }
 
+    @SuppressWarnings("deprecation")
     @ApplicationScoped
     public static class BeanUsingDefaultOverflow {
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyDropOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyDropOverflowStrategyTest.java
@@ -61,6 +61,7 @@ public class LegacyDropOverflowStrategyTest extends WeldTestBaseWithoutTails {
         assertThat(bean.exception()).isNull();
     }
 
+    @SuppressWarnings("deprecation")
     @ApplicationScoped
     public static class BeanUsingDropOverflowStrategy {
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyEmitterBufferOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyEmitterBufferOverflowStrategyTest.java
@@ -61,6 +61,7 @@ public class LegacyEmitterBufferOverflowStrategyTest extends WeldTestBaseWithout
         assertThat(bean.exception()).isInstanceOf(IllegalStateException.class);
     }
 
+    @SuppressWarnings("deprecation")
     @ApplicationScoped
     public static class BeanUsingBufferOverflowStrategy {
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyFailOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyFailOverflowStrategyTest.java
@@ -62,6 +62,7 @@ public class LegacyFailOverflowStrategyTest extends WeldTestBaseWithoutTails {
         assertThat(bean.failure()).isNotNull().isInstanceOf(BackPressureFailure.class);
     }
 
+    @SuppressWarnings("deprecation")
     @ApplicationScoped
     public static class BeanWithFailOverflowStrategy {
 
@@ -70,7 +71,7 @@ public class LegacyFailOverflowStrategyTest extends WeldTestBaseWithoutTails {
         @OnOverflow(value = OnOverflow.Strategy.FAIL)
         Emitter<String> emitter;
 
-        private List<String> output = new CopyOnWriteArrayList<>();
+        private final List<String> output = new CopyOnWriteArrayList<>();
 
         private volatile Throwable downstreamFailure;
         private Exception callerException;
@@ -117,9 +118,7 @@ public class LegacyFailOverflowStrategyTest extends WeldTestBaseWithoutTails {
             return values
                     .observeOn(scheduler)
                     .delay(1, TimeUnit.MILLISECONDS, scheduler)
-                    .doOnError(err -> {
-                        downstreamFailure = err;
-                    });
+                    .doOnError(err -> downstreamFailure = err);
         }
 
         @Incoming("out")

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyLatestOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyLatestOverflowStrategyTest.java
@@ -63,6 +63,7 @@ public class LegacyLatestOverflowStrategyTest extends WeldTestBaseWithoutTails {
         assertThat(bean.exception()).isNull();
     }
 
+    @SuppressWarnings("deprecation")
     @ApplicationScoped
     public static class BeanUsingLatestOverflowStrategy {
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/InvalidBindingTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/InvalidBindingTest.java
@@ -1,6 +1,6 @@
 package io.smallrye.reactive.messaging.merge;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/skip/StreamSkipTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/skip/StreamSkipTest.java
@@ -104,7 +104,7 @@ public class StreamSkipTest extends WeldTestBaseWithoutTails {
         public Multi<String> processPayloadStream(Multi<String> stream) {
             return stream
                     .transform().byFilteringItemsWith(s -> !s.equalsIgnoreCase("skip"))
-                    .onItem().apply(String::toUpperCase);
+                    .onItem().transform(String::toUpperCase);
         }
 
         @Incoming("in")
@@ -112,7 +112,7 @@ public class StreamSkipTest extends WeldTestBaseWithoutTails {
         public Multi<Message<String>> processMessageStream(Multi<Message<String>> stream) {
             return stream
                     .transform().byFilteringItemsWith(m -> !m.getPayload().equalsIgnoreCase("skip"))
-                    .onItem().apply(m -> m.withPayload(m.getPayload().toUpperCase()));
+                    .onItem().transform(m -> m.withPayload(m.getPayload().toUpperCase()));
         }
     }
 }

--- a/smallrye-reactive-messaging-vertx-eventbus/pom.xml
+++ b/smallrye-reactive-messaging-vertx-eventbus/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>smallrye-reactive-messaging-vertx-eventbus</artifactId>
 
-  <name>SmallRye Reactive Messaging : Connector :: VertX EventBus</name>
+  <name>SmallRye Reactive Messaging : Connector :: Vert.x EventBus</name>
 
   <dependencies>
     <dependency>
@@ -40,7 +40,7 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>        
+        <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <generatedSourcesDirectory>${project.build.directory}/generated-sources/</generatedSourcesDirectory>
           <annotationProcessors>


### PR DESCRIPTION
Update to Mutiny 0.6.0 and uses the new API.

The previously used API is still available but deprecated.
We switched to the new API to illustrate its usage.

This PR also cleanup a few deprecation and typos.
