### PR TITLE
Add AMQP nack strategies for the modified delivery state

### DIFF
--- a/documentation/src/main/doc/modules/amqp/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/amqp/pages/inbound.adoc
@@ -112,18 +112,24 @@ When a Reactive Messaging `Message` associated with an AMQP Message is acknowled
 
 === Failure Management
 
-If a message produced from an AMQP message  is _nacked_, a failure strategy is applied.
-The AMQP connector supports 4 strategies:
+If a message produced from an AMQP message is _nacked_, a failure strategy is applied.
+The AMQP connector supports six strategies:
 
-* `fail` - fail the application, no more AMQP messages will be processed (default).
-The AMQP message is mark as rejected.
-* `accept` - the failure is logged, but the processing continue.
-The AMQP message is mark as accepted.
-This strategy ignores the failure.
-* `release` - the failure is logged, but the processing continue.
-The AMQP message is mark as released.
-* `reject` - the failure is logged, but the processing continue.
-The AMQP message is mark as rejected.
+* `fail` - fail the application; no more AMQP messages will be processed (default).
+The AMQP message is marked as rejected.
+* `accept` - this strategy marks the AMQP message as _accepted_. The processing continues ignoring the failure.
+Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-accepted[accepted delivery state documentation].
+* `release` - this strategy marks the AMQP message as _released_. The processing continues with the next message. The broker can redeliver the message.
+Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-released[released delivery state documentation].
+* `reject` - this strategy marks the AMQP message as rejected. The processing continues with the next message.
+Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-rejected[rejected delivery state documentation].
+* `modified-failed` - this strategy marks the AMQP
+message as _modified_ and indicates that it failed (with the `delivery-failed` attribute). The processing continues with the next message, but the broker may attempt to redeliver the message.
+Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified[modified delivery state documentation]
+* `modified-failed-undeliverable-here` - this strategy marks the AMQP message as _modified_ and indicates that it failed (with the `delivery-failed` attribute). It also indicates that the application cannot process the message, meaning that the broker will not attempt to redeliver the message to this node. The processing continues with the next message.
+Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified[modified delivery state documentation]
+
+
 
 === Configuration Reference
 

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-amqp-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-amqp-incoming.adoc
@@ -81,7 +81,7 @@ Type: _boolean_ | false | `true`
 
 Type: _boolean_ | false | `false`
 
-| *failure-strategy* | Specify the failure strategy to apply when a message produced from an AMQP message is nacked. Values can be `fail` (default), `accept`, `release`, `reject`
+| *failure-strategy* | Specify the failure strategy to apply when a message produced from an AMQP message is nacked. Accepted values are `fail` (default), `accept`, `release`, `reject`, `modified-failed`, `modified-failed-undeliverable-here`
 
 Type: _string_ | false | `fail`
 

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -63,7 +63,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "broadcast", direction = INCOMING, description = "Whether the received AMQP messages must be dispatched to multiple _subscribers_", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "durable", direction = INCOMING, description = "Whether AMQP subscription is durable", type = "boolean", defaultValue = "true")
 @ConnectorAttribute(name = "auto-acknowledgement", direction = INCOMING, description = "Whether the received AMQP messages must be acknowledged when received", type = "boolean", defaultValue = "false")
-@ConnectorAttribute(name = "failure-strategy", type = "string", direction = INCOMING, description = "Specify the failure strategy to apply when a message produced from an AMQP message is nacked. Values can be `fail` (default), `accept`, `release`, `reject`", defaultValue = "fail")
+@ConnectorAttribute(name = "failure-strategy", type = "string", direction = INCOMING, description = "Specify the failure strategy to apply when a message produced from an AMQP message is nacked. Accepted values are `fail` (default), `accept`, `release`, `reject`, `modified-failed`, `modified-failed-undeliverable-here`", defaultValue = "fail")
 
 @ConnectorAttribute(name = "durable", direction = OUTGOING, description = "Whether sent AMQP messages are marked durable", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "ttl", direction = OUTGOING, description = "The time-to-live of the send AMQP messages. 0 to disable the TTL", type = "long", defaultValue = "0")
