### PR TITLE
Introduce Message Converters

### DIFF
--- a/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.List;
 
 import javax.enterprise.inject.spi.Bean;
@@ -53,6 +54,13 @@ public interface MediatorConfiguration {
      * programmatically, or have a constructor that takes a single Object parameter - the bean to operate on
      */
     Class<? extends Invoker> getInvokerClass();
+
+    /**
+     * @return the discovered ingested payload type. May be {@code null} if there is no consumption or the type cannot be
+     *         extracted.
+     *         Conversion is based on this type.
+     */
+    Type getIngestedPayloadType();
 
     enum Production {
         STREAM_OF_MESSAGE,

--- a/api/src/main/java/io/smallrye/reactive/messaging/MessageConverter.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MessageConverter.java
@@ -1,5 +1,6 @@
 package io.smallrye.reactive.messaging;
 
+import io.smallrye.common.annotation.Experimental;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 import javax.enterprise.inject.spi.Prioritized;
@@ -12,6 +13,7 @@ import java.lang.reflect.Type;
  * When multiple converters are available, implementation should override the {@link #getPriority()} method.
  * The default priority is {@link #CONVERTER_DEFAULT_PRIORITY}. Converters with higher priority are executed first.
  */
+@Experimental("SmallRye only feature")
 public interface MessageConverter extends Prioritized {
 
     /**

--- a/api/src/main/java/io/smallrye/reactive/messaging/MessageConverter.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MessageConverter.java
@@ -1,0 +1,33 @@
+package io.smallrye.reactive.messaging;
+
+import java.lang.reflect.Type;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * Converter transforming {@code Message<A>} into {@code Message<B>}.
+ * To register a converter, expose a, generally {@code ApplicationScoped} bean, implementing this interface.
+ */
+public interface MessageConverter {
+
+    /**
+     * Checks whether this instance of converter can convert the given message {@code in} into a {@code Message<T>} with
+     * {@code T} being the type represented by {@code target}.
+     *
+     * @param in the input message, not {@code null}
+     * @param target the target type, generally the type ingested by a method
+     * @return {@code true} if the conversion is possible, {@code false} otherwise.
+     */
+    boolean accept(Message<?> in, Type target);
+
+    /**
+     * Converts the given message {@code in} into a {@code Message<T>}.
+     * This method is only called after a successful call to {@link #accept(Message, Type)} with the given target type.
+     *
+     * @param in the input message
+     * @param target the target type
+     * @return the converted message.
+     */
+    Message<?> convert(Message<?> in, Type target);
+
+}

--- a/api/src/main/java/io/smallrye/reactive/messaging/MessageConverter.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MessageConverter.java
@@ -1,34 +1,51 @@
 package io.smallrye.reactive.messaging;
 
-import java.lang.reflect.Type;
-
 import org.eclipse.microprofile.reactive.messaging.Message;
+
+import javax.enterprise.inject.spi.Prioritized;
+import java.lang.reflect.Type;
 
 /**
  * Converter transforming {@code Message<A>} into {@code Message<B>}.
  * To register a converter, expose a, generally {@code ApplicationScoped} bean, implementing this interface.
+ * <p>
+ * When multiple converters are available, implementation should override the {@link #getPriority()} method.
+ * The default priority is {@link #CONVERTER_DEFAULT_PRIORITY}. Converters with higher priority are executed first.
  */
-public interface MessageConverter {
+public interface MessageConverter extends Prioritized {
+
+    /**
+     * Default priority: {@code 100}
+     */
+    int CONVERTER_DEFAULT_PRIORITY = 100;
 
     /**
      * Checks whether this instance of converter can convert the given message {@code in} into a {@code Message<T>} with
      * {@code T} being the type represented by {@code target}.
      *
-     * @param in the input message, not {@code null}
+     * When reactive messaging looks for a converter, it picks the first converter returning {@code true} for a given
+     * message.
+     *
+     * @param in     the input message, not {@code null}
      * @param target the target type, generally the type ingested by a method
      * @return {@code true} if the conversion is possible, {@code false} otherwise.
      */
-    boolean accept(Message<?> in, Type target);
+    boolean canConvert(Message<?> in, Type target);
 
     /**
      * Converts the given message {@code in} into a {@code Message<T>}.
-     * This method is only called after a successful call to {@link #accept(Message, Type)} with the given target type.
+     * This method is only called after a successful call to {@link #canConvert(Message, Type)} with the given target type.
      *
-     * @param in the input message
+     * @param in     the input message
      * @param target the target type
      * @return the converted message.
      */
     Message<?> convert(Message<?> in, Type target);
+
+    @Override
+    default int getPriority() {
+        return CONVERTER_DEFAULT_PRIORITY;
+    }
 
     class IdentityConverter implements MessageConverter {
 
@@ -39,7 +56,7 @@ public interface MessageConverter {
         }
 
         @Override
-        public boolean accept(Message<?> in, Type target) {
+        public boolean canConvert(Message<?> in, Type target) {
             return true;
         }
 

--- a/api/src/main/java/io/smallrye/reactive/messaging/MessageConverter.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MessageConverter.java
@@ -30,4 +30,23 @@ public interface MessageConverter {
      */
     Message<?> convert(Message<?> in, Type target);
 
+    class IdentityConverter implements MessageConverter {
+
+        public static final IdentityConverter INSTANCE = new IdentityConverter();
+
+        private IdentityConverter() {
+            // Avoid direct instantiation.
+        }
+
+        @Override
+        public boolean accept(Message<?> in, Type target) {
+            return true;
+        }
+
+        @Override
+        public Message<?> convert(Message<?> in, Type target) {
+            return in;
+        }
+    }
+
 }

--- a/documentation/src/main/doc/modules/ROOT/examples/converters/ConverterExample.java
+++ b/documentation/src/main/doc/modules/ROOT/examples/converters/ConverterExample.java
@@ -1,0 +1,23 @@
+package converters;
+
+import io.smallrye.mutiny.Multi;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+public class ConverterExample {
+
+    // tag::code[]
+    @Outgoing("persons")
+    public Multi<String> source() {
+        return Multi.createFrom().items("Neo", "Morpheus", "Trinity");
+    }
+
+    // The messages need to be converted as they are emitted as Message<String>
+    // and consumed as Message<Person>
+    @Incoming("persons")
+    public void consume(Person p) {
+        // ...
+    }
+    // end::code[]
+
+}

--- a/documentation/src/main/doc/modules/ROOT/examples/converters/MyConverter.java
+++ b/documentation/src/main/doc/modules/ROOT/examples/converters/MyConverter.java
@@ -1,0 +1,26 @@
+package converters;
+
+import io.smallrye.reactive.messaging.MessageConverter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.lang.reflect.Type;
+
+// tag::code[]
+@ApplicationScoped
+public class MyConverter implements MessageConverter {
+    @Override
+    public boolean canConvert(Message<?> in, Type target) {
+        // Checks whether this converter can be used to convert the incoming message into a message
+        // containing a payload of the type `target`.
+        return in.getPayload().getClass().equals(String.class)  && target.equals(Person.class);
+    }
+
+    @Override
+    public Message<?> convert(Message<?> in, Type target) {
+        // Convert the incoming message into the new message.
+        // It's important to build the new message **from** the received one.
+        return in.withPayload(new Person((String) in.getPayload()));
+    }
+}
+// end::code[]

--- a/documentation/src/main/doc/modules/ROOT/examples/converters/Person.java
+++ b/documentation/src/main/doc/modules/ROOT/examples/converters/Person.java
@@ -1,0 +1,10 @@
+package converters;
+
+public class Person {
+
+    private final String name;
+
+    public Person(String name) {
+        this.name = name;
+    }
+}

--- a/documentation/src/main/doc/modules/ROOT/nav.adoc
+++ b/documentation/src/main/doc/modules/ROOT/nav.adoc
@@ -16,6 +16,7 @@
 ** xref:model/model.adoc#processing-payloads[Processing payloads]
 ** xref:model/model.adoc#processing-streams[Processing streams]
 ** xref:model/model.adoc#skipping[Skipping messages or payloads]
+** xref:model/model.adoc#converters[Converting messages]
 
 ** xref:acknowledgement/acknowledgement.adoc[Acknowledgement]
 ** xref:advanced/broadcast.adoc[Broadcasting]

--- a/documentation/src/main/doc/modules/ROOT/pages/model/converters.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/model/converters.adoc
@@ -1,0 +1,34 @@
+[#converters]
+== Message Converters
+
+SmallRye Reactive Messaging supports _message converters_, allowing to transform an incoming message into a version accepted by the method.
+If the incoming messages or payload does not match the invoked method's expectation, SmallRye Reactive Messaging looks for a suitable converter.
+If found, it converts the incoming message with this converter.
+
+Converters can have multiple purposes, but the main use case is about transforming the message's payload:
+
+[source,java,indent=0]
+----
+include::example$converters/MyConverter.java[tag=code]
+----
+
+To provide a converter, implement a bean exposing the `MessageConverter` interface.
+The `canConvert` method is called during the lookup and verifies if it can handle the conversion.
+The `target` type is the expected payload type.
+If the converter returns `true` to `canConvert`, SmallRye Reactive Messaging calls the `convert` method to proceed to the conversion.
+
+The previous converter can be used in application like the following, to convert `Message<String>` to `Message<Person>`:
+
+[source,java,indent=0]
+----
+include::example$converters/ConverterExample.java[tag=code]
+----
+
+Converters work for all supported method signatures.
+However, the signature must be well-formed to allow the extraction of the expected payload type.
+Wildcards and raw types do not support conversion.
+If the expected payload type cannot be extracted, or no converter fits, the message is passed as received.
+
+If multiple suitable converters are present, implementations should override the `getPriority` method returning the priority.
+The default priority is `100`.
+The converter lookup invokes converters with higher priority first.

--- a/documentation/src/main/doc/modules/ROOT/pages/model/model.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/model/model.adoc
@@ -1,8 +1,7 @@
 = Development Model and Annotations
 
-Reactive Messaging relies on CDI.
-Your application is composed by _beans_.
-
+Reactive Messaging proposes a CDI-based programming model to implement event-driven applications.
+Following the CDI principles, _beans_ are forming the main building block of your application.
 Reactive Messaging provides a set of annotations and types to implement beans that generate, consume or process messages.
 
 include::overview.adoc[]
@@ -13,3 +12,4 @@ include::consuming.adoc[]
 include::processing.adoc[]
 include::processing-streams.adoc[]
 include::skipping.adoc[]
+include::converters.adoc[]

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/MediatorConfigurationSupport.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/MediatorConfigurationSupport.java
@@ -1,7 +1,10 @@
 package io.smallrye.reactive.messaging;
 
 import static io.smallrye.reactive.messaging.i18n.ProviderExceptions.ex;
+import static io.smallrye.reactive.messaging.i18n.ProviderLogging.log;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
@@ -114,11 +117,27 @@ public class MediatorConfigurationSupport {
                 throw ex.definitionSubscriberTypeParam("@Incoming", methodAsString);
             }
             // Need to distinguish 1 or 2
-            MediatorConfiguration.Consumption consumption = assignableToMessageCheck == GenericTypeAssignable.Result.Assignable
-                    ? MediatorConfiguration.Consumption.STREAM_OF_MESSAGE
-                    : MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD;
+            MediatorConfiguration.Consumption consumption;
+            Type payloadType;
+            if (assignableToMessageCheck == GenericTypeAssignable.Result.Assignable) {
+                consumption = MediatorConfiguration.Consumption.STREAM_OF_MESSAGE;
+                Type m = returnTypeAssignable.getType(0);
+                if (m instanceof ParameterizedType) {
+                    payloadType = ((ParameterizedType) m).getActualTypeArguments()[0];
+                } else {
+                    payloadType = null;
+                }
+            } else {
+                consumption = MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD;
+                payloadType = returnTypeAssignable.getType(0);
+            }
 
-            return new ValidationOutput(production, consumption);
+            boolean builder = ClassUtils.isAssignable(returnType, SubscriberBuilder.class);
+            if (payloadType == null) {
+                log.unableToExtractIngestedPayloadType(methodAsString,
+                        "Cannot extract the type from the method signature");
+            }
+            return new ValidationOutput(production, consumption, builder, payloadType);
         }
 
         if (ClassUtils.isAssignable(returnType, CompletionStage.class)) {
@@ -132,10 +151,18 @@ public class MediatorConfigurationSupport {
             //                throw getIncomingError("when returning a CompletionStage, the generic type must be Void`");
             //            }
 
-            return new ValidationOutput(production,
-                    // Distinction between 3 and 4
-                    ClassUtils.isAssignable(parameterTypes[0], Message.class) ? MediatorConfiguration.Consumption.MESSAGE
-                            : MediatorConfiguration.Consumption.PAYLOAD);
+            MediatorConfiguration.Consumption consumption;
+            Type payloadType;
+            // Distinction between 3 and 4
+            if (ClassUtils.isAssignable(parameterTypes[0], Message.class)) {
+                consumption = MediatorConfiguration.Consumption.MESSAGE;
+                payloadType = firstMethodParamTypeAssignable.getType(0);
+            } else {
+                consumption = MediatorConfiguration.Consumption.PAYLOAD;
+                payloadType = parameterTypes[0];
+            }
+
+            return new ValidationOutput(production, consumption, payloadType);
         }
 
         if (ClassUtils.isAssignable(returnType, Uni.class)) {
@@ -149,10 +176,23 @@ public class MediatorConfigurationSupport {
             //                throw getIncomingError("when returning a CompletionStage, the generic type must be Void`");
             //            }
 
-            return new ValidationOutput(production,
-                    // Distinction between 3 and 4
-                    ClassUtils.isAssignable(parameterTypes[0], Message.class) ? MediatorConfiguration.Consumption.MESSAGE
-                            : MediatorConfiguration.Consumption.PAYLOAD);
+            MediatorConfiguration.Consumption consumption;
+            Type payloadType;
+            // Distinction between 3 and 4
+            if (ClassUtils.isAssignable(parameterTypes[0], Message.class)) {
+                consumption = MediatorConfiguration.Consumption.MESSAGE;
+                payloadType = firstMethodParamTypeAssignable.getType(0);
+            } else {
+                consumption = MediatorConfiguration.Consumption.PAYLOAD;
+                payloadType = parameterTypes[0];
+            }
+
+            if (payloadType == null) {
+                log.unableToExtractIngestedPayloadType(methodAsString,
+                        "Cannot extract the type from the method signature");
+            }
+
+            return new ValidationOutput(production, consumption, payloadType);
         }
 
         // Case 5 and 6, void
@@ -176,7 +216,7 @@ public class MediatorConfigurationSupport {
             //                                + returnType);
             //            }
 
-            return new ValidationOutput(production, consumption);
+            return new ValidationOutput(production, consumption, param);
         }
 
         throw ex.definitionUnsupportedSignature("@Incoming", methodAsString);
@@ -214,7 +254,7 @@ public class MediatorConfigurationSupport {
                     assignableToMessageCheck == GenericTypeAssignable.Result.Assignable
                             ? MediatorConfiguration.Production.STREAM_OF_MESSAGE
                             : MediatorConfiguration.Production.STREAM_OF_PAYLOAD,
-                    consumption);
+                    consumption, null);
         }
 
         if (ClassUtils.isAssignable(returnType, PublisherBuilder.class)) {
@@ -228,12 +268,12 @@ public class MediatorConfigurationSupport {
                     assignableToMessageCheck == GenericTypeAssignable.Result.Assignable
                             ? MediatorConfiguration.Production.STREAM_OF_MESSAGE
                             : MediatorConfiguration.Production.STREAM_OF_PAYLOAD,
-                    consumption, true);
+                    consumption, true, null);
         }
 
         if (ClassUtils.isAssignable(returnType, Message.class)) {
             // Case 6
-            return new ValidationOutput(MediatorConfiguration.Production.INDIVIDUAL_MESSAGE, consumption);
+            return new ValidationOutput(MediatorConfiguration.Production.INDIVIDUAL_MESSAGE, consumption, null);
         }
 
         if (ClassUtils.isAssignable(returnType, CompletionStage.class)) {
@@ -247,7 +287,7 @@ public class MediatorConfigurationSupport {
                     assignableToMessageCheck == GenericTypeAssignable.Result.Assignable
                             ? MediatorConfiguration.Production.COMPLETION_STAGE_OF_MESSAGE
                             : MediatorConfiguration.Production.COMPLETION_STAGE_OF_PAYLOAD,
-                    consumption);
+                    consumption, null);
         }
 
         if (ClassUtils.isAssignable(returnType, Uni.class)) {
@@ -261,11 +301,11 @@ public class MediatorConfigurationSupport {
                     assignableToMessageCheck == GenericTypeAssignable.Result.Assignable
                             ? MediatorConfiguration.Production.UNI_OF_MESSAGE
                             : MediatorConfiguration.Production.UNI_OF_PAYLOAD,
-                    consumption);
+                    consumption, null);
         }
 
         // Case 5
-        return new ValidationOutput(MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD, consumption);
+        return new ValidationOutput(MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD, consumption, null);
     }
 
     private ValidationOutput validateProcessor(Acknowledgment.Strategy acknowledgment) {
@@ -287,7 +327,8 @@ public class MediatorConfigurationSupport {
 
         MediatorConfiguration.Production production;
         MediatorConfiguration.Consumption consumption;
-        Boolean useBuilderTypes = null;
+        boolean useBuilderTypes = false;
+        Type payloadType;
 
         if (ClassUtils.isAssignable(returnType, Processor.class)
                 || ClassUtils.isAssignable(returnType, ProcessorBuilder.class)) {
@@ -303,6 +344,18 @@ public class MediatorConfigurationSupport {
             consumption = firstGenericParamOfReturn == GenericTypeAssignable.Result.Assignable
                     ? MediatorConfiguration.Consumption.STREAM_OF_MESSAGE
                     : MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD;
+
+            if (consumption == MediatorConfiguration.Consumption.STREAM_OF_MESSAGE) {
+                Type type = returnTypeAssignable.getType(0);
+                if (type instanceof ParameterizedType) {
+                    payloadType = ((ParameterizedType) type).getActualTypeArguments()[0];
+                } else {
+                    log.unableToExtractIngestedPayloadType(methodAsString, "The Message type is not parameterized");
+                    payloadType = null;
+                }
+            } else {
+                payloadType = returnTypeAssignable.getType(0);
+            }
 
             GenericTypeAssignable.Result secondGenericParamOfReturn = returnTypeAssignable.check(Message.class, 1);
             if (secondGenericParamOfReturn == GenericTypeAssignable.Result.NotGeneric) {
@@ -330,8 +383,11 @@ public class MediatorConfigurationSupport {
                     : MediatorConfiguration.Production.STREAM_OF_PAYLOAD;
 
             consumption = ClassUtils.isAssignable(parameterTypes[0], Message.class)
-                    ? MediatorConfiguration.Consumption.STREAM_OF_MESSAGE
-                    : MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD;
+                    ? MediatorConfiguration.Consumption.MESSAGE
+                    : MediatorConfiguration.Consumption.PAYLOAD;
+
+            payloadType = extractIngestedTypeFromFirstParameter(consumption, firstMethodParamTypeAssignable.getType(0),
+                    parameterTypes[0]);
 
             useBuilderTypes = ClassUtils.isAssignable(returnType, PublisherBuilder.class);
         } else {
@@ -351,6 +407,9 @@ public class MediatorConfigurationSupport {
                         : MediatorConfiguration.Production.COMPLETION_STAGE_OF_PAYLOAD;
                 consumption = ClassUtils.isAssignable(param, Message.class) ? MediatorConfiguration.Consumption.MESSAGE
                         : MediatorConfiguration.Consumption.PAYLOAD;
+
+                payloadType = extractIngestedTypeFromFirstParameter(consumption,
+                        firstMethodParamTypeAssignable.getType(0), param);
             } else if (ClassUtils.isAssignable(returnType, Uni.class)) {
                 // Case 11 or 12 - Uni variant
                 GenericTypeAssignable.Result assignableToMessageCheck = returnTypeAssignable.check(Message.class, 0);
@@ -363,6 +422,9 @@ public class MediatorConfigurationSupport {
                         : MediatorConfiguration.Production.UNI_OF_PAYLOAD;
                 consumption = ClassUtils.isAssignable(param, Message.class) ? MediatorConfiguration.Consumption.MESSAGE
                         : MediatorConfiguration.Consumption.PAYLOAD;
+
+                payloadType = extractIngestedTypeFromFirstParameter(consumption,
+                        firstMethodParamTypeAssignable.getType(0), param);
             } else {
                 // Case 9 or 10
                 production = ClassUtils.isAssignable(returnType, Message.class)
@@ -370,6 +432,9 @@ public class MediatorConfigurationSupport {
                         : MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD;
                 consumption = ClassUtils.isAssignable(param, Message.class) ? MediatorConfiguration.Consumption.MESSAGE
                         : MediatorConfiguration.Consumption.PAYLOAD;
+
+                payloadType = extractIngestedTypeFromFirstParameter(consumption,
+                        firstMethodParamTypeAssignable.getType(0), param);
             }
         }
 
@@ -378,7 +443,19 @@ public class MediatorConfigurationSupport {
             throw ex.illegalStateForValidateProcessor(methodAsString);
         }
 
-        return new ValidationOutput(production, consumption, useBuilderTypes);
+        return new ValidationOutput(production, consumption, useBuilderTypes, payloadType);
+    }
+
+    private Type extractIngestedTypeFromFirstParameter(MediatorConfiguration.Consumption consumption,
+            Type genericTypeOfFirstParam, Class<?> parameterType) {
+        Type payloadType;
+        if (consumption == MediatorConfiguration.Consumption.MESSAGE
+                || consumption == MediatorConfiguration.Consumption.STREAM_OF_MESSAGE) {
+            payloadType = genericTypeOfFirstParam;
+        } else {
+            payloadType = parameterType;
+        }
+        return payloadType;
     }
 
     private ValidationOutput validateStreamTransformer(Acknowledgment.Strategy acknowledgment) {
@@ -395,6 +472,7 @@ public class MediatorConfigurationSupport {
         MediatorConfiguration.Production production;
         MediatorConfiguration.Consumption consumption;
         boolean useBuilderTypes;
+        Type payloadType;
 
         // The mediator produces and consumes a stream
         GenericTypeAssignable.Result returnTypeGenericCheck = returnTypeAssignable.check(Message.class, 0);
@@ -432,6 +510,12 @@ public class MediatorConfigurationSupport {
             throw ex.definitionManualAckNotSupported("@Incoming & @Outgoing", methodAsString);
         }
 
+        if (consumption == MediatorConfiguration.Consumption.STREAM_OF_MESSAGE) {
+            payloadType = firstMethodParamTypeAssignable.getType(0, 0);
+        } else {
+            payloadType = firstMethodParamTypeAssignable.getType(0);
+        }
+
         if (useBuilderTypes) {
             //TODO Test validation.
 
@@ -444,19 +528,29 @@ public class MediatorConfigurationSupport {
 
         // TODO Ensure that the parameter is also a publisher builder.
 
-        return new ValidationOutput(production, consumption, useBuilderTypes);
+        if (payloadType == null) {
+            log.unableToExtractIngestedPayloadType(methodAsString, "Cannot extract the type from the method signature");
+        }
+
+        return new ValidationOutput(production, consumption, useBuilderTypes, payloadType);
     }
 
     public Acknowledgment.Strategy processDefaultAcknowledgement(Shape shape,
-            MediatorConfiguration.Consumption consumption) {
+            MediatorConfiguration.Consumption consumption, MediatorConfiguration.Production production) {
         if (shape == Shape.STREAM_TRANSFORMER) {
-            if (consumption == MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD) {
+            if (production == MediatorConfiguration.Production.STREAM_OF_PAYLOAD) {
+                return Acknowledgment.Strategy.PRE_PROCESSING;
+            } else if (consumption == MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD) {
                 return Acknowledgment.Strategy.PRE_PROCESSING;
             } else {
                 return Acknowledgment.Strategy.MANUAL;
             }
         } else if (shape == Shape.PROCESSOR) {
             if (consumption == MediatorConfiguration.Consumption.PAYLOAD) {
+                if (production == MediatorConfiguration.Production.STREAM_OF_PAYLOAD
+                        || production == MediatorConfiguration.Production.STREAM_OF_MESSAGE) {
+                    return Acknowledgment.Strategy.PRE_PROCESSING;
+                }
                 return Acknowledgment.Strategy.POST_PROCESSING;
             } else if (consumption == MediatorConfiguration.Consumption.MESSAGE
                     || consumption == MediatorConfiguration.Consumption.STREAM_OF_MESSAGE) {
@@ -521,19 +615,21 @@ public class MediatorConfigurationSupport {
     public static class ValidationOutput {
         private final MediatorConfiguration.Production production;
         private final MediatorConfiguration.Consumption consumption;
-        private final Boolean useBuilderTypes;
+        private final boolean useBuilderTypes;
+        private final Type ingestedPayloadType;
 
         public ValidationOutput(MediatorConfiguration.Production production,
-                MediatorConfiguration.Consumption consumption) {
-            this(production, consumption, null);
+                MediatorConfiguration.Consumption consumption, Type ingestedPayloadType) {
+            this(production, consumption, false, ingestedPayloadType);
         }
 
         public ValidationOutput(MediatorConfiguration.Production production,
                 MediatorConfiguration.Consumption consumption,
-                Boolean useBuilderTypes) {
+                boolean useBuilderTypes, Type ingestedPayloadType) {
             this.production = production;
             this.consumption = consumption;
             this.useBuilderTypes = useBuilderTypes;
+            this.ingestedPayloadType = ingestedPayloadType;
         }
 
         public MediatorConfiguration.Production getProduction() {
@@ -544,14 +640,35 @@ public class MediatorConfigurationSupport {
             return consumption;
         }
 
-        public Boolean getUseBuilderTypes() {
+        public boolean getUseBuilderTypes() {
             return useBuilderTypes;
+        }
+
+        public Type getIngestedPayloadType() {
+            return ingestedPayloadType;
         }
     }
 
     public interface GenericTypeAssignable {
 
         Result check(Class<?> target, int index);
+
+        /**
+         * Gets the underlying type. For example, on a {@code Message<X>}, it returns {@code X}.
+         * 
+         * @param index the index of the type
+         * @return the type, {@code null} if not set or wildcard
+         */
+        Type getType(int index);
+
+        /**
+         * Gets the underlying sub-type. For example, on a {@code Publisher<Message<X>>}, it returns {@code X}.
+         * 
+         * @param index the index of the type
+         * @param subIndex the second index
+         * @return the type, {@code null} if not set or wildcard
+         */
+        Type getType(int index, int subIndex);
 
         enum Result {
             NotGeneric,

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/ProcessorMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/ProcessorMediator.java
@@ -35,7 +35,7 @@ public class ProcessorMediator extends AbstractMediator {
     @Override
     public void connectToUpstream(PublisherBuilder<? extends Message<?>> publisher) {
         assert processor != null;
-        this.publisher = decorate(publisher.via(processor));
+        this.publisher = decorate(convert(publisher).via(processor));
     }
 
     @Override

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/PublisherMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/PublisherMediator.java
@@ -103,6 +103,7 @@ public class PublisherMediator extends AbstractMediator {
     }
 
     private void setPublisher(PublisherBuilder<Message<?>> publisher) {
+        // no conversion for publisher.
         this.publisher = decorate(publisher);
     }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/StreamTransformerMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/StreamTransformerMediator.java
@@ -28,7 +28,7 @@ public class StreamTransformerMediator extends AbstractMediator {
     @Override
     public void connectToUpstream(PublisherBuilder<? extends Message<?>> publisher) {
         Objects.requireNonNull(function);
-        this.publisher = decorate(function.apply(publisher));
+        this.publisher = decorate(function.apply(convert(publisher)));
     }
 
     @Override

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/SubscriberMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/SubscriberMediator.java
@@ -84,7 +84,7 @@ public class SubscriberMediator extends AbstractMediator {
 
     @Override
     public void connectToUpstream(PublisherBuilder<? extends Message<?>> publisher) {
-        this.source = publisher;
+        this.source = convert(publisher);
     }
 
     @SuppressWarnings({ "ReactiveStreamsSubscriberImplementation" })

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
@@ -36,15 +36,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.reactive.messaging.AbstractMediator;
-import io.smallrye.reactive.messaging.ChannelRegistar;
-import io.smallrye.reactive.messaging.ChannelRegistry;
-import io.smallrye.reactive.messaging.Invoker;
-import io.smallrye.reactive.messaging.MediatorConfiguration;
-import io.smallrye.reactive.messaging.MediatorFactory;
-import io.smallrye.reactive.messaging.PublisherDecorator;
-import io.smallrye.reactive.messaging.Shape;
-import io.smallrye.reactive.messaging.WeavingException;
+import io.smallrye.reactive.messaging.*;
 import io.smallrye.reactive.messaging.annotations.Incomings;
 import io.smallrye.reactive.messaging.annotations.Merge;
 import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
@@ -94,6 +86,9 @@ public class MediatorManager {
 
     @Inject
     Instance<PublisherDecorator> decorators;
+
+    @Inject
+    Instance<MessageConverter> converters;
 
     @Inject
     HealthCenter health;
@@ -163,12 +158,12 @@ public class MediatorManager {
         log.initializingMediators();
         collected.mediators()
                 .forEach(configuration -> {
-
                     AbstractMediator mediator = createMediator(configuration);
 
                     log.initializingMethod(mediator.getMethodAsString());
 
                     mediator.setDecorators(decorators);
+                    mediator.setConverters(converters);
                     mediator.setHealth(health);
                     mediator.setWorkerPoolRegistry(workerPoolRegistry);
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
@@ -118,7 +118,7 @@ public interface ProviderLogging extends BasicLogger {
 
     @LogMessage(level = Logger.Level.INFO)
     @Message(id = 224, value = "Analyzing mediator bean: %s")
-    void analyzingMediatorBean(Bean bean);
+    void analyzingMediatorBean(Bean<?> bean);
 
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 225, value = "No subscriber for channel %s  attached to the emitter %s.%s")
@@ -151,4 +151,9 @@ public interface ProviderLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 232, value = "Outgoing channel `%s` disabled by configuration")
     void outgoingChannelDisabled(String channel);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 233, value = "Unable to extract the ingested payload type for method `%s`, the reason is: %s")
+    void unableToExtractIngestedPayloadType(String method, String reason);
+
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MediatorConfigurationSupportTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MediatorConfigurationSupportTest.java
@@ -1,0 +1,616 @@
+package io.smallrye.reactive.messaging;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.ProcessorBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
+import org.junit.Test;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@SuppressWarnings("ConstantConditions")
+public class MediatorConfigurationSupportTest {
+
+    static Class<ClassContainingAllSortsOfMethods> clazz = ClassContainingAllSortsOfMethods.class;
+
+    private MediatorConfigurationSupport create(String method) {
+        for (Method m : clazz.getDeclaredMethods()) {
+            if (m.getName().equalsIgnoreCase(method)) {
+                return new MediatorConfigurationSupport(
+                        method,
+                        m.getReturnType(),
+                        m.getParameterTypes(),
+                        new DefaultMediatorConfiguration.ReturnTypeGenericTypeAssignable(m),
+                        m.getParameterTypes().length == 0
+                                ? new DefaultMediatorConfiguration.AlwaysInvalidIndexGenericTypeAssignable()
+                                : new DefaultMediatorConfiguration.MethodParamGenericTypeAssignable(m, 0));
+            }
+        }
+        fail("Unable to find method " + method);
+        return null;
+    }
+
+    @Test
+    public void testPublishers() {
+        MediatorConfigurationSupport support = create("publisherPublisherOfMessage");
+        MediatorConfigurationSupport.ValidationOutput output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherMultiOfMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherPublisherOfPayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherMultiOfPayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherPublisherBuilderOfMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("publisherPublisherBuilderOfPayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("publisherGeneratePayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.INDIVIDUAL_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateCompletionStagePayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.COMPLETION_STAGE_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateCompletionStageMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.COMPLETION_STAGE_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateUniPayload");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("publisherGenerateUniMessage");
+        output = support.validate(Shape.PUBLISHER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.NONE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isNull();
+        assertThat(output.getUseBuilderTypes()).isFalse();
+    }
+
+    @Test
+    public void testSubscribers() {
+        MediatorConfigurationSupport support = create("subscriberSubscriberOfMessage");
+        MediatorConfigurationSupport.ValidationOutput output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSubscriberOfPayload");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSubscriberBuilderOfMessage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("subscriberSubscriberBuilderOfPayload");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        assertThatThrownBy(() -> create("subscriberSinkOfMessage").validate(Shape.SUBSCRIBER, null))
+                .isInstanceOf(DefinitionException.class);
+
+        support = create("subscriberSinkOfPayload");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfMessageCompletionStage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfPayloadCompletionStage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfMessageUni");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfPayloadUni");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfRawMessageCompletionStage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("subscriberSinkOfWildcardMessageCompletionStage");
+        output = support.validate(Shape.SUBSCRIBER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.NONE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+    }
+
+    @Test
+    public void testProcessors() {
+        MediatorConfigurationSupport support = create("processorProcessorOfMessage");
+        MediatorConfigurationSupport.ValidationOutput output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessorOfPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessorBuilderOfMessage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("processorProcessorBuilderOfPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("processorPublisherOfMessage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorPublisherOfPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorPublisherBuilderOfMessage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("processorPublisherBuilderOfPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(String.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("processorProcessMessage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.INDIVIDUAL_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessPayload");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessMessageCompletionStage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.COMPLETION_STAGE_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessPayloadCompletionStage");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.COMPLETION_STAGE_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessMessageUni");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessPayloadUni");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessMessageUniRaw");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("processorProcessMessageUniWildcard");
+        output = support.validate(Shape.PROCESSOR, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.UNI_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+    }
+
+    @Test
+    public void testStreamTransformers() {
+        MediatorConfigurationSupport support = create("transformerPublisherOfMessage");
+        MediatorConfigurationSupport.ValidationOutput output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerPublisherOfPayload");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerMultiOfMessage");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerMultiOfPayload");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerPublisherBuilderOfMessage");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("transformerPublisherBuilderOfPayload");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(Person.class);
+        assertThat(output.getUseBuilderTypes()).isTrue();
+
+        support = create("transformerPublisherOfMessageRaw");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        support = create("transformerPublisherOfMessageWildcard");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_MESSAGE);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_MESSAGE);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+
+        assertThatThrownBy(() -> create("transformerPublisherOfPayloadRaw").validate(Shape.STREAM_TRANSFORMER, null))
+                .isInstanceOf(DefinitionException.class);
+
+        support = create("transformerPublisherOfPayloadWildcard");
+        output = support.validate(Shape.STREAM_TRANSFORMER, null);
+        assertThat(output.getConsumption()).isEqualTo(MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD);
+        assertThat(output.getProduction()).isEqualTo(MediatorConfiguration.Production.STREAM_OF_PAYLOAD);
+        assertThat(output.getIngestedPayloadType()).isEqualTo(null);
+        assertThat(output.getUseBuilderTypes()).isFalse();
+    }
+
+    static class ClassContainingAllSortsOfMethods {
+
+        // Publishers
+        Publisher<Message<Person>> publisherPublisherOfMessage() {
+            return null;
+        }
+
+        Multi<Message<Person>> publisherMultiOfMessage() {
+            return null;
+        }
+
+        Publisher<Person> publisherPublisherOfPayload() {
+            return null;
+        }
+
+        Multi<Person> publisherMultiOfPayload() {
+            return null;
+        }
+
+        PublisherBuilder<Message<Person>> publisherPublisherBuilderOfMessage() {
+            return null;
+        }
+
+        PublisherBuilder<Person> publisherPublisherBuilderOfPayload() {
+            return null;
+        }
+
+        Person publisherGeneratePayload() {
+            return null;
+        }
+
+        Message<Person> publisherGenerateMessage() {
+            return null;
+        }
+
+        CompletionStage<Person> publisherGenerateCompletionStagePayload() {
+            return null;
+        }
+
+        CompletionStage<Message<Person>> publisherGenerateCompletionStageMessage() {
+            return null;
+        }
+
+        Uni<Person> publisherGenerateUniPayload() {
+            return null;
+        }
+
+        Uni<Message<Person>> publisherGenerateUniMessage() {
+            return null;
+        }
+
+        // Subscribers
+        Subscriber<Message<Person>> subscriberSubscriberOfMessage() {
+            return null;
+        }
+
+        Subscriber<Person> subscriberSubscriberOfPayload() {
+            return null;
+        }
+
+        SubscriberBuilder<Message<Person>, Void> subscriberSubscriberBuilderOfMessage() {
+            return null;
+        }
+
+        SubscriberBuilder<Person, Void> subscriberSubscriberBuilderOfPayload() {
+            return null;
+        }
+
+        void subscriberSinkOfMessage(Message<Person> p) {
+            // Invalid
+        }
+
+        void subscriberSinkOfPayload(Person p) {
+
+        }
+
+        CompletionStage<Void> subscriberSinkOfMessageCompletionStage(Message<Person> p) {
+            return null;
+        }
+
+        CompletionStage<Void> subscriberSinkOfPayloadCompletionStage(Person p) {
+            return null;
+        }
+
+        Uni<Void> subscriberSinkOfMessageUni(Message<Person> p) {
+            return null;
+        }
+
+        Uni<Void> subscriberSinkOfPayloadUni(Person p) {
+            return null;
+        }
+
+        @SuppressWarnings("rawtypes")
+        CompletionStage<Void> subscriberSinkOfRawMessageCompletionStage(Message p) {
+            return null;
+        }
+
+        CompletionStage<Void> subscriberSinkOfWildcardMessageCompletionStage(Message<?> p) {
+            return null;
+        }
+
+        // Processors
+
+        Processor<Message<String>, Message<Person>> processorProcessorOfMessage() {
+            return null;
+        }
+
+        Processor<String, Person> processorProcessorOfPayload() {
+            return null;
+        }
+
+        ProcessorBuilder<Message<String>, Message<Person>> processorProcessorBuilderOfMessage() {
+            return null;
+        }
+
+        ProcessorBuilder<String, Person> processorProcessorBuilderOfPayload() {
+            return null;
+        }
+
+        Publisher<Message<Person>> processorPublisherOfMessage(Message<String> in) {
+            return null;
+        }
+
+        Publisher<Person> processorPublisherOfPayload(String in) {
+            return null;
+        }
+
+        PublisherBuilder<Message<Person>> processorPublisherBuilderOfMessage(Message<String> in) {
+            return null;
+        }
+
+        PublisherBuilder<Person> processorPublisherBuilderOfPayload(String in) {
+            return null;
+        }
+
+        Message<String> processorProcessMessage(Message<Person> in) {
+            return null;
+        }
+
+        String processorProcessPayload(Person in) {
+            return null;
+        }
+
+        CompletionStage<Message<String>> processorProcessMessageCompletionStage(Message<Person> in) {
+            return null;
+        }
+
+        CompletionStage<String> processorProcessPayloadCompletionStage(Person in) {
+            return null;
+        }
+
+        Uni<Message<String>> processorProcessMessageUni(Message<Person> in) {
+            return null;
+        }
+
+        Uni<String> processorProcessPayloadUni(Person in) {
+            return null;
+        }
+
+        Uni<Message<String>> processorProcessMessageUniRaw(Message in) {
+            return null;
+        }
+
+        Uni<Message<String>> processorProcessMessageUniWildcard(Message<?> in) {
+            return null;
+        }
+
+        // Transformers
+
+        Publisher<Message<String>> transformerPublisherOfMessage(Publisher<Message<Person>> in) {
+            return null;
+        }
+
+        Multi<Message<String>> transformerMultiOfMessage(Multi<Message<Person>> in) {
+            return null;
+        }
+
+        PublisherBuilder<Message<String>> transformerPublisherBuilderOfMessage(PublisherBuilder<Message<Person>> in) {
+            return null;
+        }
+
+        Publisher<String> transformerPublisherOfPayload(Publisher<Person> in) {
+            return null;
+        }
+
+        Multi<String> transformerMultiOfPayload(Multi<Person> in) {
+            return null;
+        }
+
+        PublisherBuilder<String> transformerPublisherBuilderOfPayload(PublisherBuilder<Person> in) {
+            return null;
+        }
+
+        @SuppressWarnings("rawtypes")
+        Publisher<Message<String>> transformerPublisherOfMessageRaw(Publisher<Message> in) {
+            return null;
+        }
+
+        Publisher<Message<String>> transformerPublisherOfMessageWildcard(Publisher<Message<?>> in) {
+            return null;
+        }
+
+        @SuppressWarnings("rawtypes")
+        Publisher<String> transformerPublisherOfPayloadRaw(Publisher in) {
+            // invalid
+            return null;
+        }
+
+        Publisher<String> transformerPublisherOfPayloadWildcard(Publisher<?> in) {
+            return null;
+        }
+
+    }
+
+    static class Person {
+
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/ErroneousConverterTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/ErroneousConverterTest.java
@@ -1,0 +1,149 @@
+package io.smallrye.reactive.messaging.converters;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.MessageConverter;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class ErroneousConverterTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testConverterThrowingExceptionOnAccept() {
+        addBeanClass(Source.class, Sink.class, PayloadProcessor.class, BadConverterThrowingExceptionOnAccept.class);
+        assertThatThrownBy(this::initialize)
+                .isInstanceOf(DeploymentException.class)
+                .hasStackTraceContaining("boom");
+    }
+
+    @Test
+    public void testConverterThrowingExceptionOnConvert() {
+        addBeanClass(Source.class, Sink.class, PayloadProcessor.class, BadConverterThrowingExceptionOnConvert.class);
+        assertThatThrownBy(this::initialize)
+                .isInstanceOf(DeploymentException.class)
+                .hasStackTraceContaining("boom");
+    }
+
+    @ApplicationScoped
+    static class BadConverterThrowingExceptionOnAccept implements MessageConverter {
+
+        @Override
+        public boolean accept(Message<?> in, Type target) {
+            throw new IllegalArgumentException("boom");
+        }
+
+        @Override
+        public Message<?> convert(Message<?> in, Type target) {
+            return in.withPayload(new Person((String) in.getPayload())).addMetadata(new Meta());
+        }
+    }
+
+    @ApplicationScoped
+    static class BadConverterThrowingExceptionOnConvert implements MessageConverter {
+
+        @Override
+        public boolean accept(Message<?> in, Type target) {
+            return target == Person.class && in.getPayload().getClass() == String.class;
+        }
+
+        @Override
+        public Message<?> convert(Message<?> in, Type target) {
+            if (in.getPayload().toString().startsWith("N") || in.getPayload().toString().startsWith("M")) {
+                throw new IllegalArgumentException("boom");
+            }
+            return in.withPayload(new Person((String) in.getPayload())).addMetadata(new Meta());
+        }
+    }
+
+    @ApplicationScoped
+    static class StringToPersonConverter implements MessageConverter {
+
+        @Override
+        public boolean accept(Message<?> in, Type target) {
+            return target == Person.class && in.getPayload().getClass() == String.class;
+        }
+
+        @Override
+        public Message<?> convert(Message<?> in, Type target) {
+            return in.withPayload(new Person((String) in.getPayload())).addMetadata(new Meta());
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+
+        private final AtomicInteger acks = new AtomicInteger();
+        private final AtomicInteger nacks = new AtomicInteger();
+
+        @Outgoing("in")
+        public Multi<Message<String>> source() {
+            return Multi.createFrom().items("Luke", "Leia", "Neo", "Morpheus", "Trinity")
+                    .map(s -> Message.of(s, () -> {
+                        acks.incrementAndGet();
+                        return CompletableFuture.completedFuture(null);
+                    }, t -> {
+                        nacks.incrementAndGet();
+                        return CompletableFuture.completedFuture(null);
+                    }));
+        }
+
+        public int acks() {
+            return acks.get();
+        }
+
+        public int nacks() {
+            return nacks.get();
+        }
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        List<Person> list = new ArrayList<>();
+
+        @Incoming("out")
+        public void sink(Person p) {
+            list.add(p);
+        }
+
+        public List<Person> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PayloadProcessor {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public Person process(Person p) {
+            return new Person(p.name.toUpperCase());
+        }
+
+    }
+
+    public static class Person {
+        public final String name;
+
+        Person(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class Meta {
+
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/ProcessorWithConverterTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/ProcessorWithConverterTest.java
@@ -1,0 +1,202 @@
+package io.smallrye.reactive.messaging.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.ProcessorBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.MessageConverter;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class ProcessorWithConverterTest extends WeldTestBaseWithoutTails {
+
+    // TODO Converter throwin exception during accept / during conversion
+
+    @Test
+    public void testConversionWhenReceivingPayload() {
+        addBeanClass(Source.class, Sink.class, StringToPersonConverter.class, PayloadProcessor.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        assertThat(sink.list()).hasSize(5);
+    }
+
+    @Test
+    public void testMissingConverter() {
+        addBeanClass(Source.class, Sink.class, PayloadProcessor.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        Source source = get(Source.class);
+        assertThat(sink.list()).hasSize(0);
+        assertThat(source.nacks()).isEqualTo(5);
+        assertThat(source.acks()).isEqualTo(0);
+    }
+
+    @Test
+    public void testConversionWhenReceivingMessage() {
+        addBeanClass(Source.class, Sink.class, StringToPersonConverter.class, MessageProcessor.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        assertThat(sink.list()).hasSize(5);
+    }
+
+    @Test
+    public void testConversionWithProcessorBuilder() {
+        addBeanClass(Source.class, Sink.class, StringToPersonConverter.class, MessageProcessorBuilder.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        assertThat(sink.list()).hasSize(5);
+    }
+
+    @Test
+    public void testConversionWithPayloadStream() {
+        addBeanClass(Source.class, Sink.class, StringToPersonConverter.class, StreamPayloadTransformer.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        assertThat(sink.list()).hasSize(5);
+    }
+
+    @Test
+    public void testConversionWithMessageStream() {
+        addBeanClass(Source.class, Sink.class, StringToPersonConverter.class, StreamMessageTransformer.class);
+        initialize();
+        Sink sink = get(Sink.class);
+        assertThat(sink.list()).hasSize(5);
+    }
+
+    @ApplicationScoped
+    static class StringToPersonConverter implements MessageConverter {
+
+        @Override
+        public boolean accept(Message<?> in, Type target) {
+            return target == Person.class && in.getPayload().getClass() == String.class;
+        }
+
+        @Override
+        public Message<?> convert(Message<?> in, Type target) {
+            return in.withPayload(new Person((String) in.getPayload())).addMetadata(new Meta());
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+
+        private final AtomicInteger acks = new AtomicInteger();
+        private final AtomicInteger nacks = new AtomicInteger();
+
+        @Outgoing("in")
+        public Multi<Message<String>> source() {
+            return Multi.createFrom().items("Luke", "Leia", "Neo", "Morpheus", "Trinity")
+                    .map(s -> Message.of(s, () -> {
+                        acks.incrementAndGet();
+                        return CompletableFuture.completedFuture(null);
+                    }, t -> {
+                        nacks.incrementAndGet();
+                        return CompletableFuture.completedFuture(null);
+                    }));
+        }
+
+        public int acks() {
+            return acks.get();
+        }
+
+        public int nacks() {
+            return nacks.get();
+        }
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        List<Person> list = new ArrayList<>();
+
+        @Incoming("out")
+        public void sink(Person p) {
+            list.add(p);
+        }
+
+        public List<Person> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PayloadProcessor {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public Person process(Person p) {
+            return new Person(p.name.toUpperCase());
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MessageProcessor {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public Message<Person> process(Message<Person> p) {
+            assertThat(p.getMetadata(Meta.class)).isNotEmpty();
+            return p.withPayload(new Person(p.getPayload().name.toUpperCase()));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MessageProcessorBuilder {
+
+        @Incoming("in")
+        @Outgoing("out")
+        public ProcessorBuilder<Message<Person>, Message<Person>> process() {
+            return ReactiveStreams.<Message<Person>> builder()
+                    .peek(p -> assertThat(p.getMetadata(Meta.class)).isNotEmpty())
+                    .map(p -> p.withPayload(new Person(p.getPayload().name.toUpperCase())));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class StreamPayloadTransformer {
+        @Incoming("in")
+        @Outgoing("out")
+        public Multi<Person> process(Multi<Person> multi) {
+            return multi
+                    .map(p -> new Person(p.name.toUpperCase()));
+        }
+    }
+
+    @ApplicationScoped
+    public static class StreamMessageTransformer {
+        @Incoming("in")
+        @Outgoing("out")
+        public Multi<Message<Person>> process(Multi<Message<Person>> multi) {
+            return multi
+                    .invoke(p -> assertThat(p.getMetadata(Meta.class)).isNotEmpty())
+                    .map(p -> p.withPayload(new Person(p.getPayload().name.toUpperCase())));
+        }
+    }
+
+    public static class Person {
+        public final String name;
+
+        Person(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class Meta {
+
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/ProcessorWithConverterTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/ProcessorWithConverterTest.java
@@ -80,7 +80,7 @@ public class ProcessorWithConverterTest extends WeldTestBaseWithoutTails {
     static class StringToPersonConverter implements MessageConverter {
 
         @Override
-        public boolean accept(Message<?> in, Type target) {
+        public boolean canConvert(Message<?> in, Type target) {
             return target == Person.class && in.getPayload().getClass() == String.class;
         }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/SubscriberWithConverterTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/SubscriberWithConverterTest.java
@@ -50,7 +50,7 @@ public class SubscriberWithConverterTest extends WeldTestBaseWithoutTails {
     static class StringToPersonConverter implements MessageConverter {
 
         @Override
-        public boolean accept(Message<?> in, Type target) {
+        public boolean canConvert(Message<?> in, Type target) {
             return target == Person.class && in.getPayload().getClass() == String.class;
         }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/SubscriberWithConverterTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/SubscriberWithConverterTest.java
@@ -1,0 +1,127 @@
+package io.smallrye.reactive.messaging.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.MessageConverter;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class SubscriberWithConverterTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testConversionWhenReceivingPayload() {
+        addBeanClass(Source.class, SinkOfPerson.class, StringToPersonConverter.class);
+        initialize();
+        SinkOfPerson sink = get(SinkOfPerson.class);
+        assertThat(sink.list()).hasSize(5);
+    }
+
+    @Test
+    public void testConversionWhenReceivingMessage() {
+        addBeanClass(Source.class, SinkOfMessageOfPerson.class, StringToPersonConverter.class);
+        initialize();
+        SinkOfMessageOfPerson sink = get(SinkOfMessageOfPerson.class);
+        assertThat(sink.list()).hasSize(5);
+    }
+
+    @Test
+    public void testConversionWithSubscriberBuilder() {
+        addBeanClass(Source.class, SubscriberOfPerson.class, StringToPersonConverter.class);
+        initialize();
+        SubscriberOfPerson sink = get(SubscriberOfPerson.class);
+        assertThat(sink.list()).hasSize(5);
+    }
+
+    @ApplicationScoped
+    static class StringToPersonConverter implements MessageConverter {
+
+        @Override
+        public boolean accept(Message<?> in, Type target) {
+            return target == Person.class && in.getPayload().getClass() == String.class;
+        }
+
+        @Override
+        public Message<?> convert(Message<?> in, Type target) {
+            return in.withPayload(new Person((String) in.getPayload())).addMetadata(new Meta());
+        }
+    }
+
+    @ApplicationScoped
+    public static class Source {
+        @Outgoing("in")
+        public Multi<String> source() {
+            return Multi.createFrom().items("Luke", "Leia", "Neo", "Morpheus", "Trinity");
+        }
+    }
+
+    @ApplicationScoped
+    public static class SinkOfPerson {
+        List<Person> list = new ArrayList<>();
+
+        @Incoming("in")
+        public void sink(Person p) {
+            list.add(p);
+        }
+
+        public List<Person> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SinkOfMessageOfPerson {
+        List<Person> list = new ArrayList<>();
+
+        @Incoming("in")
+        public CompletionStage<Void> sink(Message<Person> m) {
+            assertThat(m.getMetadata(Meta.class)).isNotEmpty();
+            list.add(m.getPayload());
+            return m.ack();
+        }
+
+        public List<Person> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SubscriberOfPerson {
+        List<Person> list = new ArrayList<>();
+
+        @Incoming("in")
+        public SubscriberBuilder<Person, Void> sink() {
+            return ReactiveStreams.<Person> builder()
+                    .forEach(p -> list.add(p));
+        }
+
+        public List<Person> list() {
+            return list;
+        }
+    }
+
+    public static class Person {
+        public final String name;
+
+        Person(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class Meta {
+
+    }
+}


### PR DESCRIPTION
This PR is a replacement for the metadata injection support (#726).
The main use case for metadata injection was to access technical metadata from method accepting payload only. 
While functional, the API was not great, and it removes a few "type" check making error detection most complicated.

MessageConverter takes the problem from the opposite direction.
It allows converting a message into another message, generally to change the type of payload. 
For example, a converter can transform a message coming from Kafka to a KafkaRecord, which means that the user can access the key directly. 

A converter is a simple bean implementing an interface.
Then, reactive messaging looks for the right converter if needed and invoke it for each transiting message. 
For the user, it's transparent, the converter being called to transform the incoming message into the expected type.
