### PR TITLE
Set fetch size to before pause value when resuming kafka source

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -150,6 +150,7 @@ public class KafkaSource<K, V> {
                     + 11_000L; // it's possible that it might expire 10 seconds before when we need it to
 
             kafkaConsumer.partitionsAssignedHandler(set -> {
+                final long currentDemand = kafkaConsumer.demand();
                 kafkaConsumer.pause();
                 log.executingConsumerAssignedRebalanceListener(group);
                 listener.onPartitionsAssigned(kafkaConsumer, set)
@@ -161,12 +162,12 @@ public class KafkaSource<K, V> {
                                 a -> {
                                     log.executedConsumerAssignedRebalanceListener(group);
                                     commitHandler.partitionsAssigned(vertx.getOrCreateContext(), set);
-                                    kafkaConsumer.resume();
+                                    kafkaConsumer.fetch(currentDemand);
                                 },
                                 t -> {
                                     log.reEnablingConsumerforGroup(group);
                                     commitHandler.partitionsAssigned(vertx.getOrCreateContext(), set);
-                                    kafkaConsumer.resume();
+                                    kafkaConsumer.fetch(currentDemand);
                                 });
             });
 


### PR DESCRIPTION
@cescoffier 
This is a doozy and I'm not this sure this fix is the correct way to go. When we have a re-balance listener configured and `partitions` is greater than 1 we will get the following if consuming messages at a high throughput (KafkaSource will then stop consuming):

```
2020-07-20 03:48:12,061 ERROR [io.sma.rea.mes.provider] (vert.x-eventloop-thread-1) SRMSG00201: Error caught during the stream processing: io.smallrye.mutiny.subscription.BackPressureFailure: Buffer full, cannot emit item
	at io.smallrye.mutiny.operators.multi.MultiFlatMapOp$FlatMapMainSubscriber.failOverflow(MultiFlatMapOp.java:539)
	at io.smallrye.mutiny.operators.multi.MultiFlatMapOp$FlatMapMainSubscriber.tryEmit(MultiFlatMapOp.java:240)
	at io.smallrye.mutiny.operators.multi.MultiFlatMapOp$FlatMapInner.onItem(MultiFlatMapOp.java:595)
	at io.smallrye.mutiny.subscription.MultiSubscriber.onNext(MultiSubscriber.java:61)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.lambda$onNext$1(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.context.SmallRyeThreadContext.lambda$withContext$0(SmallRyeThreadContext.java:217)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.onNext(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.mutiny.helpers.HalfSerializer.onNext(HalfSerializer.java:31)
	at io.smallrye.mutiny.helpers.StrictMultiSubscriber.onItem(StrictMultiSubscriber.java:81)
	at io.smallrye.mutiny.operators.multi.MultiMapOp$MapProcessor.onItem(MultiMapOp.java:50)
	at io.smallrye.mutiny.subscription.MultiSubscriber.onNext(MultiSubscriber.java:61)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.lambda$onNext$1(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.context.SmallRyeThreadContext.lambda$withContext$0(SmallRyeThreadContext.java:217)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.onNext(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.lambda$onNext$1(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.context.SmallRyeThreadContext.lambda$withContext$0(SmallRyeThreadContext.java:217)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.onNext(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.mutiny.helpers.HalfSerializer.onNext(HalfSerializer.java:31)
	at io.smallrye.mutiny.helpers.StrictMultiSubscriber.onItem(StrictMultiSubscriber.java:81)
	at io.smallrye.mutiny.operators.multi.MultiSignalConsumerOp$SignalSubscriber.onItem(MultiSignalConsumerOp.java:161)
	at io.smallrye.mutiny.subscription.MultiSubscriber.onNext(MultiSubscriber.java:61)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.lambda$onNext$1(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.context.SmallRyeThreadContext.lambda$withContext$0(SmallRyeThreadContext.java:217)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.onNext(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.lambda$onNext$1(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.context.SmallRyeThreadContext.lambda$withContext$0(SmallRyeThreadContext.java:217)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.onNext(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.mutiny.helpers.HalfSerializer.onNext(HalfSerializer.java:31)
	at io.smallrye.mutiny.helpers.StrictMultiSubscriber.onItem(StrictMultiSubscriber.java:81)
	at io.smallrye.mutiny.operators.multi.MultiSignalConsumerOp$SignalSubscriber.onItem(MultiSignalConsumerOp.java:161)
	at io.smallrye.mutiny.subscription.MultiSubscriber.onNext(MultiSubscriber.java:61)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.lambda$onNext$1(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.context.SmallRyeThreadContext.lambda$withContext$0(SmallRyeThreadContext.java:217)
	at io.smallrye.mutiny.context.ContextPropagationMultiInterceptor$1.onNext(ContextPropagationMultiInterceptor.java:36)
	at io.smallrye.mutiny.vertx.MultiReadStream.lambda$subscribe$2(MultiReadStream.java:76)
	at io.vertx.kafka.client.consumer.impl.KafkaConsumerImpl.lambda$handler$1(KafkaConsumerImpl.java:79)
	at io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl.run(KafkaReadStreamImpl.java:229)
	at io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl.lambda$schedule$8(KafkaReadStreamImpl.java:184)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:366)
	at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:834)

```

This happens because when resuming the Vert.x consumer it set sets the fetch amount to Long.MAX_VALUE
https://github.com/vert-x3/vertx-kafka-client/blob/3.9.1/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java#L571

There's also a less severe side effect when `partitions` is 1. Because of the `MAX_VALUE` fetch amount it will consume more than 1 message concurrently when using a worker thread to perform blocking operations, ex:

```
    @Incoming("topic-in")
    public CompletionStage<Void> consume(IncomingKafkaRecord<String, String> record) {
        return CompletableFuture.runAsync(() -> {
            // perform blocking code.
        });
    }
```

Without a re-balance listener it will process the messages one at a time (`MultiFlapMapOp#drainLoop` always ends up requesting 1 in this case). Configuring a consumer re-balance listener shouldn't affect this behavior.

When `partitions` is 1 the the fetch amount should be 1 and when greater than 1 the amount should be 128. This resolves both issues.

What I don't like about this fix is that I arrived at these values empirically. It seems like this bug resides in the Vert.x Kafka code. Maybe resume should be setting the fetch amount to the previous non zero fetch amount before pausing. Something like:

```
  @Override
  public KafkaReadStreamImpl<K, V> resume() {
    return fetch(this.previousFetchAmountBeforePausing.get());
  }

```