@@ -242,6 +242,10 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
                 return new AmqpReject(config.getChannel());
             case RELEASE:
                 return new AmqpRelease(config.getChannel());
+            case MODIFIED_FAILED:
+                return new AmqpModifiedFailed(config.getChannel());
+            case MODIFIED_FAILED_UNDELIVERABLE_HERE:
+                return new AmqpModifiedFailedAndUndeliverableHere(config.getChannel());
             default:
                 throw ex.illegalArgumentInvalidFailureStrategy(strategy);
         }

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/fault/AmqpFailureHandler.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/fault/AmqpFailureHandler.java
@@ -25,7 +25,21 @@ public interface AmqpFailureHandler {
         /**
          * Mark the message as {@code rejected} and continue.
          */
-        REJECT;
+        REJECT,
+
+        /**
+         * Mark the message as {@code modified} and continue.
+         * This strategy increments the delivery count.
+         * The message may be re-delivered on the same node.
+         */
+        MODIFIED_FAILED,
+
+        /**
+         * Mark the message as {@code modified} and continue.
+         * This strategy increments the delivery count and mark the message as undeliverable on this node.
+         * The message cannot be re-delivered on the same node, but may be redelivered on another node.
+         */
+        MODIFIED_FAILED_UNDELIVERABLE_HERE;
 
         public static Strategy from(String s) {
             if (s == null || s.equalsIgnoreCase("fail")) {
@@ -39,6 +53,12 @@ public interface AmqpFailureHandler {
             }
             if (s.equalsIgnoreCase("reject")) {
                 return REJECT;
+            }
+            if (s.equalsIgnoreCase("modified-failed")) {
+                return MODIFIED_FAILED;
+            }
+            if (s.equalsIgnoreCase("modified-failed-undeliverable-here")) {
+                return MODIFIED_FAILED_UNDELIVERABLE_HERE;
             }
             throw ex.illegalArgumentUnknownFailureStrategy(s);
         }

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/fault/AmqpModifiedFailed.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/fault/AmqpModifiedFailed.java
@@ -1,0 +1,32 @@
+package io.smallrye.reactive.messaging.amqp.fault;
+
+import static io.smallrye.reactive.messaging.amqp.i18n.AMQPLogging.log;
+
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.reactive.messaging.amqp.AmqpMessage;
+import io.smallrye.reactive.messaging.amqp.ConnectionHolder;
+import io.vertx.mutiny.core.Context;
+
+/**
+ * This nack strategy marking the message as {@code modified} and set the {@code delivery-failed} attribute to {@code true}.
+ * <p>
+ * The message might be redelivered on the same node.
+ * <p>
+ * See http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified.
+ */
+public class AmqpModifiedFailed implements AmqpFailureHandler {
+
+    private final String channel;
+
+    public AmqpModifiedFailed(String channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public <V> CompletionStage<Void> handle(AmqpMessage<V> msg, Context context, Throwable reason) {
+        log.nackedModifiedFailedMessage(channel);
+        log.fullIgnoredFailure(reason);
+        return ConnectionHolder.runOnContext(context, () -> msg.getAmqpMessage().modified(true, false));
+    }
+}

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/fault/AmqpModifiedFailedAndUndeliverableHere.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/fault/AmqpModifiedFailedAndUndeliverableHere.java
@@ -1,0 +1,33 @@
+package io.smallrye.reactive.messaging.amqp.fault;
+
+import static io.smallrye.reactive.messaging.amqp.i18n.AMQPLogging.log;
+
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.reactive.messaging.amqp.AmqpMessage;
+import io.smallrye.reactive.messaging.amqp.ConnectionHolder;
+import io.vertx.mutiny.core.Context;
+
+/**
+ * This nack strategy marking the message as {@code modified} and set the {@code delivery-failed} attribute to {@code true},
+ * as well as the {@code undeliverable-here} flag to {@code true}.
+ * <p>
+ * The message will not be redelivered on the same node, but may be redelivered on another node.
+ * <p>
+ * See http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified.
+ */
+public class AmqpModifiedFailedAndUndeliverableHere implements AmqpFailureHandler {
+
+    private final String channel;
+
+    public AmqpModifiedFailedAndUndeliverableHere(String channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public <V> CompletionStage<Void> handle(AmqpMessage<V> msg, Context context, Throwable reason) {
+        log.nackedModifiedFailedMessageAndUndeliverableHere(channel);
+        log.fullIgnoredFailure(reason);
+        return ConnectionHolder.runOnContext(context, () -> msg.getAmqpMessage().modified(true, true));
+    }
+}

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/i18n/AMQPLogging.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/i18n/AMQPLogging.java
@@ -85,7 +85,7 @@ public interface AMQPLogging extends BasicLogger {
     void unableToRecoverFromConnectionDisruption(@Cause Throwable t);
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 16217, value = "A message sent to channel `%s` has been nacked, ignoring the failure and mark the message as accepted")
+    @Message(id = 16217, value = "A message sent to channel `%s` has been nacked, ignoring the failure and marking the AMQP message as accepted")
     void nackedAcceptMessage(String channel);
 
     @LogMessage(level = Logger.Level.DEBUG)
@@ -93,15 +93,15 @@ public interface AMQPLogging extends BasicLogger {
     void fullIgnoredFailure(@Cause Throwable t);
 
     @LogMessage(level = Logger.Level.ERROR)
-    @Message(id = 16219, value = "A message sent to channel `%s` has been nacked, rejecting the message and fail-stop")
+    @Message(id = 16219, value = "A message sent to channel `%s` has been nacked, rejecting the AMQP message and fail-stop")
     void nackedFailMessage(String channel);
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 16220, value = "A message sent to channel `%s` has been nacked, ignoring the failure and mark the message as rejected")
+    @Message(id = 16220, value = "A message sent to channel `%s` has been nacked, ignoring the failure and marking the AMQP the message as rejected")
     void nackedIgnoreMessage(String channel);
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 16221, value = "A message sent to channel `%s` has been nacked, ignoring the failure and mark the message as released")
+    @Message(id = 16221, value = "A message sent to channel `%s` has been nacked, ignoring the failure and marking the AMQP the message as released")
     void nackedReleaseMessage(String channel);
 
     @LogMessage(level = Logger.Level.DEBUG)
@@ -119,4 +119,12 @@ public interface AMQPLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.ERROR)
     @Message(id = 16225, value = "Failure reported for channel `%s`, closing client")
     void failureReported(String channel, @Cause Throwable reason);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 16226, value = "A message sent to channel `%s` has been nacked, ignoring the message and marking the AMQP message as modified with `delivery-failed`")
+    void nackedModifiedFailedMessage(String channel);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 16227, value = "A message sent to channel `%s` has been nacked, ignoring the message and marking the AMQP message as modified with `delivery-failed` and `undeliverable-here`")
+    void nackedModifiedFailedMessageAndUndeliverableHere(String channel);
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpFailureHandlerTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpFailureHandlerTest.java
@@ -45,8 +45,17 @@ public class AmqpFailureHandlerTest extends AmqpTestBase {
         return container.getBeanManager().createInstance().select(MyReceiverBean.class).get();
     }
 
