### PR TITLE
Update to Mutiny 0.8.1

### DIFF
--- a/documentation/src/main/doc/antora.yml
+++ b/documentation/src/main/doc/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
         project-version: '2.4.0-SNAPSHOT'
         weld-version: '3.1.3.Final'
         smallrye-config-version: '1.8.6'
-        mutiny-version: '0.8.0'
+        mutiny-version: '0.8.1'
         camel-version: '3.5.0'
         spec-version: '1.0'
         javadoc-base: 'https://smallrye.io/smallrye-reactive-messaging/2.4.0-SNAPSHOT/apidocs'

--- a/examples/amqp-quickstart/pom.xml
+++ b/examples/amqp-quickstart/pom.xml
@@ -17,7 +17,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <weld-core.version>3.1.3.Final</weld-core.version>
-    <mutiny.version>0.8.0</mutiny.version>
 
     <mainClass>acme.Main</mainClass>
 

--- a/examples/awssns-quickstart/pom.xml
+++ b/examples/awssns-quickstart/pom.xml
@@ -18,7 +18,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <weld-core.version>3.1.3.Final</weld-core.version>
-    <mutiny.version>0.8.0</mutiny.version>
 
     <mainClass>awssns.Main</mainClass>
 

--- a/examples/cloud-events/pom.xml
+++ b/examples/cloud-events/pom.xml
@@ -17,7 +17,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <weld-core.version>3.1.3.Final</weld-core.version>
-    <mutiny.version>0.8.0</mutiny.version>
 
     <mainClass>io.smallrye.reactive.messaging.example.eventclouds.Main</mainClass>
 

--- a/examples/gcp-pubsub-quickstart/pom.xml
+++ b/examples/gcp-pubsub-quickstart/pom.xml
@@ -17,7 +17,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <weld-core.version>3.1.3.Final</weld-core.version>
-    <mutiny.version>0.8.0</mutiny.version>
 
     <mainClass>gcp.pubsub.Main</mainClass>
 

--- a/examples/kafka-quickstart-kotlin/pom.xml
+++ b/examples/kafka-quickstart-kotlin/pom.xml
@@ -18,7 +18,6 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <kotlin.version>1.4.10</kotlin.version>
     <weld-core.version>3.1.3.Final</weld-core.version>
-    <mutiny.version>0.8.0</mutiny.version>
 
     <mainClass>acme.Main</mainClass>
 

--- a/examples/kafka-quickstart/pom.xml
+++ b/examples/kafka-quickstart/pom.xml
@@ -17,7 +17,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <weld-core.version>3.1.4.Final</weld-core.version>
-    <mutiny.version>0.8.0</mutiny.version>
 
     <mainClass>acme.Main</mainClass>
 

--- a/examples/mqtt-quickstart/pom.xml
+++ b/examples/mqtt-quickstart/pom.xml
@@ -17,7 +17,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <weld-core.version>3.1.3.Final</weld-core.version>
-    <mutiny.version>0.8.0</mutiny.version>
 
     <mainClass>acme.Main</mainClass>
 

--- a/examples/mqtt-server-quickstart/pom.xml
+++ b/examples/mqtt-server-quickstart/pom.xml
@@ -19,7 +19,6 @@
 
     <smallrye-reactive-streams-operators.version>1.0.7</smallrye-reactive-streams-operators.version>
     <weld-core.version>3.1.2.Final</weld-core.version>
-    <mutiny.version>0.8.0</mutiny.version>
 
     <mainClass>acme.Main</mainClass>
 

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -20,7 +20,6 @@
     <weld-core.version>3.1.4.Final</weld-core.version>
 
     <mainClass>acme.Main</mainClass>
-    <mutiny.version>0.8.0</mutiny.version>
 
     <sonar.skip>true</sonar.skip>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <smallrye-health.version>2.2.3</smallrye-health.version>
     <smallrye-testing.version>0.1.0</smallrye-testing.version>
 
-    <mutiny.version>0.8.0</mutiny.version>
+    <mutiny.version>0.8.1</mutiny.version>
     <artemis.version>2.15.0</artemis.version>
 
     <jboss-log-manager.version>2.1.17.Final</jboss-log-manager.version>


### PR DESCRIPTION
Mutiny 0.8.0 has a bug in the `onOverflow().drop()` operator (a bug that I personally introduced). This release fixes it. 