### PR TITLE
Add metrics to the base scope

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/metrics/MetricDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/metrics/MetricDecorator.java
@@ -8,7 +8,9 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricRegistry.Type;
 import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 
@@ -20,7 +22,7 @@ public class MetricDecorator implements PublisherDecorator {
     private MetricRegistry registry;
 
     @Inject
-    private void setMetricRegistry(Instance<MetricRegistry> registryInstance) {
+    private void setMetricRegistry(@RegistryType(type = Type.BASE) Instance<MetricRegistry> registryInstance) {
         if (registryInstance.isResolvable()) {
             registry = registryInstance.get();
         }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metrics/MetricsTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metrics/MetricsTest.java
@@ -3,9 +3,13 @@ package io.smallrye.reactive.messaging.metrics;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
+import javax.enterprise.util.AnnotationLiteral;
+
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricRegistry.Type;
 import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.junit.Test;
 
 import io.smallrye.metrics.setup.MetricCdiInjectionExtension;
@@ -31,7 +35,23 @@ public class MetricsTest extends WeldTestBase {
     }
 
     private Counter getCounter(String channelName) {
-        MetricRegistry registry = container.select(MetricRegistry.class).get();
+        MetricRegistry registry = container.select(MetricRegistry.class, RegistryTypeLiteral.BASE).get();
         return registry.counter("mp.messaging.message.count", new Tag("channel", channelName));
+    }
+
+    @SuppressWarnings("serial")
+    private static class RegistryTypeLiteral extends AnnotationLiteral<RegistryType> implements RegistryType {
+        public static final RegistryTypeLiteral BASE = new RegistryTypeLiteral(MetricRegistry.Type.BASE);
+
+        private Type registryType;
+
+        public RegistryTypeLiteral(Type registryType) {
+            this.registryType = registryType;
+        }
+
+        @Override
+        public Type type() {
+            return registryType;
+        }
     }
 }


### PR DESCRIPTION
Create metrics defined by the spec in the base scope, rather than the
application scope.

To match eclipse/microprofile-reactive-messaging#93