### PR TITLE
Add the name of the check in the healthcheck output

### DIFF
--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/HealthChecks.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/HealthChecks.java
@@ -4,9 +4,9 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 
 public class HealthChecks {
-    public static HealthCheckResponse getHealthCheck(HealthReport report) {
+    public static HealthCheckResponse getHealthCheck(HealthReport report, String check) {
         HealthCheckResponseBuilder builder = HealthCheckResponse.builder()
-                .name("SmallRye Reactive Messaging")
+                .name("SmallRye Reactive Messaging - " + check)
                 .state(report.isOk());
 
         report.getChannels().forEach(ci -> {

--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheck.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheck.java
@@ -17,7 +17,7 @@ public class SmallRyeReactiveMessagingLivenessCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
         HealthReport report = health.getLiveness();
-        return HealthChecks.getHealthCheck(report);
+        return HealthChecks.getHealthCheck(report, "liveness check");
     }
 
 }

--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingReadinessCheck.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingReadinessCheck.java
@@ -19,6 +19,6 @@ public class SmallRyeReactiveMessagingReadinessCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
         HealthReport report = health.getReadiness();
-        return HealthChecks.getHealthCheck(report);
+        return HealthChecks.getHealthCheck(report, "readiness check");
     }
 }


### PR DESCRIPTION
Fix https://github.com/smallrye/smallrye-reactive-messaging/issues/690﻿

When retrieving the health status using `/health`, you get both the readiness and liveness checks.
The output contains 2 entries named "SmallRye Reactive Messaging" and the user cannot distinguish which one is the readiness and which one is the liveness.

This PR append the type of checks to the check name.
