### PR TITLE
Add support for multiple topics subscription and topic pattern

### DIFF
--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -9,13 +9,21 @@ _(kafka.bootstrap.servers)_ | A comma-separated list of host:port to use for est
 
 Type: _string_ | false | `localhost:9092`
 
-| *topic* | The consumed / populated Kafka topic. If not set, the channel name is used
+| *topic* | The consumed / populated Kafka topic. If neither this property nor the `topics` properties are set, the channel name is used
 
 Type: _string_ | false | 
 
 | *health-enabled* | Whether health reporting is enabled (default) or disabled
 
 Type: _boolean_ | false | `true`
+
+| *topics* | A comma-separating list of topics to be consumed. Cannot be used with the `topic` or `pattern` properties
+
+Type: _string_ | false | 
+
+| *pattern* | Indicate that the `topic` property is a regular expression. Must be used with the `topic` property. Cannot be used with the `topics` property
+
+Type: _boolean_ | false | `false`
 
 | *key.deserializer* | The deserializer classname used to deserialize the record's key
 

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
@@ -41,7 +41,7 @@ Type: _int_ | false | `-1`
 
 Type: _long_ | false | `2147483647`
 
-| *topic* | The consumed / populated Kafka topic. If not set, the channel name is used
+| *topic* | The consumed / populated Kafka topic. If neither this property nor the `topics` properties are set, the channel name is used
 
 Type: _string_ | false | 
 

--- a/documentation/src/main/doc/modules/kafka/pages/health.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/health.adoc
@@ -13,6 +13,9 @@ On the inbound side (receiving records from Kafka), the readiness check verifies
 * the Kafka topic is created (available in the broker).
 * no failures have been caught
 
+If you consume multiple topics using the `topics` attribute, the readiness check verifies that all the consumed topics are available.
+If you use a pattern (using the `pattern` attribute), the readiness check verifies that at least one existing topic matches the pattern.
+
 On the outbound side (writing records to Kafka), the readiness check verifies that:
 
 * the broker is available

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -45,7 +45,9 @@ import io.vertx.mutiny.core.Vertx;
 @ApplicationScoped
 @Connector(KafkaConnector.CONNECTOR_NAME)
 @ConnectorAttribute(name = "bootstrap.servers", alias = "kafka.bootstrap.servers", type = "string", defaultValue = "localhost:9092", direction = Direction.INCOMING_AND_OUTGOING, description = "A comma-separated list of host:port to use for establishing the initial connection to the Kafka cluster.")
-@ConnectorAttribute(name = "topic", type = "string", direction = Direction.INCOMING_AND_OUTGOING, description = "The consumed / populated Kafka topic. If not set, the channel name is used")
+@ConnectorAttribute(name = "topic", type = "string", direction = Direction.INCOMING_AND_OUTGOING, description = "The consumed / populated Kafka topic. If neither this property nor the `topics` properties are set, the channel name is used")
+@ConnectorAttribute(name = "topics", type = "string", direction = Direction.INCOMING, description = "A comma-separating list of topics to be consumed. Cannot be used with the `topic` or `pattern` properties")
+@ConnectorAttribute(name = "pattern", type = "boolean", direction = Direction.INCOMING, description = "Indicate that the `topic` property is a regular expression. Must be used with the `topic` property. Cannot be used with the `topics` property", defaultValue = "false")
 @ConnectorAttribute(name = "health-enabled", type = "boolean", direction = Direction.INCOMING_AND_OUTGOING, description = "Whether health reporting is enabled (default) or disabled", defaultValue = "true")
 @ConnectorAttribute(name = "key.deserializer", type = "string", direction = Direction.INCOMING, description = "The deserializer classname used to deserialize the record's key", defaultValue = "org.apache.kafka.common.serialization.StringDeserializer")
 @ConnectorAttribute(name = "value.deserializer", type = "string", direction = Direction.INCOMING, description = "The deserializer classname used to deserialize the record's value", mandatory = true)

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.kafka.i18n;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -87,8 +88,8 @@ public interface KafkaLogging extends BasicLogger {
     void noGroupId(String randomId);
 
     @LogMessage(level = Logger.Level.ERROR)
-    @Message(id = 18217, value = "Unable to read a record from Kafka topic '%s'")
-    void unableToReadRecord(String topic, @Cause Throwable t);
+    @Message(id = 18217, value = "Unable to read a record from Kafka topics '%s'")
+    void unableToReadRecord(Set<String> topics, @Cause Throwable t);
 
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 18218, value = "An exception has been caught while closing the Kafka consumer")
@@ -131,7 +132,14 @@ public interface KafkaLogging extends BasicLogger {
     void reEnablingConsumerforGroup(String consumerGroup);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 18228, value = "A failure has been reported for Kafka topic '%s'")
