### PR TITLE
Implement Record and ConsumerRecord converter in the Kafka connector

### DIFF
--- a/documentation/src/main/doc/modules/kafka/examples/inbound/Converters.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/Converters.java
@@ -1,0 +1,32 @@
+package inbound;
+
+import io.smallrye.reactive.messaging.kafka.Record;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.concurrent.CompletionStage;
+
+@ApplicationScoped
+public class Converters {
+
+
+    // tag::code[]
+    @Incoming("topic-a")
+    public void consume(Record<String, String> record) {
+        String key = record.key(); // Can be `null` if the incoming record has no value
+        String value = record.value(); // Can be `null` if the incoming record has no value
+    }
+
+    @Incoming("topic-b")
+    public void consume(ConsumerRecord<String, String> record) {
+        String key = record.key(); // Can be `null` if the incoming record has no value
+        String value = record.value(); // Can be `null` if the incoming record has no value
+        String topic = record.topic();
+        int partition = record.partition();
+        // ...
+    }
+    // end::code[]
+
+}

--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -48,6 +48,17 @@ You need to configure the:
 
 If you want to use a custom deserializer, add it to your `CLASSPATH` and configure the associate attribute.
 
+In addition, the Kafka Connector also provides a set of _message converters_.
+So you can receive _payloads_ representing records from Kafka using:
+
+* {javadoc-base}/io/smallrye/reactive/messaging/kafka/Record.html[Record<K,V>] - a pair key/value
+* https://kafka.apache.org/26/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html[KafkaConsumer<K,V>] - a structure representing the record with all its metadata
+
+[source, java]
+----
+include::example$inbound/Converters.java[tags=code]
+----
+
 === Inbound Metadata
 
 Messages coming from Kafka contains an instance of {javadoc-base}/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecordMetadata.html[IncomingKafkaRecordMetadata<K, T>] in the metadata.

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -67,6 +67,12 @@
       <version>1.14.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/converters/ConsumerRecordConverter.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/converters/ConsumerRecordConverter.java
