### PR TITLE
WIP - Metadata injection support

### DIFF
--- a/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 
 import javax.enterprise.inject.spi.Bean;
 
@@ -46,6 +47,11 @@ public interface MediatorConfiguration {
     String getWorkerPoolName();
 
     boolean isBlockingExecutionOrdered();
+
+    /**
+     * @return the list of requested metadata. For each, the key is the class name and the value whether the injection is optional.
+     */
+    Map<String, Boolean> getRequestedMetadata();
 
     /**
      * Implementation of the {@link Invoker} interface that can be used to invoke the method described by this configuration

--- a/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
@@ -49,7 +49,8 @@ public interface MediatorConfiguration {
     boolean isBlockingExecutionOrdered();
 
     /**
-     * @return the list of requested metadata. For each, the key is the class name and the value whether the injection is optional.
+     * @return the list of requested metadata. For each, the key is the class name and the value whether the injection is
+     *         optional.
      */
     Map<String, Boolean> getRequestedMetadata();
 

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
@@ -428,7 +428,6 @@ public interface Message<T> {
             throw new IllegalArgumentException("`className` must not be `null`");
         }
         for (Object meta : getMetadata()) {
-            System.out.println("Comparing " + meta.getClass().getName() + " and " + className);
             if (meta.getClass().getName().equals(className)) {
                 return Optional.of(meta);
             }

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
@@ -418,6 +418,25 @@ public interface Message<T> {
     }
 
     /**
+     * Retrieves the metadata associated with the given classname.
+     *
+     * @param className the classname of the metadata to retrieve, must not be {@code null}
+     * @return an {@link Optional} containing the associated metadata, empty if none.
+     */
+    default Optional<?> getMetadata(String className) {
+        if (className == null) {
+            throw new IllegalArgumentException("`className` must not be `null`");
+        }
+        for (Object meta : getMetadata()) {
+            System.out.println("Comparing " + meta.getClass().getName() + " and " + className);
+            if (meta.getClass().getName().equals(className)) {
+                return Optional.of(meta);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
      * @return the supplier used to retrieve the acknowledgement {@link CompletionStage}.
      */
     default Supplier<CompletionStage<Void>> getAck() {

--- a/api/src/test/java/org/eclipse/microprofile/reactive/messaging/MessageTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/reactive/messaging/MessageTest.java
@@ -413,9 +413,12 @@ public class MessageTest {
 
         assertThat(message.getMetadata(MyMetadata.class))
                 .hasValueSatisfying(m -> assertThat(m.getValue()).isEqualTo("bar"));
+        assertThat(message.getMetadata(MyMetadata.class.getName()))
+                .hasValueSatisfying(m -> assertThat(((MyMetadata) m).getValue()).isEqualTo("bar"));
         assertThat(message.getMetadata(AtomicInteger.class)).hasValueSatisfying(m -> assertThat(m.get()).isEqualTo(2));
         assertThat(message.getMetadata(String.class)).isEmpty();
-        assertThatThrownBy(() -> message.getMetadata(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> message.getMetadata((Class<?>) null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> message.getMetadata((String) null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     private static class MyMetadata {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
@@ -1,25 +1,23 @@
 package io.smallrye.reactive.messaging;
 
-import static io.smallrye.reactive.messaging.i18n.ProviderExceptions.ex;
-import static io.smallrye.reactive.messaging.i18n.ProviderLogging.log;
-import static io.smallrye.reactive.messaging.i18n.ProviderMessages.msg;
-
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
-
-import javax.enterprise.inject.Instance;
-
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
+import io.smallrye.reactive.messaging.helpers.BroadcastHelper;
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 
-import io.smallrye.mutiny.Uni;
-import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
-import io.smallrye.reactive.messaging.extension.HealthCenter;
-import io.smallrye.reactive.messaging.helpers.BroadcastHelper;
+import javax.enterprise.inject.Instance;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import static io.smallrye.reactive.messaging.i18n.ProviderExceptions.ex;
+import static io.smallrye.reactive.messaging.i18n.ProviderLogging.log;
+import static io.smallrye.reactive.messaging.i18n.ProviderMessages.msg;
 
 public abstract class AbstractMediator {
 
@@ -29,8 +27,62 @@ public abstract class AbstractMediator {
     private Instance<PublisherDecorator> decorators;
     protected HealthCenter health;
 
+    final Function<Message<?>, Object[]> invocationParameters;
+
     public AbstractMediator(MediatorConfiguration configuration) {
         this.configuration = configuration;
+        this.invocationParameters = createInvocationParameterFunction(configuration);
+    }
+
+    private Function<Message<?>, Object[]> createInvocationParameterFunction(MediatorConfiguration configuration) {
+        if (configuration.getParameterTypes().length == 0) {
+            return null;
+        } else if (configuration.getParameterTypes().length == 1) {
+            if (configuration.consumption() == MediatorConfiguration.Consumption.PAYLOAD) {
+                return m -> new Object[] { m.getPayload() };
+            } else {
+                return m -> new Object[] { m };
+            }
+        } else {
+            Map<String, Boolean> signature = configuration.getRequestedMetadata();
+            List<Function<Message<?>, Object>> extractors = new ArrayList<>(signature.size() + 1);
+
+            // Payload or message
+            if (configuration.consumption() == MediatorConfiguration.Consumption.PAYLOAD) {
+                extractors.add(Message::getPayload);
+            } else {
+                extractors.add(m -> m);
+            }
+            // Metadata
+            for (Map.Entry<String, Boolean> entry : signature.entrySet()) {
+                boolean optional = entry.getValue();
+                String className = entry.getKey();
+                if (optional) {
+                    extractors.add(m -> m.getMetadata(className));
+                } else {
+                    extractors.add(m -> m.getMetadata(className)
+                        .orElseThrow(() -> {
+                            log.noSuchMetadata(className);
+                            NoSuchElementException exception = new NoSuchElementException(
+                                "No metadata of type " + className + " attached to the message");
+                            if (configuration.getAcknowledgment() == Acknowledgment.Strategy.MANUAL) {
+                                // The method won't be invoked, the user cannot ack/nack
+                                // nacking automatically
+                                m.nack(exception);
+                            }
+                            return exception;
+                        }));
+                }
+            }
+
+            return msg -> {
+                Object[] parameters = new Object[extractors.size()];
+                for (int i = 0; i < parameters.length; i++) {
+                    parameters[i] = extractors.get(i).apply(msg);
+                }
+                return parameters;
+            };
+        }
     }
 
     public synchronized void setInvoker(Invoker invoker) {
@@ -65,10 +117,45 @@ public abstract class AbstractMediator {
                     try {
                         return this.configuration.getMethod().invoke(bean, args);
                     } catch (Exception e) {
+                        e.printStackTrace();
                         throw ex.processingException(configuration.methodAsString(), e);
                     }
                 };
             }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> T invoke(Message<?> message) {
+        try {
+            Objects.requireNonNull(this.invoker, msg.invokerNotInitialized());
+            Object[] objects = invocationParameters.apply(message);
+            return (T) this.invoker.invoke(objects);
+        } catch (RuntimeException e) { // NOSONAR
+            log.methodException(configuration().methodAsString(), e);
+            throw e;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> Uni<T> invokeBlocking(Message<?> message) {
+        try {
+            Objects.requireNonNull(this.invoker, msg.invokerNotInitialized());
+            Objects.requireNonNull(this.workerPoolRegistry, msg.workerPoolNotInitialized());
+            return workerPoolRegistry.executeWork(
+                future -> {
+                    try {
+                        future.complete((T) this.invoker.invoke(invocationParameters.apply(message)));
+                    } catch (RuntimeException e) {
+                        log.methodException(configuration().methodAsString(), e);
+                        future.fail(e);
+                    }
+                },
+                configuration.getWorkerPoolName(),
+                configuration.isBlockingExecutionOrdered());
+        } catch (RuntimeException e) {
+            log.methodException(configuration().methodAsString(), e);
+            throw e;
         }
     }
 
@@ -89,16 +176,16 @@ public abstract class AbstractMediator {
             Objects.requireNonNull(this.invoker, msg.invokerNotInitialized());
             Objects.requireNonNull(this.workerPoolRegistry, msg.workerPoolNotInitialized());
             return workerPoolRegistry.executeWork(
-                    future -> {
-                        try {
-                            future.complete((T) this.invoker.invoke(args));
-                        } catch (RuntimeException e) {
-                            log.methodException(configuration().methodAsString(), e);
-                            future.fail(e);
-                        }
-                    },
-                    configuration.getWorkerPoolName(),
-                    configuration.isBlockingExecutionOrdered());
+                future -> {
+                    try {
+                        future.complete((T) this.invoker.invoke(args));
+                    } catch (RuntimeException e) {
+                        log.methodException(configuration().methodAsString(), e);
+                        future.fail(e);
+                    }
+                },
+                configuration.getWorkerPoolName(),
+                configuration.isBlockingExecutionOrdered());
         } catch (RuntimeException e) {
             log.methodException(configuration().methodAsString(), e);
             throw e;
@@ -153,7 +240,8 @@ public abstract class AbstractMediator {
         }
 
         if (configuration.getBroadcast()) {
-            return BroadcastHelper.broadcastPublisher(input.buildRs(), configuration.getNumberOfSubscriberBeforeConnecting());
+            return BroadcastHelper
+                .broadcastPublisher(input.buildRs(), configuration.getNumberOfSubscriberBeforeConnecting());
         } else {
             return input;
         }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/DefaultMediatorConfiguration.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/DefaultMediatorConfiguration.java
@@ -137,7 +137,7 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
             this.useBuilderTypes = validationOutput.getUseBuilderTypes();
         }
         if (this.acknowledgment == null) {
-            this.acknowledgment = this.mediatorConfigurationSupport.processDefaultAcknowledgement(this.shape, this.consumption);
+            this.acknowledgment = this.mediatorConfigurationSupport.processDefaultAcknowledgement(this.shape, this.consumption, this.production);
         }
         this.mergePolicy = this.mediatorConfigurationSupport.processMerge(incomings, () -> {
             Merge annotation = method.getAnnotation(Merge.class);

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/MediatorConfigurationSupport.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/MediatorConfigurationSupport.java
@@ -59,8 +59,8 @@ public class MediatorConfigurationSupport {
     private boolean isConsumingAPublisherOrAPublisherBuilder(Class[] parameterTypes) {
         if (parameterTypes.length >= 1) {
             Class<?> type = parameterTypes[0];
-            return ClassUtils.isAssignable(type, Publisher.class) || ClassUtils
-                    .isAssignable(type, PublisherBuilder.class);
+            return ClassUtils.isAssignable(type, Publisher.class)
+                    || ClassUtils.isAssignable(type, PublisherBuilder.class);
         }
         return false;
     }
@@ -437,8 +437,8 @@ public class MediatorConfigurationSupport {
     }
 
     public Acknowledgment.Strategy processDefaultAcknowledgement(Shape shape,
-        MediatorConfiguration.Consumption consumption,
-        MediatorConfiguration.Production production) {
+            MediatorConfiguration.Consumption consumption,
+            MediatorConfiguration.Production production) {
         if (shape == Shape.STREAM_TRANSFORMER) {
             if (consumption == MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD) {
                 return Acknowledgment.Strategy.PRE_PROCESSING;
@@ -448,7 +448,7 @@ public class MediatorConfigurationSupport {
         } else if (shape == Shape.PROCESSOR) {
             if (consumption == MediatorConfiguration.Consumption.PAYLOAD) {
                 if (production == MediatorConfiguration.Production.STREAM_OF_PAYLOAD
-                || production == MediatorConfiguration.Production.STREAM_OF_MESSAGE) {
+                        || production == MediatorConfiguration.Production.STREAM_OF_MESSAGE) {
                     return Acknowledgment.Strategy.PRE_PROCESSING;
                 }
                 return Acknowledgment.Strategy.POST_PROCESSING;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/MediatorConfigurationSupport.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/MediatorConfigurationSupport.java
@@ -123,10 +123,7 @@ public class MediatorConfigurationSupport {
 
         if (ClassUtils.isAssignable(returnType, CompletionStage.class)) {
             // Case 3 or 4
-            // Expected parameter 1, Message or payload
-            if (parameterTypes.length != 1) {
-                throw ex.definitionOnParam("@Incoming", methodAsString, "CompletionStage");
-            }
+
             // This check must be enabled once the TCK is released.
             //            if (strict && returnTypeAssignable.check(Void.class, 0) != GenericTypeAssignable.Result.Assignable) {
             //                throw getIncomingError("when returning a CompletionStage, the generic type must be Void`");
@@ -140,10 +137,7 @@ public class MediatorConfigurationSupport {
 
         if (ClassUtils.isAssignable(returnType, Uni.class)) {
             // Case 3 or 4 - Uni variants
-            // Expected parameter 1, Message or payload
-            if (parameterTypes.length != 1) {
-                throw ex.definitionOnParam("@Incoming", methodAsString, "Uni");
-            }
+
             // This check must be enabled once the TCK is released.
             //            if (strict && returnTypeAssignable.check(Void.class, 0) != GenericTypeAssignable.Result.Assignable) {
             //                throw getIncomingError("when returning a CompletionStage, the generic type must be Void`");
@@ -156,8 +150,7 @@ public class MediatorConfigurationSupport {
         }
 
         // Case 5 and 6, void
-        if (parameterTypes.length == 1) {
-            // TODO Revisit it with injected parameters
+        if (parameterTypes.length >= 1) {
             Class<?> param = parameterTypes[0];
             // Distinction between 5 and 6
             MediatorConfiguration.Consumption consumption = ClassUtils.isAssignable(param, Message.class)
@@ -317,10 +310,6 @@ public class MediatorConfigurationSupport {
         } else if (ClassUtils.isAssignable(returnType, Publisher.class)
                 || ClassUtils.isAssignable(returnType, PublisherBuilder.class)) {
             // Case 5, 6, 7, 8
-            if (parameterTypes.length != 1) {
-                throw ex.illegalArgumentForValidateProcessor(methodAsString);
-            }
-
             GenericTypeAssignable.Result assignableToMessageCheck = returnTypeAssignable.check(Message.class, 0);
             if (assignableToMessageCheck == GenericTypeAssignable.Result.NotGeneric) {
                 throw ex.definitionExpectedReturnedParam("@Outgoing", methodAsString, "Publisher");

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/MediatorConfigurationSupport.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/MediatorConfigurationSupport.java
@@ -330,8 +330,8 @@ public class MediatorConfigurationSupport {
                     : MediatorConfiguration.Production.STREAM_OF_PAYLOAD;
 
             consumption = ClassUtils.isAssignable(parameterTypes[0], Message.class)
-                    ? MediatorConfiguration.Consumption.STREAM_OF_MESSAGE
-                    : MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD;
+                    ? MediatorConfiguration.Consumption.MESSAGE
+                    : MediatorConfiguration.Consumption.PAYLOAD;
 
             useBuilderTypes = ClassUtils.isAssignable(returnType, PublisherBuilder.class);
         } else {
@@ -448,7 +448,8 @@ public class MediatorConfigurationSupport {
     }
 
     public Acknowledgment.Strategy processDefaultAcknowledgement(Shape shape,
-            MediatorConfiguration.Consumption consumption) {
+        MediatorConfiguration.Consumption consumption,
+        MediatorConfiguration.Production production) {
         if (shape == Shape.STREAM_TRANSFORMER) {
             if (consumption == MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD) {
                 return Acknowledgment.Strategy.PRE_PROCESSING;
@@ -457,6 +458,10 @@ public class MediatorConfigurationSupport {
             }
         } else if (shape == Shape.PROCESSOR) {
             if (consumption == MediatorConfiguration.Consumption.PAYLOAD) {
+                if (production == MediatorConfiguration.Production.STREAM_OF_PAYLOAD
+                || production == MediatorConfiguration.Production.STREAM_OF_MESSAGE) {
+                    return Acknowledgment.Strategy.PRE_PROCESSING;
+                }
                 return Acknowledgment.Strategy.POST_PROCESSING;
             } else if (consumption == MediatorConfiguration.Consumption.MESSAGE
                     || consumption == MediatorConfiguration.Consumption.STREAM_OF_MESSAGE) {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/ProcessorMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/ProcessorMediator.java
@@ -221,7 +221,7 @@ public class ProcessorMediator extends AbstractMediator {
         this.processor = ReactiveStreams.<Message<?>> builder()
                 .flatMapCompletionStage(managePreProcessingAck())
                 .flatMap(message -> {
-                    PublisherBuilder<?> pb = invoke(message.getPayload());
+                    PublisherBuilder<?> pb = invoke(message);
                     return pb.map(payload -> Message.of(payload, message.getMetadata()));
                     // TODO We can handle post-acknowledgement here.
                 })
@@ -232,7 +232,7 @@ public class ProcessorMediator extends AbstractMediator {
         this.processor = ReactiveStreams.<Message<?>> builder()
                 .flatMapCompletionStage(managePreProcessingAck())
                 .flatMap(message -> {
-                    Publisher<?> pub = invoke(message.getPayload());
+                    Publisher<?> pub = invoke(message);
                     return ReactiveStreams.fromPublisher(pub)
                             .map(payload -> Message.of(payload, message.getMetadata()));
                     // TODO We can handle post-acknowledgement here.
@@ -246,7 +246,7 @@ public class ProcessorMediator extends AbstractMediator {
             if (configuration.isBlocking()) {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().transformToUni(x -> invokeBlocking(message.getPayload()))
+                                .onItem().transformToUni(x -> invokeBlocking(message))
                                 .onItem().transform(x -> (Message<?>) x)
                                 .onItemOrFailure().<Message<Object>> transformToUni(this::handlePostInvocationWithMessage)
                                 .onItem().transformToMulti(this::handleSkip))
@@ -254,7 +254,7 @@ public class ProcessorMediator extends AbstractMediator {
             } else {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().transform(x -> invoke(message.getPayload()))
+                                .onItem().transform(x -> invoke(message))
                                 .onItem().transform(x -> (Message<?>) x)
                                 .onItemOrFailure().<Message<Object>> transformToUni(this::handlePostInvocationWithMessage)
                                 .onItem().transformToMulti(this::handleSkip))
@@ -291,7 +291,7 @@ public class ProcessorMediator extends AbstractMediator {
             if (configuration.isBlocking()) {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().transformToUni(x -> (Uni<?>) invokeBlocking(message.getPayload()))
+                                .onItem().transformToUni(x -> (Uni<?>) invokeBlocking(message))
                                 .onItemOrFailure()
                                 .<Message<Object>> transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
                                 .onItem().transformToMulti(this::handleSkip))
@@ -299,7 +299,7 @@ public class ProcessorMediator extends AbstractMediator {
             } else {
                 this.processor = ReactiveStreams.<Message<?>> builder()
                         .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                                .onItem().transform(input -> invoke(input.getPayload()))
+                                .onItem().transform(this::invoke)
                                 .onItemOrFailure()
                                 .<Message<Object>> transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
                                 .onItem().transformToMulti(this::handleSkip))
@@ -397,7 +397,7 @@ public class ProcessorMediator extends AbstractMediator {
                 .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
                         .onItem()
                         .transformToUni(
-                                x -> Uni.createFrom().completionStage((CompletionStage<?>) invoke(message.getPayload())))
+                                x -> Uni.createFrom().completionStage((CompletionStage<?>) invoke(message)))
                         .onItemOrFailure().transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
                         .onItem().transformToMulti(this::handleSkip))
                 .buildRs();
@@ -406,7 +406,7 @@ public class ProcessorMediator extends AbstractMediator {
     private void processMethodReturningAUniOfPayloadAndConsumingIndividualPayload() {
         this.processor = ReactiveStreams.<Message<?>> builder()
                 .flatMapRsPublisher(message -> Uni.createFrom().completionStage(handlePreProcessingAck(message))
-                        .onItem().transformToUni(x -> invoke(message.getPayload()))
+                        .onItem().transformToUni(x -> invoke(message))
                         .onItemOrFailure().transformToUni((res, fail) -> handlePostInvocation(message, res, fail))
                         .onItem().transformToMulti(this::handleSkip))
                 .buildRs();

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
@@ -144,4 +144,8 @@ public interface ProviderLogging extends BasicLogger {
     @Message(id = 230, value = "Unable to create the publisher or subscriber during initialization")
     void unableToCreatePublisherOrSubscriber(@Cause Throwable t);
 
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 231, value = "No metadata of type %s attached to the message")
+    void noSuchMetadata(String type);
+
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MandatoryMetadataInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MandatoryMetadataInjectionTest.java
@@ -3,10 +3,6 @@ package io.smallrye.reactive.messaging.metadata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -14,8 +10,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.Test;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 
@@ -23,10 +17,12 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleMandatoryMetadataInjectionWhenProcessingPayload() {
-        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingPayload.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleMandatoryMetadataInjectionWhenProcessingPayload.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -34,10 +30,12 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleMandatoryMetadataInjectionWhenProcessingMessage() {
-        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingMessage.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleMandatoryMetadataInjectionWhenProcessingMessage.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -45,10 +43,12 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleMandatoryMetadataInjectionWhenProcessingPayloadBlocking() {
-        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingPayloadBlocking.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleMandatoryMetadataInjectionWhenProcessingPayloadBlocking.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -56,10 +56,12 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleMandatoryMetadataInjectionWhenProcessingMessageBlocking() {
-        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingMessageBlocking.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleMandatoryMetadataInjectionWhenProcessingMessageBlocking.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -67,10 +69,12 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleMandatoryMetadataInjectionWhenProcessingMessageAndReturningPayload() {
-        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingMessageAndReturningPayload.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleMandatoryMetadataInjectionWhenProcessingMessageAndReturningPayload.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -78,38 +82,44 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingPayload() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingPayload.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                SingleMandatoryMetadataInjectionWhenProcessingPayload.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingMessage() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingMessage.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                SingleMandatoryMetadataInjectionWhenProcessingMessage.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().until(() -> source.nacked().size() == 1);
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingPayloadBlocking() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class,
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
                 SingleMandatoryMetadataInjectionWhenProcessingPayloadBlocking.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingMessageBlocking() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class,
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
                 SingleMandatoryMetadataInjectionWhenProcessingMessageBlocking.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(1));
         assertThat(source.acked()).hasSize(0);
     }
@@ -119,7 +129,7 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public String process(String payload, MyMetadata metadata) {
+        public String process(String payload, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
             return payload.toUpperCase();
         }
@@ -131,7 +141,7 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
         @Incoming("in")
         @Outgoing("out")
         @Blocking
-        public String process(String payload, MyMetadata metadata) {
+        public String process(String payload, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
             return payload.toUpperCase();
         }
@@ -142,10 +152,10 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public Message<String> process(Message<String> msg, MyMetadata metadata) {
+        public Message<String> process(Message<String> msg, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
-            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
-            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MetadataInjectionBase.MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
             return msg.withPayload(msg.getPayload().toUpperCase());
         }
     }
@@ -156,10 +166,10 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
         @Incoming("in")
         @Outgoing("out")
         @Blocking
-        public Message<String> process(Message<String> msg, MyMetadata metadata) {
+        public Message<String> process(Message<String> msg, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
-            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
-            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MetadataInjectionBase.MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
             return msg.withPayload(msg.getPayload().toUpperCase());
         }
     }
@@ -169,123 +179,12 @@ public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public String process(Message<String> msg, MyMetadata metadata) {
+        public String process(Message<String> msg, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
-            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
-            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MetadataInjectionBase.MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
             msg.ack();
             return msg.getPayload().toUpperCase();
-        }
-    }
-
-    @ApplicationScoped
-    public static class Sink {
-        List<String> list = new CopyOnWriteArrayList<>();
-
-        @Incoming("out")
-        public void consume(String s) {
-            list.add(s);
-        }
-
-        public List<String> list() {
-            return list;
-        }
-    }
-
-    @ApplicationScoped
-    public static class Source {
-        int i = 0;
-        List<Integer> acked = new CopyOnWriteArrayList<>();
-        List<Integer> nacked = new CopyOnWriteArrayList<>();
-
-        @Outgoing("in")
-        public Multi<Message<String>> producer() {
-            return Multi.createFrom().range(0, 5)
-                    .emitOn(Infrastructure.getDefaultExecutor())
-                    .onItem().transform(i -> {
-                        i = i + 1;
-                        int v = i;
-                        return Message.of("hello")
-                                .addMetadata(new MyMetadata(i))
-                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
-                                .withAck(() -> {
-                                    acked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                })
-                                .withNack(t -> {
-                                    nacked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                });
-
-                    });
-        }
-
-        public List<Integer> acked() {
-            return acked;
-        }
-
-        public List<Integer> nacked() {
-            return nacked;
-        }
-    }
-
-    @ApplicationScoped
-    public static class SourceWithoutMyMetadata {
-        int i = 0;
-        List<Integer> acked = new CopyOnWriteArrayList<>();
-        List<Integer> nacked = new CopyOnWriteArrayList<>();
-
-        @Outgoing("in")
-        public Multi<Message<String>> producer() {
-            return Multi.createFrom().range(0, 5)
-                    .emitOn(Infrastructure.getDefaultExecutor())
-                    .onItem().transform(i -> {
-                        i = i + 1;
-                        int v = i;
-                        return Message.of("hello")
-                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
-                                .withAck(() -> {
-                                    acked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                })
-                                .withNack(t -> {
-                                    nacked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                });
-
-                    });
-        }
-
-        public List<Integer> acked() {
-            return acked;
-        }
-
-        public List<Integer> nacked() {
-            return nacked;
-        }
-    }
-
-    public static class MyMetadata {
-        private final int id;
-
-        public MyMetadata(int id) {
-            this.id = id;
-        }
-
-        public int getId() {
-            return id;
-        }
-    }
-
-    public static class MyOtherMetadata {
-        private final String id;
-
-        public MyOtherMetadata(String id) {
-            this.id = id;
-        }
-
-        public String getId() {
-            return id;
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MandatoryMetadataInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MandatoryMetadataInjectionTest.java
@@ -1,0 +1,292 @@
+package io.smallrye.reactive.messaging.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+
+public class MandatoryMetadataInjectionTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWhenProcessingPayload() {
+        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingPayload.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWhenProcessingMessage() {
+        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingMessage.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWhenProcessingPayloadBlocking() {
+        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingPayloadBlocking.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWhenProcessingMessageBlocking() {
+        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingMessageBlocking.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWhenProcessingMessageAndReturningPayload() {
+        addBeanClass(Source.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingMessageAndReturningPayload.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingPayload() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingPayload.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingMessage() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, SingleMandatoryMetadataInjectionWhenProcessingMessage.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().until(() -> source.nacked().size() == 1);
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingPayloadBlocking() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class,
+                SingleMandatoryMetadataInjectionWhenProcessingPayloadBlocking.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingMessageBlocking() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class,
+                SingleMandatoryMetadataInjectionWhenProcessingMessageBlocking.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(1));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @ApplicationScoped
+    public static class SingleMandatoryMetadataInjectionWhenProcessingPayload {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public String process(String payload, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            return payload.toUpperCase();
+        }
+    }
+
+    @ApplicationScoped
+    public static class SingleMandatoryMetadataInjectionWhenProcessingPayloadBlocking {
+
+        @Incoming("in")
+        @Outgoing("out")
+        @Blocking
+        public String process(String payload, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            return payload.toUpperCase();
+        }
+    }
+
+    @ApplicationScoped
+    public static class SingleMandatoryMetadataInjectionWhenProcessingMessage {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public Message<String> process(Message<String> msg, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            return msg.withPayload(msg.getPayload().toUpperCase());
+        }
+    }
+
+    @ApplicationScoped
+    public static class SingleMandatoryMetadataInjectionWhenProcessingMessageBlocking {
+
+        @Incoming("in")
+        @Outgoing("out")
+        @Blocking
+        public Message<String> process(Message<String> msg, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            return msg.withPayload(msg.getPayload().toUpperCase());
+        }
+    }
+
+    @ApplicationScoped
+    public static class SingleMandatoryMetadataInjectionWhenProcessingMessageAndReturningPayload {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public String process(Message<String> msg, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            msg.ack();
+            return msg.getPayload().toUpperCase();
+        }
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("out")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyMetadata(i))
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SourceWithoutMyMetadata {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    public static class MyMetadata {
+        private final int id;
+
+        public MyMetadata(int id) {
+            this.id = id;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class MyOtherMetadata {
+        private final String id;
+
+        public MyOtherMetadata(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MessageTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MessageTest.java
@@ -115,9 +115,11 @@ public class MessageTest {
 
         assertThat(message.getMetadata()).hasSize(2);
         assertThat(message.getMetadata(MyMetadata.class).map(i -> i.v)).hasValue("value");
+        assertThat(message.getMetadata(MyMetadata.class.getName())).isNotEmpty();
         assertThat(message.getMetadata(CountMetadata.class).map(i -> i.count)).hasValue(23);
         assertThat(message.getMetadata(String.class)).isEmpty();
-        assertThatThrownBy(() -> message.getMetadata(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> message.getMetadata((Class<?>) null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> message.getMetadata((String) null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     private static class MyMessage implements Message<String> {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MetadataInjectionBase.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MetadataInjectionBase.java
@@ -1,0 +1,135 @@
+package io.smallrye.reactive.messaging.metadata;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class MetadataInjectionBase {
+    @ApplicationScoped
+    public static class Sink {
+        List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("out")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Inject
+        @Channel("in")
+        Emitter<String> emitter;
+
+        public void run() {
+            Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyMetadata(i))
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+                    }).subscribe().with(i -> emitter.send(i));
+            ;
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SourceWithoutMyMetadata {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Inject
+        @Channel("in")
+        Emitter<String> emitter;
+
+        public void run() {
+            Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    }).subscribe().with(i -> emitter.send(i));
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    public static class MyMetadata {
+        private final int id;
+
+        public MyMetadata(int id) {
+            this.id = id;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class MyOtherMetadata {
+        private final String id;
+
+        public MyOtherMetadata(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MultipleMetadataInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MultipleMetadataInjectionTest.java
@@ -3,10 +3,7 @@ package io.smallrye.reactive.messaging.metadata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -15,8 +12,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.Test;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 
@@ -25,10 +20,12 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMultipleMetadataInjectionWhenProcessingPayload() {
-        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingPayload.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                MultipleMetadataInjectionWhenProcessingPayload.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -36,10 +33,12 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMultipleMetadataInjectionWhenProcessingMessage() {
-        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessage.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                MultipleMetadataInjectionWhenProcessingMessage.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -47,10 +46,12 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMultipleMetadataInjectionWhenProcessingPayloadBlocking() {
-        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingPayloadBlocking.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                MultipleMetadataInjectionWhenProcessingPayloadBlocking.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -58,10 +59,12 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMultipleMetadataInjectionWhenProcessingMessageBlocking() {
-        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessageBlocking.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                MultipleMetadataInjectionWhenProcessingMessageBlocking.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -69,10 +72,12 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMultipleMetadataInjectionWhenProcessingMessageAndReturningPayload() {
-        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessageAndReturningPayload.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                MultipleMetadataInjectionWhenProcessingMessageAndReturningPayload.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -80,36 +85,44 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingPayload() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, MultipleMetadataInjectionWhenProcessingPayload.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                MultipleMetadataInjectionWhenProcessingPayload.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingMessage() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessage.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                MultipleMetadataInjectionWhenProcessingMessage.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().until(() -> source.nacked().size() == 1);
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingPayloadBlocking() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, MultipleMetadataInjectionWhenProcessingPayloadBlocking.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                MultipleMetadataInjectionWhenProcessingPayloadBlocking.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingMessageBlocking() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessageBlocking.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                MultipleMetadataInjectionWhenProcessingMessageBlocking.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(1));
         assertThat(source.acked()).hasSize(0);
     }
@@ -119,7 +132,8 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public String process(String payload, MyMetadata metadata, Optional<MyOtherMetadata> other,
+        public String process(String payload, MetadataInjectionBase.MyMetadata metadata,
+                Optional<MetadataInjectionBase.MyOtherMetadata> other,
                 Optional<UnusedMetadata> unused) {
             assertThat(metadata.getId()).isNotZero();
             assertThat(other).isNotEmpty();
@@ -134,7 +148,8 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
         @Incoming("in")
         @Outgoing("out")
         @Blocking
-        public String process(String payload, MyMetadata metadata, Optional<MyOtherMetadata> other,
+        public String process(String payload, MetadataInjectionBase.MyMetadata metadata,
+                Optional<MetadataInjectionBase.MyOtherMetadata> other,
                 Optional<UnusedMetadata> unused) {
             assertThat(metadata.getId()).isNotZero();
             assertThat(other).isNotEmpty();
@@ -148,13 +163,14 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public Message<String> process(Message<String> msg, Optional<MyOtherMetadata> other, MyMetadata metadata,
+        public Message<String> process(Message<String> msg, Optional<MetadataInjectionBase.MyOtherMetadata> other,
+                MetadataInjectionBase.MyMetadata metadata,
                 Optional<UnusedMetadata> unused) {
             assertThat(metadata.getId()).isNotZero();
             assertThat(other).isNotEmpty();
             assertThat(unused).isEmpty();
-            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
-            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MetadataInjectionBase.MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
             return msg.withPayload(msg.getPayload().toUpperCase());
         }
     }
@@ -165,13 +181,14 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
         @Incoming("in")
         @Outgoing("out")
         @Blocking
-        public Message<String> process(Message<String> msg, MyMetadata metadata, Optional<MyOtherMetadata> other,
+        public Message<String> process(Message<String> msg, MetadataInjectionBase.MyMetadata metadata,
+                Optional<MetadataInjectionBase.MyOtherMetadata> other,
                 Optional<UnusedMetadata> unused) {
             assertThat(metadata.getId()).isNotZero();
             assertThat(other).isNotEmpty();
             assertThat(unused).isEmpty();
-            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
-            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MetadataInjectionBase.MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
             return msg.withPayload(msg.getPayload().toUpperCase());
         }
     }
@@ -181,127 +198,16 @@ public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public String process(Message<String> msg, MyMetadata metadata, Optional<MyOtherMetadata> other,
+        public String process(Message<String> msg, MetadataInjectionBase.MyMetadata metadata,
+                Optional<MetadataInjectionBase.MyOtherMetadata> other,
                 Optional<UnusedMetadata> unused) {
             assertThat(metadata.getId()).isNotZero();
             assertThat(other).isNotEmpty();
             assertThat(unused).isEmpty();
-            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
-            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MetadataInjectionBase.MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
             msg.ack();
             return msg.getPayload().toUpperCase();
-        }
-    }
-
-    @ApplicationScoped
-    public static class Sink {
-        List<String> list = new CopyOnWriteArrayList<>();
-
-        @Incoming("out")
-        public void consume(String s) {
-            list.add(s);
-        }
-
-        public List<String> list() {
-            return list;
-        }
-    }
-
-    @ApplicationScoped
-    public static class Source {
-        int i = 0;
-        List<Integer> acked = new CopyOnWriteArrayList<>();
-        List<Integer> nacked = new CopyOnWriteArrayList<>();
-
-        @Outgoing("in")
-        public Multi<Message<String>> producer() {
-            return Multi.createFrom().range(0, 5)
-                    .emitOn(Infrastructure.getDefaultExecutor())
-                    .onItem().transform(i -> {
-                        i = i + 1;
-                        int v = i;
-                        Message<String> m = Message.of("hello")
-                                .addMetadata(new MyMetadata(i))
-                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
-                                .withAck(() -> {
-                                    acked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                })
-                                .withNack(t -> {
-                                    nacked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                });
-                        return m;
-
-                    });
-        }
-
-        public List<Integer> acked() {
-            return acked;
-        }
-
-        public List<Integer> nacked() {
-            return nacked;
-        }
-    }
-
-    @ApplicationScoped
-    public static class SourceWithoutMyMetadata {
-        int i = 0;
-        List<Integer> acked = new CopyOnWriteArrayList<>();
-        List<Integer> nacked = new CopyOnWriteArrayList<>();
-
-        @Outgoing("in")
-        public Multi<Message<String>> producer() {
-            return Multi.createFrom().range(0, 5)
-                    .emitOn(Infrastructure.getDefaultExecutor())
-                    .onItem().transform(i -> {
-                        i = i + 1;
-                        int v = i;
-                        return Message.of("hello")
-                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
-                                .withAck(() -> {
-                                    acked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                })
-                                .withNack(t -> {
-                                    nacked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                });
-
-                    });
-        }
-
-        public List<Integer> acked() {
-            return acked;
-        }
-
-        public List<Integer> nacked() {
-            return nacked;
-        }
-    }
-
-    public static class MyMetadata {
-        private final int id;
-
-        public MyMetadata(int id) {
-            this.id = id;
-        }
-
-        public int getId() {
-            return id;
-        }
-    }
-
-    public static class MyOtherMetadata {
-        private final String id;
-
-        public MyOtherMetadata(String id) {
-            this.id = id;
-        }
-
-        public String getId() {
-            return id;
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MultipleMetadataInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MultipleMetadataInjectionTest.java
@@ -1,0 +1,312 @@
+package io.smallrye.reactive.messaging.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public class MultipleMetadataInjectionTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testMultipleMetadataInjectionWhenProcessingPayload() {
+        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingPayload.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMultipleMetadataInjectionWhenProcessingMessage() {
+        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessage.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMultipleMetadataInjectionWhenProcessingPayloadBlocking() {
+        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingPayloadBlocking.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMultipleMetadataInjectionWhenProcessingMessageBlocking() {
+        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessageBlocking.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMultipleMetadataInjectionWhenProcessingMessageAndReturningPayload() {
+        addBeanClass(Source.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessageAndReturningPayload.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingPayload() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, MultipleMetadataInjectionWhenProcessingPayload.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingMessage() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessage.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().until(() -> source.nacked().size() == 1);
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingPayloadBlocking() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, MultipleMetadataInjectionWhenProcessingPayloadBlocking.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingMessageBlocking() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, MultipleMetadataInjectionWhenProcessingMessageBlocking.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(1));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @ApplicationScoped
+    public static class MultipleMetadataInjectionWhenProcessingPayload {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public String process(String payload, MyMetadata metadata, Optional<MyOtherMetadata> other,
+                Optional<UnusedMetadata> unused) {
+            assertThat(metadata.getId()).isNotZero();
+            assertThat(other).isNotEmpty();
+            assertThat(unused).isEmpty();
+            return payload.toUpperCase();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MultipleMetadataInjectionWhenProcessingPayloadBlocking {
+
+        @Incoming("in")
+        @Outgoing("out")
+        @Blocking
+        public String process(String payload, MyMetadata metadata, Optional<MyOtherMetadata> other,
+                Optional<UnusedMetadata> unused) {
+            assertThat(metadata.getId()).isNotZero();
+            assertThat(other).isNotEmpty();
+            assertThat(unused).isEmpty();
+            return payload.toUpperCase();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MultipleMetadataInjectionWhenProcessingMessage {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public Message<String> process(Message<String> msg, Optional<MyOtherMetadata> other, MyMetadata metadata,
+                Optional<UnusedMetadata> unused) {
+            assertThat(metadata.getId()).isNotZero();
+            assertThat(other).isNotEmpty();
+            assertThat(unused).isEmpty();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            return msg.withPayload(msg.getPayload().toUpperCase());
+        }
+    }
+
+    @ApplicationScoped
+    public static class MultipleMetadataInjectionWhenProcessingMessageBlocking {
+
+        @Incoming("in")
+        @Outgoing("out")
+        @Blocking
+        public Message<String> process(Message<String> msg, MyMetadata metadata, Optional<MyOtherMetadata> other,
+                Optional<UnusedMetadata> unused) {
+            assertThat(metadata.getId()).isNotZero();
+            assertThat(other).isNotEmpty();
+            assertThat(unused).isEmpty();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            return msg.withPayload(msg.getPayload().toUpperCase());
+        }
+    }
+
+    @ApplicationScoped
+    public static class MultipleMetadataInjectionWhenProcessingMessageAndReturningPayload {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public String process(Message<String> msg, MyMetadata metadata, Optional<MyOtherMetadata> other,
+                Optional<UnusedMetadata> unused) {
+            assertThat(metadata.getId()).isNotZero();
+            assertThat(other).isNotEmpty();
+            assertThat(unused).isEmpty();
+            assertThat(metadata).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
+            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            msg.ack();
+            return msg.getPayload().toUpperCase();
+        }
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("out")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        Message<String> m = Message.of("hello")
+                                .addMetadata(new MyMetadata(i))
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+                        return m;
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SourceWithoutMyMetadata {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    public static class MyMetadata {
+        private final int id;
+
+        public MyMetadata(int id) {
+            this.id = id;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class MyOtherMetadata {
+        private final String id;
+
+        public MyOtherMetadata(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+    public static class UnusedMetadata {
+
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/OptionalMetadataInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/OptionalMetadataInjectionTest.java
@@ -1,0 +1,332 @@
+package io.smallrye.reactive.messaging.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testSingleOptionalMetadataInjectionWhenProcessingPayload() {
+        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingPayload.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+        assertThat(sink.list()).containsExactly("found", "found", "found", "found", "found");
+    }
+
+    @Test
+    public void testSingleOptionalMetadataInjectionWhenProcessingMessage() {
+        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingMessage.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+        assertThat(sink.list()).containsExactly("HELLO-OK", "HELLO-OK", "HELLO-OK", "HELLO-OK", "HELLO-OK");
+    }
+
+    @Test
+    public void testSingleOptionalMetadataInjectionWhenProcessingPayloadBlocking() {
+        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingPayloadBlocking.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+        assertThat(sink.list()).containsExactly("found", "found", "found", "found", "found");
+    }
+
+    @Test
+    public void testSingleOptionalMetadataInjectionWhenProcessingMessageBlocking() {
+        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingMessageBlocking.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+        assertThat(sink.list()).containsExactly("found", "found", "found", "found", "found");
+    }
+
+    @Test
+    public void testSingleOptionalMetadataInjectionWhenProcessingMessageAndReturningPayload() {
+        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingMessageAndReturningPayload.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+        assertThat(sink.list()).containsExactly("HELLO-OK", "HELLO-OK", "HELLO-OK", "HELLO-OK", "HELLO-OK");
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingPayload() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingPayload.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        Sink sink = get(Sink.class);
+        await().untilAsserted(() -> assertThat(source.acked()).hasSize(5));
+        assertThat(source.nacked()).hasSize(0);
+        assertThat(sink.list()).containsExactly("HELLO", "HELLO", "HELLO", "HELLO", "HELLO");
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingMessage() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingMessage.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().until(() -> source.acked().size() == 5);
+        Sink sink = get(Sink.class);
+        assertThat(source.nacked()).hasSize(0);
+        assertThat(sink.list()).containsExactly("HELLO", "HELLO", "HELLO", "HELLO", "HELLO");
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWhenProcessingPayloadBlocking() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class,
+                SingleOptionalMetadataInjectionWhenProcessingPayloadBlocking.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.acked()).hasSize(5));
+        Sink sink = get(Sink.class);
+        assertThat(source.nacked()).hasSize(0);
+        assertThat(sink.list()).containsExactly("HELLO", "HELLO", "HELLO", "HELLO", "HELLO");
+    }
+
+    @Test
+    public void testMissingOptionalMetadataInjectionWhenProcessingMessageBlocking() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class,
+                SingleOptionalMetadataInjectionWhenProcessingMessageBlocking.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.acked()).hasSize(5));
+        Sink sink = get(Sink.class);
+        assertThat(source.nacked()).hasSize(0);
+        assertThat(sink.list()).containsExactly("HELLO", "HELLO", "HELLO", "HELLO", "HELLO");
+    }
+
+    @ApplicationScoped
+    public static class SingleOptionalMetadataInjectionWhenProcessingPayload {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public String process(String payload, Optional<MyMetadata> metadata) {
+            if (metadata.isPresent()) {
+                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
+                return "found";
+            } else {
+                return payload.toUpperCase();
+            }
+
+        }
+    }
+
+    @ApplicationScoped
+    public static class SingleOptionalMetadataInjectionWhenProcessingPayloadBlocking {
+
+        @Incoming("in")
+        @Outgoing("out")
+        @Blocking
+        public String process(String payload, Optional<MyMetadata> metadata) {
+            if (metadata.isPresent()) {
+                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
+                return "found";
+            }
+            return payload.toUpperCase();
+        }
+    }
+
+    @ApplicationScoped
+    public static class SingleOptionalMetadataInjectionWhenProcessingMessage {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public Message<String> process(Message<String> msg, Optional<MyMetadata> metadata) {
+            if (metadata.isPresent()) {
+                assertThat(metadata).isNotEmpty();
+                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
+                assertThat(metadata.orElse(null)).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
+                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                return msg.withPayload(msg.getPayload().toUpperCase() + "-OK");
+            } else {
+                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                return msg.withPayload(msg.getPayload().toUpperCase());
+            }
+        }
+    }
+
+    @ApplicationScoped
+    public static class SingleOptionalMetadataInjectionWhenProcessingMessageBlocking {
+
+        @Incoming("in")
+        @Outgoing("out")
+        @Blocking
+        public Message<String> process(Message<String> msg, Optional<MyMetadata> metadata) {
+            if (metadata.isPresent()) {
+                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
+                assertThat(metadata.orElse(null)).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
+                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                return msg.withPayload("found");
+            }
+            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            return msg.withPayload(msg.getPayload().toUpperCase());
+        }
+    }
+
+    @ApplicationScoped
+    public static class SingleOptionalMetadataInjectionWhenProcessingMessageAndReturningPayload {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public CompletionStage<String> process(Message<String> msg, Optional<MyMetadata> metadata) {
+            if (metadata.isPresent()) {
+                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
+                assertThat(metadata.orElse(null)).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
+                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                return msg.ack()
+                        .thenApply(x -> msg.getPayload().toUpperCase() + "-OK");
+            } else {
+                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                return msg.ack()
+                        .thenApply(x -> msg.getPayload().toUpperCase());
+            }
+        }
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("out")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyMetadata(i))
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SourceWithoutMyMetadata {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    public static class MyMetadata {
+        private final int id;
+
+        public MyMetadata(int id) {
+            this.id = id;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class MyOtherMetadata {
+        private final String id;
+
+        public MyOtherMetadata(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/OptionalMetadataInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/OptionalMetadataInjectionTest.java
@@ -3,11 +3,8 @@ package io.smallrye.reactive.messaging.metadata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -16,8 +13,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.Test;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 
@@ -26,10 +21,12 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleOptionalMetadataInjectionWhenProcessingPayload() {
-        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingPayload.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleOptionalMetadataInjectionWhenProcessingPayload.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -38,10 +35,12 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleOptionalMetadataInjectionWhenProcessingMessage() {
-        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingMessage.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleOptionalMetadataInjectionWhenProcessingMessage.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -50,10 +49,12 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleOptionalMetadataInjectionWhenProcessingPayloadBlocking() {
-        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingPayloadBlocking.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleOptionalMetadataInjectionWhenProcessingPayloadBlocking.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -62,10 +63,12 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleOptionalMetadataInjectionWhenProcessingMessageBlocking() {
-        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingMessageBlocking.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleOptionalMetadataInjectionWhenProcessingMessageBlocking.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -74,10 +77,12 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleOptionalMetadataInjectionWhenProcessingMessageAndReturningPayload() {
-        addBeanClass(Source.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingMessageAndReturningPayload.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                SingleOptionalMetadataInjectionWhenProcessingMessageAndReturningPayload.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -86,10 +91,12 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingPayload() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingPayload.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                SingleOptionalMetadataInjectionWhenProcessingPayload.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
-        Sink sink = get(Sink.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.acked()).hasSize(5));
         assertThat(source.nacked()).hasSize(0);
         assertThat(sink.list()).containsExactly("HELLO", "HELLO", "HELLO", "HELLO", "HELLO");
@@ -97,35 +104,39 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingMessage() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, SingleOptionalMetadataInjectionWhenProcessingMessage.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                SingleOptionalMetadataInjectionWhenProcessingMessage.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        source.run();
         await().until(() -> source.acked().size() == 5);
-        Sink sink = get(Sink.class);
         assertThat(source.nacked()).hasSize(0);
         assertThat(sink.list()).containsExactly("HELLO", "HELLO", "HELLO", "HELLO", "HELLO");
     }
 
     @Test
     public void testMissingMandatoryMetadataInjectionWhenProcessingPayloadBlocking() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class,
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
                 SingleOptionalMetadataInjectionWhenProcessingPayloadBlocking.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.acked()).hasSize(5));
-        Sink sink = get(Sink.class);
         assertThat(source.nacked()).hasSize(0);
         assertThat(sink.list()).containsExactly("HELLO", "HELLO", "HELLO", "HELLO", "HELLO");
     }
 
     @Test
     public void testMissingOptionalMetadataInjectionWhenProcessingMessageBlocking() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class,
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
                 SingleOptionalMetadataInjectionWhenProcessingMessageBlocking.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.acked()).hasSize(5));
-        Sink sink = get(Sink.class);
         assertThat(source.nacked()).hasSize(0);
         assertThat(sink.list()).containsExactly("HELLO", "HELLO", "HELLO", "HELLO", "HELLO");
     }
@@ -135,9 +146,9 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public String process(String payload, Optional<MyMetadata> metadata) {
+        public String process(String payload, Optional<MetadataInjectionBase.MyMetadata> metadata) {
             if (metadata.isPresent()) {
-                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
+                assertThat(metadata.orElse(new MetadataInjectionBase.MyMetadata(0)).getId()).isNotZero();
                 return "found";
             } else {
                 return payload.toUpperCase();
@@ -152,9 +163,9 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
         @Incoming("in")
         @Outgoing("out")
         @Blocking
-        public String process(String payload, Optional<MyMetadata> metadata) {
+        public String process(String payload, Optional<MetadataInjectionBase.MyMetadata> metadata) {
             if (metadata.isPresent()) {
-                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
+                assertThat(metadata.orElse(new MetadataInjectionBase.MyMetadata(0)).getId()).isNotZero();
                 return "found";
             }
             return payload.toUpperCase();
@@ -166,15 +177,16 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public Message<String> process(Message<String> msg, Optional<MyMetadata> metadata) {
+        public Message<String> process(Message<String> msg, Optional<MetadataInjectionBase.MyMetadata> metadata) {
             if (metadata.isPresent()) {
                 assertThat(metadata).isNotEmpty();
-                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
-                assertThat(metadata.orElse(null)).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
-                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                assertThat(metadata.orElse(new MetadataInjectionBase.MyMetadata(0)).getId()).isNotZero();
+                assertThat(metadata.orElse(null))
+                        .isEqualTo(msg.getMetadata(MetadataInjectionBase.MyMetadata.class).orElse(null));
+                assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
                 return msg.withPayload(msg.getPayload().toUpperCase() + "-OK");
             } else {
-                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
                 return msg.withPayload(msg.getPayload().toUpperCase());
             }
         }
@@ -186,14 +198,15 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
         @Incoming("in")
         @Outgoing("out")
         @Blocking
-        public Message<String> process(Message<String> msg, Optional<MyMetadata> metadata) {
+        public Message<String> process(Message<String> msg, Optional<MetadataInjectionBase.MyMetadata> metadata) {
             if (metadata.isPresent()) {
-                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
-                assertThat(metadata.orElse(null)).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
-                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                assertThat(metadata.orElse(new MetadataInjectionBase.MyMetadata(0)).getId()).isNotZero();
+                assertThat(metadata.orElse(null))
+                        .isEqualTo(msg.getMetadata(MetadataInjectionBase.MyMetadata.class).orElse(null));
+                assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
                 return msg.withPayload("found");
             }
-            assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+            assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
             return msg.withPayload(msg.getPayload().toUpperCase());
         }
     }
@@ -203,129 +216,20 @@ public class OptionalMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public CompletionStage<String> process(Message<String> msg, Optional<MyMetadata> metadata) {
+        public CompletionStage<String> process(Message<String> msg,
+                Optional<MetadataInjectionBase.MyMetadata> metadata) {
             if (metadata.isPresent()) {
-                assertThat(metadata.orElse(new MyMetadata(0)).getId()).isNotZero();
-                assertThat(metadata.orElse(null)).isEqualTo(msg.getMetadata(MyMetadata.class).orElse(null));
-                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                assertThat(metadata.orElse(new MetadataInjectionBase.MyMetadata(0)).getId()).isNotZero();
+                assertThat(metadata.orElse(null))
+                        .isEqualTo(msg.getMetadata(MetadataInjectionBase.MyMetadata.class).orElse(null));
+                assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
                 return msg.ack()
                         .thenApply(x -> msg.getPayload().toUpperCase() + "-OK");
             } else {
-                assertThat(msg.getMetadata(MyOtherMetadata.class)).isNotEmpty();
+                assertThat(msg.getMetadata(MetadataInjectionBase.MyOtherMetadata.class)).isNotEmpty();
                 return msg.ack()
                         .thenApply(x -> msg.getPayload().toUpperCase());
             }
-        }
-    }
-
-    @ApplicationScoped
-    public static class Sink {
-        List<String> list = new CopyOnWriteArrayList<>();
-
-        @Incoming("out")
-        public void consume(String s) {
-            list.add(s);
-        }
-
-        public List<String> list() {
-            return list;
-        }
-    }
-
-    @ApplicationScoped
-    public static class Source {
-        int i = 0;
-        List<Integer> acked = new CopyOnWriteArrayList<>();
-        List<Integer> nacked = new CopyOnWriteArrayList<>();
-
-        @Outgoing("in")
-        public Multi<Message<String>> producer() {
-            return Multi.createFrom().range(0, 5)
-                    .emitOn(Infrastructure.getDefaultExecutor())
-                    .onItem().transform(i -> {
-                        i = i + 1;
-                        int v = i;
-                        return Message.of("hello")
-                                .addMetadata(new MyMetadata(i))
-                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
-                                .withAck(() -> {
-                                    acked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                })
-                                .withNack(t -> {
-                                    nacked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                });
-
-                    });
-        }
-
-        public List<Integer> acked() {
-            return acked;
-        }
-
-        public List<Integer> nacked() {
-            return nacked;
-        }
-    }
-
-    @ApplicationScoped
-    public static class SourceWithoutMyMetadata {
-        int i = 0;
-        List<Integer> acked = new CopyOnWriteArrayList<>();
-        List<Integer> nacked = new CopyOnWriteArrayList<>();
-
-        @Outgoing("in")
-        public Multi<Message<String>> producer() {
-            return Multi.createFrom().range(0, 5)
-                    .emitOn(Infrastructure.getDefaultExecutor())
-                    .onItem().transform(i -> {
-                        i = i + 1;
-                        int v = i;
-                        return Message.of("hello")
-                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
-                                .withAck(() -> {
-                                    acked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                })
-                                .withNack(t -> {
-                                    nacked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                });
-
-                    });
-        }
-
-        public List<Integer> acked() {
-            return acked;
-        }
-
-        public List<Integer> nacked() {
-            return nacked;
-        }
-    }
-
-    public static class MyMetadata {
-        private final int id;
-
-        public MyMetadata(int id) {
-            this.id = id;
-        }
-
-        public int getId() {
-            return id;
-        }
-    }
-
-    public static class MyOtherMetadata {
-        private final String id;
-
-        public MyOtherMetadata(String id) {
-            this.id = id;
-        }
-
-        public String getId() {
-            return id;
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/ProcessorMetadataInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/ProcessorMetadataInjectionTest.java
@@ -3,31 +3,27 @@ package io.smallrye.reactive.messaging.metadata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.messaging.*;
 import org.junit.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 
 public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testSingleMandatoryMetadataInjectionWithProcessorReturningUni() {
-        addBeanClass(Source.class, Sink.class, ProcessorReturningUni.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class, ProcessorReturningUni.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -35,19 +31,22 @@ public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMissingMandatoryMetadataInjectionWithProcessorReturningUni() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningUni.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                ProcessorReturningUni.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testSingleMandatoryMetadataInjectionWithProcessorReturningCS() {
-        addBeanClass(Source.class, Sink.class, ProcessorReturningCS.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class, ProcessorReturningCS.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -55,19 +54,23 @@ public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMissingMandatoryMetadataInjectionWithProcessorReturningCS() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningCS.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                ProcessorReturningCS.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testSingleMandatoryMetadataInjectionWithProcessorReturningUniOfMessage() {
-        addBeanClass(Source.class, Sink.class, ProcessorReturningUniOfMessage.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class,
+                ProcessorReturningUniOfMessage.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -75,19 +78,22 @@ public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMissingMandatoryMetadataInjectionWithProcessorReturningUniOfMessage() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningUniOfMessage.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                ProcessorReturningUniOfMessage.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(1));
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testSingleMandatoryMetadataInjectionWithProcessorReturningCSOfMessage() {
-        addBeanClass(Source.class, Sink.class, ProcessorReturningCSOfMessage.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class, ProcessorReturningCSOfMessage.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -95,19 +101,22 @@ public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMissingMandatoryMetadataInjectionWithProcessorReturningCSOfMessage() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningCSOfMessage.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                ProcessorReturningCSOfMessage.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         await().untilAsserted(() -> assertThat(source.nacked()).hasSize(1));
         assertThat(source.acked()).hasSize(0);
     }
 
     @Test
     public void testSingleMandatoryMetadataInjectionWithProcessorReturningPublisher() {
-        addBeanClass(Source.class, Sink.class, ProcessorReturningPublisher.class);
+        addBeanClass(MetadataInjectionBase.Source.class, MetadataInjectionBase.Sink.class, ProcessorReturningPublisher.class);
         initialize();
-        Sink sink = get(Sink.class);
-        Source source = get(Source.class);
+        MetadataInjectionBase.Sink sink = get(MetadataInjectionBase.Sink.class);
+        MetadataInjectionBase.Source source = get(MetadataInjectionBase.Source.class);
+        source.run();
         await().until(() -> sink.list().size() == 5);
         assertThat(source.acked()).hasSize(5);
         assertThat(source.nacked()).hasSize(0);
@@ -115,22 +124,22 @@ public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testMissingMandatoryMetadataInjectionWithProcessorReturningPublisher() {
-        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningPublisher.class);
+        addBeanClass(MetadataInjectionBase.SourceWithoutMyMetadata.class, MetadataInjectionBase.Sink.class,
+                ProcessorReturningPublisher.class);
         initialize();
-        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        MetadataInjectionBase.SourceWithoutMyMetadata source = get(MetadataInjectionBase.SourceWithoutMyMetadata.class);
+        source.run();
         // Use pre-processing by default, so we will get 1 ack
         await().untilAsserted(() -> assertThat(source.acked()).hasSize(1));
         assertThat(source.acked()).hasSize(1);
     }
-
-    ////////////
 
     @ApplicationScoped
     public static class ProcessorReturningUni {
 
         @Incoming("in")
         @Outgoing("out")
-        public Uni<String> process(String payload, MyMetadata metadata) {
+        public Uni<String> process(String payload, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
             return Uni.createFrom().item(payload.toUpperCase());
         }
@@ -141,7 +150,7 @@ public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public CompletionStage<String> process(String payload, MyMetadata metadata) {
+        public CompletionStage<String> process(String payload, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
             return CompletableFuture.completedFuture(payload.toUpperCase());
         }
@@ -152,7 +161,7 @@ public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public Uni<Message<String>> process(Message<String> msg, MyMetadata metadata) {
+        public Uni<Message<String>> process(Message<String> msg, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
             return Uni.createFrom().item(msg.withPayload(msg.getPayload().toUpperCase()));
         }
@@ -163,7 +172,7 @@ public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public CompletionStage<Message<String>> process(Message<String> msg, MyMetadata metadata) {
+        public CompletionStage<Message<String>> process(Message<String> msg, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
             return CompletableFuture.completedFuture(msg.withPayload(msg.getPayload().toUpperCase()));
         }
@@ -174,120 +183,9 @@ public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
 
         @Incoming("in")
         @Outgoing("out")
-        public Multi<String> process(String payload, MyMetadata metadata) {
+        public Multi<String> process(String payload, MetadataInjectionBase.MyMetadata metadata) {
             assertThat(metadata.getId()).isNotZero();
             return Multi.createFrom().item(payload.toUpperCase());
-        }
-    }
-
-    @ApplicationScoped
-    public static class Sink {
-        List<String> list = new CopyOnWriteArrayList<>();
-
-        @Incoming("out")
-        public void consume(String s) {
-            list.add(s);
-        }
-
-        public List<String> list() {
-            return list;
-        }
-    }
-
-    @ApplicationScoped
-    public static class Source {
-        int i = 0;
-        List<Integer> acked = new CopyOnWriteArrayList<>();
-        List<Integer> nacked = new CopyOnWriteArrayList<>();
-
-        @Outgoing("in")
-        public Multi<Message<String>> producer() {
-            return Multi.createFrom().range(0, 5)
-                    .emitOn(Infrastructure.getDefaultExecutor())
-                    .onItem().transform(i -> {
-                        i = i + 1;
-                        int v = i;
-                        return Message.of("hello")
-                                .addMetadata(new MyMetadata(i))
-                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
-                                .withAck(() -> {
-                                    acked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                })
-                                .withNack(t -> {
-                                    nacked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                });
-
-                    });
-        }
-
-        public List<Integer> acked() {
-            return acked;
-        }
-
-        public List<Integer> nacked() {
-            return nacked;
-        }
-    }
-
-    @ApplicationScoped
-    public static class SourceWithoutMyMetadata {
-        int i = 0;
-        List<Integer> acked = new CopyOnWriteArrayList<>();
-        List<Integer> nacked = new CopyOnWriteArrayList<>();
-
-        @Outgoing("in")
-        public Multi<Message<String>> producer() {
-            return Multi.createFrom().range(0, 5)
-                    .emitOn(Infrastructure.getDefaultExecutor())
-                    .onItem().transform(i -> {
-                        i = i + 1;
-                        int v = i;
-                        return Message.of("hello")
-                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
-                                .withAck(() -> {
-                                    acked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                })
-                                .withNack(t -> {
-                                    nacked.add(v);
-                                    return CompletableFuture.completedFuture(null);
-                                });
-
-                    });
-        }
-
-        public List<Integer> acked() {
-            return acked;
-        }
-
-        public List<Integer> nacked() {
-            return nacked;
-        }
-    }
-
-    public static class MyMetadata {
-        private final int id;
-
-        public MyMetadata(int id) {
-            this.id = id;
-        }
-
-        public int getId() {
-            return id;
-        }
-    }
-
-    public static class MyOtherMetadata {
-        private final String id;
-
-        public MyOtherMetadata(String id) {
-            this.id = id;
-        }
-
-        public String getId() {
-            return id;
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/ProcessorMetadataInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/ProcessorMetadataInjectionTest.java
@@ -1,0 +1,294 @@
+package io.smallrye.reactive.messaging.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class ProcessorMetadataInjectionTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWithProcessorReturningUni() {
+        addBeanClass(Source.class, Sink.class, ProcessorReturningUni.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWithProcessorReturningUni() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningUni.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWithProcessorReturningCS() {
+        addBeanClass(Source.class, Sink.class, ProcessorReturningCS.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWithProcessorReturningCS() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningCS.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(5));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWithProcessorReturningUniOfMessage() {
+        addBeanClass(Source.class, Sink.class, ProcessorReturningUniOfMessage.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWithProcessorReturningUniOfMessage() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningUniOfMessage.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(1));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWithProcessorReturningCSOfMessage() {
+        addBeanClass(Source.class, Sink.class, ProcessorReturningCSOfMessage.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWithProcessorReturningCSOfMessage() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningCSOfMessage.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().untilAsserted(() -> assertThat(source.nacked()).hasSize(1));
+        assertThat(source.acked()).hasSize(0);
+    }
+
+    @Test
+    public void testSingleMandatoryMetadataInjectionWithProcessorReturningPublisher() {
+        addBeanClass(Source.class, Sink.class, ProcessorReturningPublisher.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testMissingMandatoryMetadataInjectionWithProcessorReturningPublisher() {
+        addBeanClass(SourceWithoutMyMetadata.class, Sink.class, ProcessorReturningPublisher.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        // Use pre-processing by default, so we will get 1 ack
+        await().untilAsserted(() -> assertThat(source.acked()).hasSize(1));
+        assertThat(source.acked()).hasSize(1);
+    }
+
+    ////////////
+
+    @ApplicationScoped
+    public static class ProcessorReturningUni {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public Uni<String> process(String payload, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            return Uni.createFrom().item(payload.toUpperCase());
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProcessorReturningCS {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public CompletionStage<String> process(String payload, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            return CompletableFuture.completedFuture(payload.toUpperCase());
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProcessorReturningUniOfMessage {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public Uni<Message<String>> process(Message<String> msg, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            return Uni.createFrom().item(msg.withPayload(msg.getPayload().toUpperCase()));
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProcessorReturningCSOfMessage {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public CompletionStage<Message<String>> process(Message<String> msg, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            return CompletableFuture.completedFuture(msg.withPayload(msg.getPayload().toUpperCase()));
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProcessorReturningPublisher {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public Multi<String> process(String payload, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            return Multi.createFrom().item(payload.toUpperCase());
+        }
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("out")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyMetadata(i))
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SourceWithoutMyMetadata {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    public static class MyMetadata {
+        private final int id;
+
+        public MyMetadata(int id) {
+            this.id = id;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class MyOtherMetadata {
+        private final String id;
+
+        public MyOtherMetadata(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/SubscriberMetadataInjectTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/SubscriberMetadataInjectTest.java
@@ -1,0 +1,237 @@
+package io.smallrye.reactive.messaging.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class SubscriberMetadataInjectTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testSubscriberConsumingPayload() {
+        addBeanClass(Source.class, SubscriberConsumingPayload.class);
+        initialize();
+        SubscriberConsumingPayload sink = get(SubscriberConsumingPayload.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testSubscriberConsumingMessage() {
+        addBeanClass(Source.class, SubscriberConsumingMessage.class);
+        initialize();
+        SubscriberConsumingMessage sink = get(SubscriberConsumingMessage.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testSubscriberConsumingPayloadReturningUni() {
+        addBeanClass(Source.class, SubscriberConsumingPayloadReturningUni.class);
+        initialize();
+        SubscriberConsumingPayloadReturningUni sink = get(SubscriberConsumingPayloadReturningUni.class);
+        Source source = get(Source.class);
+        await().until(() -> sink.list().size() == 5);
+        assertThat(source.acked()).hasSize(5);
+        assertThat(source.nacked()).hasSize(0);
+    }
+
+    @Test
+    public void testSubscriberConsumingPayloadWithMissingMandatoryMetadata() {
+        addBeanClass(SourceWithoutMyMetadata.class, SubscriberConsumingPayload.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().until(() -> source.nacked().size() == 5);
+        assertThat(source.acked()).hasSize(0);
+        assertThat(source.nacked()).hasSize(5);
+    }
+
+    @Test
+    public void testSubscriberConsumingMessageWithMissingMandatoryMetadata() {
+        addBeanClass(SourceWithoutMyMetadata.class, SubscriberConsumingMessage.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().until(() -> source.nacked().size() == 1);
+        assertThat(source.acked()).hasSize(0);
+        assertThat(source.nacked()).hasSize(1);
+    }
+
+    @Test
+    public void testSubscriberConsumingPayloadReturningUniWithMissingMandatoryMetadata() {
+        addBeanClass(SourceWithoutMyMetadata.class, SubscriberConsumingPayloadReturningUni.class);
+        initialize();
+        SourceWithoutMyMetadata source = get(SourceWithoutMyMetadata.class);
+        await().until(() -> source.nacked().size() == 5);
+        assertThat(source.acked()).hasSize(0);
+        assertThat(source.nacked()).hasSize(5);
+    }
+
+    @ApplicationScoped
+    public static class SubscriberConsumingPayload {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("in")
+        public void consume(String payload, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            list.add(payload);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SubscriberConsumingPayloadReturningUni {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("in")
+        public Uni<Void> consume(String payload, MyMetadata metadata, Optional<MyOtherMetadata> other) {
+            assertThat(metadata.getId()).isNotZero();
+            assertThat(other).isNotEmpty();
+            list.add(payload);
+            return Uni.createFrom().nullItem();
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SubscriberConsumingMessage {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("in")
+        public CompletionStage<Void> consume(Message<String> msg, MyMetadata metadata) {
+            assertThat(metadata.getId()).isNotZero();
+            list.add(msg.getPayload());
+            return msg.ack();
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyMetadata(i))
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SourceWithoutMyMetadata {
+        int i = 0;
+        List<Integer> acked = new CopyOnWriteArrayList<>();
+        List<Integer> nacked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> producer() {
+            return Multi.createFrom().range(0, 5)
+                    .emitOn(Infrastructure.getDefaultExecutor())
+                    .onItem().transform(i -> {
+                        i = i + 1;
+                        int v = i;
+                        return Message.of("hello")
+                                .addMetadata(new MyOtherMetadata(Integer.toString(i)))
+                                .withAck(() -> {
+                                    acked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                                .withNack(t -> {
+                                    nacked.add(v);
+                                    return CompletableFuture.completedFuture(null);
+                                });
+
+                    });
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+
+        public List<Integer> nacked() {
+            return nacked;
+        }
+    }
+
+    public static class MyMetadata {
+        private final int id;
+
+        public MyMetadata(int id) {
+            this.id = id;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class MyOtherMetadata {
+        private final String id;
+
+        public MyOtherMetadata(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+}


### PR DESCRIPTION
This PR implement metadata injection, so methods can receive metadata object attached to incoming messages directly as a method parameter. 
It supports mandatory metadata and optional metadata:

```java
public String process(String payload, MyMetadata mandatory, Optional<MyOtherMetadata> optional) {...}
```

It only supports methods consuming a single payload and message.

TODO:

* [ ] - Documentation
* [ ] - Example with Kafka to extract the key

Related to #588 