-    void failureReported(String topic, @Cause Throwable t);
+    @Message(id = 18228, value = "A failure has been reported for Kafka topics '%s'")
+    void failureReported(Set<String> topics, @Cause Throwable t);
 
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18229, value = "Consumed topics for channel '%s': %s")
+    void configuredTopics(String channel, Set<String> topics);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18230, value = "Consumed topics matching pattern for channel '%s': %s")
+    void configuredPattern(String channel, String pattern);
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaTestBase.java
@@ -114,4 +114,12 @@ public class KafkaTestBase {
         return container.getBeanManager().createInstance().select(HealthCenter.class).get();
     }
 
+    public boolean isReady(WeldContainer container) {
+        return getHealth(container).getReadiness().isOk();
+    }
+
+    public boolean isLive(WeldContainer container) {
+        return getHealth(container).getLiveness().isOk();
+    }
+
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MapBasedConfig.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MapBasedConfig.java
@@ -4,11 +4,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.*;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -24,6 +20,15 @@ public class MapBasedConfig implements Config {
 
     public MapBasedConfig(Map<String, Object> map) {
         this.map = map;
+    }
+
+    public MapBasedConfig() {
+        this.map = new HashMap<>();
+    }
+
+    public MapBasedConfig put(String k, Object v) {
+        this.map.put(k, v);
+        return this;
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MultiTopicsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MultiTopicsTest.java
@@ -1,0 +1,279 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+
+/**
+ * Test the Incoming connector when multiple topics are used either using a pattern or a list of topics.
+ */
+@SuppressWarnings("rawtypes")
+public class MultiTopicsTest extends KafkaTestBase {
+
+    private WeldContainer container;
+    private KafkaUsage usage;
+
+    @After
+    public void cleanup() {
+        if (container != null) {
+            container.close();
+        }
+        // Release the config objects
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+    }
+
+    @Before
+    public void prepare() {
+        usage = new KafkaUsage();
+    }
+
+    @Test
+    public void testWithThreeTopicsInConfiguration() {
+        String topic1 = UUID.randomUUID().toString();
+        String topic2 = UUID.randomUUID().toString();
+        String topic3 = UUID.randomUUID().toString();
+
+        KafkaConsumer bean = deploy(new MapBasedConfig()
+                .put("mp.messaging.incoming.kafka.connector", KafkaConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.kafka.value.deserializer", StringDeserializer.class.getName())
+                .put("mp.messaging.incoming.kafka.topics", topic1 + ", " + topic2 + ", " + topic3));
+
+        await().until(() -> isReady(container));
+        await().until(() -> isLive(container));
+
+        assertThat(bean.getMessages()).isEmpty();
+
+        new Thread(() -> usage.produceStrings(3, null,
+                () -> new ProducerRecord<>(topic1, "hello"))).start();
+
+        new Thread(() -> usage.produceStrings(3, null,
+                () -> new ProducerRecord<>(topic2, "hallo"))).start();
+
+        new Thread(() -> usage.produceStrings(3, null,
+                () -> new ProducerRecord<>(topic3, "bonjour"))).start();
+
+        await().until(() -> bean.getMessages().size() == 9);
+
+        AtomicInteger top1 = new AtomicInteger();
+        AtomicInteger top2 = new AtomicInteger();
+        AtomicInteger top3 = new AtomicInteger();
+        bean.getMessages().forEach(message -> {
+            IncomingKafkaRecordMetadata record = message.getMetadata(IncomingKafkaRecordMetadata.class).orElse(null);
+            assertThat(record).isNotNull();
+            String topic = record.getTopic();
+            if (topic.equals(topic1)) {
+                top1.incrementAndGet();
+                assertThat(message.getPayload()).isEqualTo("hello");
+            } else if (topic.equals(topic2)) {
+                top2.incrementAndGet();
+                assertThat(message.getPayload()).isEqualTo("hallo");
+            } else if (topic.equals(topic3)) {
+                top3.incrementAndGet();
+                assertThat(message.getPayload()).isEqualTo("bonjour");
+            }
+        });
+
+        assertThat(top1).hasValue(3);
+        assertThat(top2).hasValue(3);
+        assertThat(top3).hasValue(3);
+    }
+
+    @Test
+    public void testWithOnlyTwoTopicsReceiving() {
+        String topic1 = UUID.randomUUID().toString();
+        String topic2 = UUID.randomUUID().toString();
+        String topic3 = UUID.randomUUID().toString();
+
+        KafkaConsumer bean = deploy(new MapBasedConfig()
+                .put("mp.messaging.incoming.kafka.connector", KafkaConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.kafka.value.deserializer", StringDeserializer.class.getName())
+                .put("mp.messaging.incoming.kafka.topics", topic1 + ", " + topic2 + ", " + topic3));
+
+        await().until(() -> isReady(container));
+        await().until(() -> isLive(container));
+
+        assertThat(bean.getMessages()).isEmpty();
+
+        new Thread(() -> usage.produceStrings(3, null,
+                () -> new ProducerRecord<>(topic1, "hello"))).start();
+
+        new Thread(() -> usage.produceStrings(3, null,
+                () -> new ProducerRecord<>(topic3, "bonjour"))).start();
+
+        await().until(() -> bean.getMessages().size() == 6);
+
+        AtomicInteger top1 = new AtomicInteger();
+        AtomicInteger top2 = new AtomicInteger();
+        AtomicInteger top3 = new AtomicInteger();
+        bean.getMessages().forEach(message -> {
+            IncomingKafkaRecordMetadata record = message.getMetadata(IncomingKafkaRecordMetadata.class).orElse(null);
+            assertThat(record).isNotNull();
+            String topic = record.getTopic();
+            if (topic.equals(topic1)) {
+                top1.incrementAndGet();
+                assertThat(message.getPayload()).isEqualTo("hello");
+            } else if (topic.equals(topic2)) {
+                top2.incrementAndGet();
+            } else if (topic.equals(topic3)) {
+                top3.incrementAndGet();
+                assertThat(message.getPayload()).isEqualTo("bonjour");
+            }
+        });
+
+        assertThat(top1).hasValue(3);
+        assertThat(top2).hasValue(0);
+        assertThat(top3).hasValue(3);
+    }
+
+    @Test
+    public void testWithPattern() {
+        String topic1 = "greetings-" + UUID.randomUUID().toString();
+        String topic2 = "greetings-" + UUID.randomUUID().toString();
+        String topic3 = "greetings-" + UUID.randomUUID().toString();
+
+        kafka.createTopic(topic1, 1, 1);
+        kafka.createTopic(topic2, 1, 1);
+        kafka.createTopic(topic3, 1, 1);
+
+        KafkaConsumer bean = deploy(new MapBasedConfig()
+                .put("mp.messaging.incoming.kafka.connector", KafkaConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.kafka.value.deserializer", StringDeserializer.class.getName())
+                .put("mp.messaging.incoming.kafka.topic", "greetings-.+")
+                .put("mp.messaging.incoming.kafka.pattern", true));
+
+        await().until(() -> isReady(container));
+        await().until(() -> isLive(container));
+
+        assertThat(bean.getMessages()).isEmpty();
+
+        new Thread(() -> usage.produceStrings(3, null,
+                () -> new ProducerRecord<>(topic1, "hello"))).start();
+
+        new Thread(() -> usage.produceStrings(3, null,
+                () -> new ProducerRecord<>(topic2, "hallo"))).start();
+
+        new Thread(() -> usage.produceStrings(3, null,
+                () -> new ProducerRecord<>(topic3, "bonjour"))).start();
+
+        new Thread(() -> usage.produceStrings(3, null,
+                () -> new ProducerRecord<>("do-not-match", "Bahh!"))).start();
+
+        await().until(() -> bean.getMessages().size() == 9);
+
+        AtomicInteger top1 = new AtomicInteger();
+        AtomicInteger top2 = new AtomicInteger();
+        AtomicInteger top3 = new AtomicInteger();
+        bean.getMessages().forEach(message -> {
+            IncomingKafkaRecordMetadata record = message.getMetadata(IncomingKafkaRecordMetadata.class).orElse(null);
+            assertThat(record).isNotNull();
+            String topic = record.getTopic();
+            if (topic.equals(topic1)) {
+                top1.incrementAndGet();
+                assertThat(message.getPayload()).isEqualTo("hello");
+            } else if (topic.equals(topic2)) {
+                top2.incrementAndGet();
+                assertThat(message.getPayload()).isEqualTo("hallo");
+            } else if (topic.equals(topic3)) {
+                top3.incrementAndGet();
+                assertThat(message.getPayload()).isEqualTo("bonjour");
+            }
+        });
+
+        assertThat(top1).hasValue(3);
+        assertThat(top2).hasValue(3);
+        assertThat(top3).hasValue(3);
+    }
+
+    @Test
+    public void testNonReadinessWithPatternIfTopicsAreNotCreated() {
+        deploy(new MapBasedConfig()
+                .put("mp.messaging.incoming.kafka.connector", KafkaConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.kafka.value.deserializer", StringDeserializer.class.getName())
+                .put("mp.messaging.incoming.kafka.topic", "greetings-.+")
+                .put("mp.messaging.incoming.kafka.pattern", true));
+
+        await().until(() -> isLive(container));
+        await()
+                .pollDelay(10, TimeUnit.MILLISECONDS)
+                .until(() -> !isReady(container));
+
+    }
+
+    @Test
+    public void testInvalidConfigurations() {
+        // Pattern and no topic
+        assertThatThrownBy(() -> deploy(new MapBasedConfig()
+                .put("mp.messaging.incoming.kafka.connector", KafkaConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.kafka.value.deserializer", StringDeserializer.class.getName())
+                .put("mp.messaging.incoming.kafka.pattern", true)))
+                        .isInstanceOf(DeploymentException.class)
+                        .hasCauseInstanceOf(IllegalArgumentException.class);
+
+        // topics and no topic
+        assertThatThrownBy(() -> deploy(new MapBasedConfig()
+                .put("mp.messaging.incoming.kafka.connector", KafkaConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.kafka.value.deserializer", StringDeserializer.class.getName())
+                .put("mp.messaging.incoming.kafka.topic", "my-topic")
+                .put("mp.messaging.incoming.kafka.topics", "a, b, c")))
+                        .isInstanceOf(DeploymentException.class)
+                        .hasCauseInstanceOf(IllegalArgumentException.class);
+
+        // topics and pattern
+        assertThatThrownBy(() -> deploy(new MapBasedConfig()
+                .put("mp.messaging.incoming.kafka.connector", KafkaConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.kafka.value.deserializer", StringDeserializer.class.getName())
+                .put("mp.messaging.incoming.kafka.pattern", true)
+                .put("mp.messaging.incoming.kafka.topics", "a, b, c"))).isInstanceOf(DeploymentException.class)
+                        .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    private KafkaConsumer deploy(MapBasedConfig config) {
+        Weld weld = baseWeld();
+        addConfig(config);
+        weld.addBeanClass(KafkaConsumer.class);
+        weld.disableDiscovery();
+        container = weld.initialize();
+        return container.getBeanManager().createInstance().select(KafkaConsumer.class).get();
+    }
+
+    @ApplicationScoped
+    public static class KafkaConsumer {
+
+        private final List<Message<String>> messages = new CopyOnWriteArrayList<>();
+
+        @Incoming("kafka")
+        public CompletionStage<Void> consume(Message<String> incoming) {
+            messages.add(incoming);
+            return incoming.ack();
+        }
+
+        public List<Message<String>> getMessages() {
+            return messages;
+        }
+
+    }
+
+}


### PR DESCRIPTION
When consuming messages from Kafka, you can now:

* configure multiple topics using the `topics` attribute (comma-separated list)
* configure `topic` to be a regexp (set the `pattern` attribute to `true`)

The PR also changes the health check logic for these cases.﻿