@@ -1,0 +1,34 @@
+package io.smallrye.reactive.messaging.kafka.converters;
+
+import java.lang.reflect.Type;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.reactive.messaging.MessageConverter;
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordMetadata;
+
+/**
+ * Convert an incoming Kafka message into a {@link ConsumerRecord}.
+ */
+@ApplicationScoped
+public class ConsumerRecordConverter implements MessageConverter {
+
+    @Override
+    public boolean canConvert(Message<?> in, Type target) {
+        return in.getMetadata(IncomingKafkaRecordMetadata.class).isPresent()
+                && target.equals(ConsumerRecord.class);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Message<?> convert(Message<?> in, Type target) {
+        IncomingKafkaRecordMetadata metadata = in.getMetadata(IncomingKafkaRecordMetadata.class)
+                .orElseThrow(() -> new IllegalStateException("No Kafka metadata"));
+        return
+        // The consumer record is not directly accessible:
+        in.withPayload(metadata.getRecord().getDelegate().record());
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/converters/RecordConverter.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/converters/RecordConverter.java
@@ -1,0 +1,32 @@
+package io.smallrye.reactive.messaging.kafka.converters;
+
+import java.lang.reflect.Type;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.reactive.messaging.MessageConverter;
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.Record;
+
+/**
+ * Convert an incoming Kafka message into a {@link Record}.
+ */
+@ApplicationScoped
+public class RecordConverter implements MessageConverter {
+
+    @Override
+    public boolean canConvert(Message<?> in, Type target) {
+        return in.getMetadata(IncomingKafkaRecordMetadata.class).isPresent()
+                && target.equals(Record.class);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Message<?> convert(Message<?> in, Type target) {
+        IncomingKafkaRecordMetadata metadata = in.getMetadata(IncomingKafkaRecordMetadata.class)
+                .orElseThrow(() -> new IllegalStateException("No Kafka metadata"));
+        return in.withPayload(Record.of(metadata.getKey(), in.getPayload()));
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/converters/ConsumerRecordConverterTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/converters/ConsumerRecordConverterTest.java
@@ -1,0 +1,85 @@
+package io.smallrye.reactive.messaging.kafka.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
+
+class ConsumerRecordConverterTest extends KafkaTestBase {
+
+    @Test
+    public void testBeanUsingConverter() {
+        MapBasedConfig.Builder builder = MapBasedConfig.builder("mp.messaging.incoming.data");
+        builder.put("value.deserializer", StringDeserializer.class.getName());
+        builder.put("auto.offset.reset", "earliest");
+        builder.put("topic", topic);
+
+        addBeans(ConsumerRecordConverter.class, RecordConverter.class);
+        MyBean bean = runApplication(builder.build(), MyBean.class);
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceStrings(10, null,
+                () -> new ProducerRecord<>(topic, counter.get() % 2 == 0 ? "key" : "k", "v-" + counter.incrementAndGet()));
+
+        await().until(() -> bean.list().size() == 10);
+
+        assertThat(bean.list()).hasSize(10).allSatisfy(r -> {
+            assertThat(r.value()).startsWith("v-");
+            assertThat(r.key()).startsWith("k");
+            if (!r.key().equalsIgnoreCase("key")) {
+                assertThat(r.key()).isEqualTo("k");
+            }
+        });
+    }
+
+    @Test
+    public void testBeanUsingConverterWithNullKeyAndValue() {
+        MapBasedConfig.Builder builder = MapBasedConfig.builder("mp.messaging.incoming.data");
+        builder.put("value.deserializer", StringDeserializer.class.getName());
+        builder.put("auto.offset.reset", "earliest");
+        builder.put("topic", topic);
+
+        addBeans(ConsumerRecordConverter.class, RecordConverter.class);
+        RecordConverterTest.MyBean bean = runApplication(builder.build(), RecordConverterTest.MyBean.class);
+
+        usage.produceStrings(10, null,
+                () -> new ProducerRecord<>(topic, null, null));
+
+        await().until(() -> bean.list().size() == 10);
+
+        assertThat(bean.list()).hasSize(10).allSatisfy(r -> {
+            assertThat(r.value()).isNull();
+            assertThat(r.value()).isNull();
+        });
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+
+        private final List<ConsumerRecord<String, String>> records = new CopyOnWriteArrayList<>();
+
+        @Incoming("data")
+        public void consume(ConsumerRecord<String, String> record) {
+            this.records.add(record);
+        }
+
+        public List<ConsumerRecord<String, String>> list() {
+            return records;
+        }
+
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/converters/CustomConverterTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/converters/CustomConverterTest.java
@@ -1,0 +1,88 @@
+package io.smallrye.reactive.messaging.kafka.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.tuples.Tuple3;
+import io.smallrye.reactive.messaging.MessageConverter;
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
+
+class CustomConverterTest extends KafkaTestBase {
+
+    @Test
+    public void testBeanUsingCustomConverter() {
+        MapBasedConfig.Builder builder = MapBasedConfig.builder("mp.messaging.incoming.data");
+        builder.put("value.deserializer", StringDeserializer.class.getName());
+        builder.put("auto.offset.reset", "earliest");
+        builder.put("topic", topic);
+
+        addBeans(ConsumerRecordConverter.class, RecordConverter.class, MyConverter.class);
+        MyBean bean = runApplication(builder.build(), MyBean.class);
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceStrings(10, null,
+                () -> new ProducerRecord<>(topic, counter.get() % 2 == 0 ? "key" : "k", "v-" + counter.incrementAndGet()));
+
+        await().until(() -> bean.list().size() == 10);
+
+        assertThat(bean.list()).hasSize(10).allSatisfy(r -> {
+            assertThat(r.getItem1()).isEqualTo(topic);
+            assertThat(r.getItem3()).startsWith("v-");
+            assertThat(r.getItem2()).startsWith("k");
+            if (!r.getItem2().equalsIgnoreCase("key")) {
+                assertThat(r.getItem2()).isEqualTo("k");
+            }
+        });
+    }
+
+    @ApplicationScoped
+    public static class MyConverter implements MessageConverter {
+
+        @Override
+        public boolean canConvert(Message<?> in, Type target) {
+            return in.getMetadata(IncomingKafkaRecordMetadata.class).isPresent()
+                    && target.equals(Tuple3.class);
+        }
+
+        @SuppressWarnings("rawtypes")
+        @Override
+        public Message<?> convert(Message<?> in, Type target) {
+            IncomingKafkaRecordMetadata metadata = in.getMetadata(IncomingKafkaRecordMetadata.class)
+                    .orElseThrow(() -> new IllegalStateException("No Kafka metadata"));
+            return in.withPayload(Tuple3.of(metadata.getTopic(), metadata.getKey(), metadata.getRecord().value()));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+
+        private final List<Tuple3<String, String, String>> records = new CopyOnWriteArrayList<>();
+
+        @Incoming("data")
+        public void consume(Tuple3<String, String, String> record) {
+            this.records.add(record);
+        }
+
+        public List<Tuple3<String, String, String>> list() {
+            return records;
+        }
+
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/converters/RecordConverterTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/converters/RecordConverterTest.java
@@ -1,0 +1,118 @@
+package io.smallrye.reactive.messaging.kafka.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.KafkaRecord;
+import io.smallrye.reactive.messaging.kafka.Record;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
+
+class RecordConverterTest extends KafkaTestBase {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testConverter() {
+        RecordConverter converter = new RecordConverter();
+        assertThat(converter.canConvert(Message.of("foo"), Record.class)).isFalse();
+
+        IncomingKafkaRecordMetadata<String, String> metadata = mock(IncomingKafkaRecordMetadata.class);
+        when(metadata.getKey()).thenReturn("key");
+        Message<String> message = Message.of("foo").addMetadata(metadata);
+        assertThat(converter.canConvert(message, Record.class)).isTrue();
+        assertThat(converter.convert(message, Record.class)).satisfies(m -> {
+            assertThat(m.getPayload()).isInstanceOf(Record.class);
+            assertThat(((Record<String, String>) m.getPayload()).key()).isEqualTo("key");
+            assertThat(((Record<String, String>) m.getPayload()).value()).isEqualTo("foo");
+        });
+
+        assertThat(converter.canConvert(message, KafkaRecord.class)).isFalse();
+
+        when(metadata.getKey()).thenReturn(null);
+        message = Message.of("foo").addMetadata(metadata);
+        assertThat(converter.canConvert(message, Record.class)).isTrue();
+        assertThat(converter.convert(message, Record.class)).satisfies(m -> {
+            assertThat(m.getPayload()).isInstanceOf(Record.class);
+            assertThat(((Record<String, String>) m.getPayload()).key()).isNull();
+            assertThat(((Record<String, String>) m.getPayload()).value()).isEqualTo("foo");
+        });
+    }
+
+    @Test
+    public void testBeanUsingConverter() {
+        MapBasedConfig.Builder builder = MapBasedConfig.builder("mp.messaging.incoming.data");
+        builder.put("value.deserializer", StringDeserializer.class.getName());
+        builder.put("auto.offset.reset", "earliest");
+        builder.put("topic", topic);
+
+        addBeans(ConsumerRecordConverter.class, RecordConverter.class);
+        MyBean bean = runApplication(builder.build(), MyBean.class);
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceStrings(10, null,
+                () -> new ProducerRecord<>(topic, counter.get() % 2 == 0 ? "key" : "k", "v-" + counter.incrementAndGet()));
+
+        await().until(() -> bean.list().size() == 10);
+
+        assertThat(bean.list()).hasSize(10).allSatisfy(r -> {
+            assertThat(r.value()).startsWith("v-");
+            assertThat(r.key()).startsWith("k");
+            if (!r.key().equalsIgnoreCase("key")) {
+                assertThat(r.key()).isEqualTo("k");
+            }
+        });
+    }
+
+    @Test
+    public void testBeanUsingConverterWithNullKeyAndValue() {
+        MapBasedConfig.Builder builder = MapBasedConfig.builder("mp.messaging.incoming.data");
+        builder.put("value.deserializer", StringDeserializer.class.getName());
+        builder.put("auto.offset.reset", "earliest");
+        builder.put("topic", topic);
+
+        addBeans(ConsumerRecordConverter.class, RecordConverter.class);
+        MyBean bean = runApplication(builder.build(), MyBean.class);
+
+        usage.produceStrings(10, null,
+                () -> new ProducerRecord<>(topic, null, null));
+
+        await().until(() -> bean.list().size() == 10);
+
+        assertThat(bean.list()).hasSize(10).allSatisfy(r -> {
+            assertThat(r.value()).isNull();
+            assertThat(r.value()).isNull();
+        });
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+
+        private final List<Record<String, String>> records = new CopyOnWriteArrayList<>();
+
+        @Incoming("data")
+        public void consume(Record<String, String> record) {
+            this.records.add(record);
+        }
+
+        public List<Record<String, String>> list() {
+            return records;
+        }
+
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/AbstractMediator.java
@@ -188,7 +188,7 @@ public abstract class AbstractMediator {
                             //noinspection ConstantConditions - it can be `null`
                             if (injectedPayloadType == null) {
                                 return o;
-                            } else if (o.getPayload().getClass().equals(injectedPayloadType)) {
+                            } else if (o.getPayload() != null && o.getPayload().getClass().equals(injectedPayloadType)) {
                                 return o;
                             }
 
@@ -196,7 +196,8 @@ public abstract class AbstractMediator {
                                 // Use the cached converter.
                                 return actual.convert(o, injectedPayloadType);
                             } else {
-                                if (TypeUtils.isAssignable(o.getPayload().getClass(), injectedPayloadType)) {
+                                if (o.getPayload() != null
+                                        && TypeUtils.isAssignable(o.getPayload().getClass(), injectedPayloadType)) {
                                     actual = MessageConverter.IdentityConverter.INSTANCE;
                                     return o;
                                 }


### PR DESCRIPTION
This PR:

- Implements Record and ConsumerRecord converters
- Allows converters to be called on null payloads

The message converters allow the user's method to ingest Record and ConsumerRecord directly, without having to implement a custom conversion. 
Note that the user can also provide a specific converter is needed.