+    private MyReceiverBeanRecovering deployRecovering() {
+        Weld weld = new Weld();
+        weld.addBeanClass(MyReceiverBeanRecovering.class);
+
+        container = weld.initialize();
+        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
+        return container.getBeanManager().createInstance().select(MyReceiverBeanRecovering.class).get();
+    }
+
     @Test
-    public void testFailStrategy() throws InterruptedException {
+    public void testFailStrategy() {
         String address = UUID.randomUUID().toString();
         getFailConfig(address);
         MyReceiverBean bean = deploy();
@@ -131,6 +140,46 @@ public class AmqpFailureHandlerTest extends AmqpTestBase {
         assertThat(isAmqpConnectorReady(connector)).isTrue();
     }
 
+    @Test
+    public void testModifiedFailedStrategy() {
+        getModifiedFailedConfig();
+        MyReceiverBeanRecovering bean = deployRecovering();
+        AtomicInteger counter = new AtomicInteger();
+        AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
+                ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
+        await().until(() -> isAmqpConnectorReady(connector));
+        await().until(() -> isAmqpConnectorAlive(connector));
+
+        usage.produceTenIntegers("modified-failed", counter::getAndIncrement);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 13);
+        // All messages should have been received + 3, 6 and 9 are redelivered
+        assertThat(bean.list()).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3, 6, 9);
+
+        assertThat(isAmqpConnectorAlive(connector)).isTrue();
+        assertThat(isAmqpConnectorReady(connector)).isTrue();
+    }
+
+    @Test
+    public void testModifiedFailedUndeliverableHereStrategy() {
+        getModifiedFailedUndeliverableConfig();
+        MyReceiverBeanRecovering bean = deployRecovering();
+        AtomicInteger counter = new AtomicInteger();
+        AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
+                ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
+        await().until(() -> isAmqpConnectorReady(connector));
+        await().until(() -> isAmqpConnectorAlive(connector));
+
+        usage.produceTenIntegers("modified-failed-undeliverable-here", counter::getAndIncrement);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 10);
+        // All messages should have been received, 3 6 and 9 are NOT redelivered
+        assertThat(bean.list()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+        assertThat(isAmqpConnectorAlive(connector)).isTrue();
+        assertThat(isAmqpConnectorReady(connector)).isTrue();
+    }
+
     private void getFailConfig(String address) {
         new MapBasedConfig()
                 .put("mp.messaging.incoming.amqp.address", address)
@@ -183,15 +232,63 @@ public class AmqpFailureHandlerTest extends AmqpTestBase {
                 .write();
     }
 
+    private void getModifiedFailedConfig() {
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.amqp.address", "modified-failed")
+                .put("mp.messaging.incoming.amqp.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.amqp.host", host)
+                .put("mp.messaging.incoming.amqp.port", port)
+                .put("mp.messaging.incoming.amqp.durable", true)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("mp.messaging.incoming.amqp.failure-strategy", "modified-failed")
+                .write();
+    }
+
+    private void getModifiedFailedUndeliverableConfig() {
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.amqp.address", "modified-failed-undeliverable-here")
+                .put("mp.messaging.incoming.amqp.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.amqp.host", host)
+                .put("mp.messaging.incoming.amqp.port", port)
+                .put("mp.messaging.incoming.amqp.durable", true)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("mp.messaging.incoming.amqp.failure-strategy", "modified-failed-undeliverable-here")
+                .write();
+    }
+
     @ApplicationScoped
     public static class MyReceiverBean {
-        private List<Integer> received = new CopyOnWriteArrayList<>();
+        private final List<Integer> received = new CopyOnWriteArrayList<>();
 
         @Incoming("amqp")
         public CompletionStage<Void> process(AmqpMessage<Integer> record) {
             Integer payload = record.getPayload();
             received.add(payload);
             if (payload != 0 && payload % 3 == 0) {
+                return record.nack(new IllegalArgumentException("nack 3 - " + payload));
+            }
+            return record.ack();
+        }
+
+        public List<Integer> list() {
+            return received;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyReceiverBeanRecovering {
+        private final List<Integer> received = new CopyOnWriteArrayList<>();
+        private final List<Integer> failed = new CopyOnWriteArrayList<>();
+
+        @Incoming("amqp")
+        public CompletionStage<Void> process(AmqpMessage<Integer> record) {
+            Integer payload = record.getPayload();
+            received.add(payload);
+            if (payload != 0 && payload % 3 == 0 && !failed.contains(payload)) {
+                failed.add(payload);
                 return record.nack(new IllegalArgumentException("nack 3 - " + payload));
             }
             return record.ack();


### PR DESCRIPTION
Add two new nack strategies to the AMQP connector:

* modified-failed - marking the message modified and incrementing the delivery count (the message may be redelivered to the application)
* modified-failed-undeliverable-here - marking the message modified, incrementing the delivery count, and indicating the application cannot process the message. The broker cannot redeliver the message to the application.
