### PR TITLE
Ignore the item produced by the "write" method when writing to the dead-queue topic

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterQueue.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterQueue.java
@@ -72,6 +72,7 @@ public class KafkaDeadLetterQueue implements KafkaFailureHandler {
         log.messageNackedDeadLetter(channel, topic);
         return producer.send(dead)
                 .onFailure().invoke(t -> source.reportFailure((Throwable) t))
+                .onItem().ignore().andContinueWithNull()
                 .subscribeAsCompletionStage();
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/fault/KafkaFailureHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/fault/KafkaFailureHandlerTest.java
@@ -24,6 +24,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.kafka.*;
 
@@ -42,7 +43,7 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
 
     @Test
     public void testFailStrategy() {
-        addConfig(getFailConfig());
+        addConfig(getFailConfig("fail"));
         container = baseWeld().addBeanClass(MyReceiverBean.class).initialize();
 
         await().until(() -> {
@@ -67,8 +68,35 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
     }
 
     @Test
+    public void testFailStrategyWithPayload() {
+        addConfig(getFailConfig("fail-payload"));
+        container = baseWeld().addBeanClass(MyReceiverBeanUsingPayload.class).initialize();
+
+        await().until(() -> {
+            HealthReport readiness = getHealth(container).getReadiness();
+            return readiness.isOk();
+        });
+
+        KafkaUsage usage = new KafkaUsage();
+        AtomicInteger counter = new AtomicInteger();
+        new Thread(() -> usage.produceIntegers(10, null,
+                () -> new ProducerRecord<>("fail-payload", counter.getAndIncrement()))).start();
+
+        MyReceiverBeanUsingPayload bean = container.getBeanManager().createInstance().select(MyReceiverBeanUsingPayload.class)
+                .get();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 4);
+        // Other records should not have been received.
+        assertThat(bean.list()).containsExactly(0, 1, 2, 3);
+
+        await().until(() -> {
+            HealthReport liveness = getHealth(container).getLiveness();
+            return !liveness.isOk();
+        });
+    }
+
+    @Test
     public void testIgnoreStrategy() {
-        addConfig(getIgnoreConfig());
+        addConfig(getIgnoreConfig("ignore"));
         container = baseWeld().addBeanClass(MyReceiverBean.class).initialize();
 
         await().until(() -> {
@@ -82,6 +110,31 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
                 () -> new ProducerRecord<>("ignore", counter.getAndIncrement()))).start();
 
         MyReceiverBean bean = container.getBeanManager().createInstance().select(MyReceiverBean.class).get();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 10);
+        // All records should not have been received.
+        assertThat(bean.list()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+        HealthReport liveness = getHealth(container).getLiveness();
+        assertThat(liveness.isOk()).isTrue();
+    }
+
+    @Test
+    public void testIgnoreStrategyWithPayload() {
+        addConfig(getIgnoreConfig("ignore-payload"));
+        container = baseWeld().addBeanClass(MyReceiverBeanUsingPayload.class).initialize();
+
+        await().until(() -> {
+            HealthReport readiness = getHealth(container).getReadiness();
+            return readiness.isOk();
+        });
+
+        KafkaUsage usage = new KafkaUsage();
+        AtomicInteger counter = new AtomicInteger();
+        new Thread(() -> usage.produceIntegers(10, null,
+                () -> new ProducerRecord<>("ignore-payload", counter.getAndIncrement()))).start();
+
+        MyReceiverBeanUsingPayload bean = container.getBeanManager().createInstance().select(MyReceiverBeanUsingPayload.class)
+                .get();
         await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 10);
         // All records should not have been received.
         assertThat(bean.list()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
@@ -129,6 +182,45 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
     }
 
     @Test
+    public void testDeadLetterQueueStrategyWithCustomTopicAndMethodUsingPayload() {
+        KafkaUsage usage = new KafkaUsage();
+        List<ConsumerRecord<String, Integer>> records = new CopyOnWriteArrayList<>();
+        String randomId = UUID.randomUUID().toString();
+
+        usage.consume(randomId, randomId, OffsetResetStrategy.EARLIEST,
+                new StringDeserializer(), new IntegerDeserializer(), () -> records.size() < 3, null, null,
+                Collections.singletonList("dead-letter-topic-kafka-payload"), records::add);
+
+        addConfig(getDeadLetterQueueWithCustomConfig("dq-payload", "dead-letter-topic-kafka-payload"));
+        container = baseWeld().addBeanClass(MyReceiverBeanUsingPayload.class).initialize();
+
+        await().until(() -> {
+            HealthReport readiness = getHealth(container).getReadiness();
+            return readiness.isOk();
+        });
+
+        AtomicInteger counter = new AtomicInteger();
+        new Thread(() -> usage.produceIntegers(10, null,
+                () -> new ProducerRecord<>("dq-payload", counter.getAndIncrement()))).start();
+
+        MyReceiverBeanUsingPayload bean = container.getBeanManager().createInstance().select(MyReceiverBeanUsingPayload.class)
+                .get();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 10);
+        assertThat(bean.list()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> records.size() == 3);
+        assertThat(records).allSatisfy(r -> {
+            assertThat(r.topic()).isEqualTo("dead-letter-topic-kafka-payload");
+            assertThat(r.value()).isIn(3, 6, 9);
+            assertThat(new String(r.headers().lastHeader("dead-letter-reason").value())).startsWith("nack 3 -");
+            assertThat(r.headers().lastHeader("dead-letter-cause")).isNull();
+        });
+
+        HealthReport liveness = getHealth(container).getLiveness();
+        assertThat(liveness.isOk()).isTrue();
+    }
+
+    @Test
     public void testDeadLetterQueueStrategyWithCustomConfig() {
         KafkaUsage usage = new KafkaUsage();
         List<ConsumerRecord<String, Integer>> records = new CopyOnWriteArrayList<>();
@@ -138,7 +230,7 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
                 new StringDeserializer(), new IntegerDeserializer(), () -> records.size() < 3, null, null,
                 Collections.singletonList("missed"), records::add);
 
-        addConfig(getDeadLetterQueueWithCustomConfig());
+        addConfig(getDeadLetterQueueWithCustomConfig("dead-letter-custom", "missed"));
         container = baseWeld().addBeanClass(MyReceiverBean.class).initialize();
 
         await().until(() -> {
@@ -166,12 +258,12 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
         assertThat(liveness.isOk()).isTrue();
     }
 
-    private MapBasedConfig getFailConfig() {
+    private MapBasedConfig getFailConfig(String topic) {
         String prefix = "mp.messaging.incoming.kafka.";
         Map<String, Object> config = new HashMap<>();
         config.put(prefix + "connector", KafkaConnector.CONNECTOR_NAME);
         config.put(prefix + "group.id", "my-group");
-        config.put(prefix + "topic", "fail");
+        config.put(prefix + "topic", topic);
         config.put(prefix + "value.deserializer", IntegerDeserializer.class.getName());
         config.put(prefix + "enable.auto.commit", "false");
         config.put(prefix + "auto.offset.reset", "earliest");
@@ -180,11 +272,11 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
         return new MapBasedConfig(config);
     }
 
-    private MapBasedConfig getIgnoreConfig() {
+    private MapBasedConfig getIgnoreConfig(String topic) {
         String prefix = "mp.messaging.incoming.kafka.";
         Map<String, Object> config = new HashMap<>();
         config.put(prefix + "connector", KafkaConnector.CONNECTOR_NAME);
-        config.put(prefix + "topic", "ignore");
+        config.put(prefix + "topic", topic);
         config.put(prefix + "group.id", "my-group");
         config.put(prefix + "value.deserializer", IntegerDeserializer.class.getName());
         config.put(prefix + "enable.auto.commit", "false");
@@ -208,17 +300,17 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
         return new MapBasedConfig(config);
     }
 
-    private MapBasedConfig getDeadLetterQueueWithCustomConfig() {
+    private MapBasedConfig getDeadLetterQueueWithCustomConfig(String topic, String dq) {
         String prefix = "mp.messaging.incoming.kafka.";
         Map<String, Object> config = new HashMap<>();
         config.put(prefix + "connector", KafkaConnector.CONNECTOR_NAME);
         config.put(prefix + "group.id", "my-group");
-        config.put(prefix + "topic", "dead-letter-custom");
+        config.put(prefix + "topic", topic);
         config.put(prefix + "value.deserializer", IntegerDeserializer.class.getName());
         config.put(prefix + "enable.auto.commit", "false");
         config.put(prefix + "auto.offset.reset", "earliest");
         config.put(prefix + "failure-strategy", "dead-letter-queue");
-        config.put(prefix + "dead-letter-queue.topic", "missed");
+        config.put(prefix + "dead-letter-queue.topic", dq);
         config.put(prefix + "dead-letter-queue.key.serializer", IntegerSerializer.class.getName());
         config.put(prefix + "dead-letter-queue.value.serializer", IntegerSerializer.class.getName());
 
@@ -227,7 +319,7 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
 
     @ApplicationScoped
     public static class MyReceiverBean {
-        private List<Integer> received = new ArrayList<>();
+        private final List<Integer> received = new ArrayList<>();
 
         @Incoming("kafka")
         public CompletionStage<Void> process(KafkaRecord<String, Integer> record) {
@@ -237,6 +329,25 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
                 return record.nack(new IllegalArgumentException("nack 3 - " + payload));
             }
             return record.ack();
+        }
+
+        public List<Integer> list() {
+            return received;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyReceiverBeanUsingPayload {
+        private final List<Integer> received = new ArrayList<>();
+
+        @Incoming("kafka")
+        public Uni<Void> process(int value) {
+            received.add(value);
+            if (value != 0 && value % 3 == 0) {
+                return Uni.createFrom().failure(new IllegalArgumentException("nack 3 - " + value));
+            }
+            return Uni.createFrom().nullItem();
         }
 
         public List<Integer> list() {


### PR DESCRIPTION
Fix #675
Ignore the item produced by the "write" method.