### PR TITLE
Throttling Commit Strategy - toward being the default

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
@@ -1,8 +1,10 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import java.util.Set;
+import java.time.Duration;
+import java.util.Collection;
 
-import io.smallrye.mutiny.Uni;
+import org.apache.kafka.clients.consumer.Consumer;
+
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 
@@ -35,29 +37,105 @@ import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 public interface KafkaConsumerRebalanceListener {
 
     /**
-     * Called when the consumer is assigned topic partitions
-     * This method might be called for each consumer available to the connector
+     * A callback method the user can implement to provide handling of customized offsets on completion of a successful
+     * partition re-assignment. This method will be called after the partition re-assignment completes and before the
+     * consumer starts fetching data, and only as the result of a {@link Consumer#poll(java.time.Duration) poll(long)} call.
+     * <p>
+     * It is guaranteed that under normal conditions all the processes in a consumer group will execute their
+     * {@link #onPartitionsRevoked(Consumer, Collection)} callback before any instance executes this
+     * callback. During exceptional scenarios, partitions may be migrated
+     * without the old owner being notified (i.e. their {@link #onPartitionsRevoked(Consumer, Collection)} callback not
+     * triggered),
+     * and later when the old owner consumer realized this event, the {@link #onPartitionsLost(Consumer, Collection)}
+     * (Collection)} callback
+     * will be triggered by the consumer then.
+     * <p>
+     * It is common for the assignment callback to use the consumer instance in order to query offsets. It is possible
+     * for a {@link org.apache.kafka.common.errors.WakeupException} or {@link org.apache.kafka.common.errors.InterruptException}
+     * to be raised from one of these nested invocations. In this case, the exception will be propagated to the current
+     * invocation of {@link org.apache.kafka.clients.consumer.KafkaConsumer#poll(java.time.Duration)} in which this callback is
+     * being executed. This means it is not
+     * necessary to catch these exceptions and re-attempt to wakeup or interrupt the consumer thread.
      *
-     * The consumer will be paused until the returned {@link Uni}
-     * indicates success. On failure will retry using an exponential back off until the consumer can
-     * be considered timed-out by Kafka, in which case will resume anyway triggering a new re-balance.
+     * <strong>IMPORTANT</strong>: The behavior must be blocking. Callback invoked from the polling thread.
      *
-     * @see KafkaConsumer#pause()
-     * @see KafkaConsumer#resume()
-     *
-     * @param consumer underlying consumer
-     * @param topicPartitions set of assigned topic partitions
-     * @return A {@link Uni} indicating operations complete or failure
+     * @param partitions The list of partitions that are now assigned to the consumer (previously owned partitions will
+     *        NOT be included, i.e. this list will only include newly added partitions)
+     * @throws org.apache.kafka.common.errors.WakeupException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+     * @throws org.apache.kafka.common.errors.InterruptException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
      */
-    Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions);
+    default void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<org.apache.kafka.common.TopicPartition> partitions) {
+
+    }
 
     /**
-     * Called when the consumer is revoked topic partitions
-     * This method might be called for each consumer available to the connector
+     * A callback method the user can implement to provide handling of offset commits to a customized store.
+     * This method will be called during a rebalance operation when the consumer has to give up some partitions.
+     * It can also be called when consumer is being closed
+     * ({@link org.apache.kafka.clients.consumer.KafkaConsumer#close(Duration)})
+     * or is unsubscribing ({@link org.apache.kafka.clients.consumer.KafkaConsumer#unsubscribe()}).
+     * It is recommended that offsets should be committed in this callback to either Kafka or a
+     * custom offset store to prevent duplicate data.
+     * <p>
+     * In eager rebalancing, it will always be called at the start of a rebalance and after the consumer stops fetching data.
+     * In cooperative rebalancing, it will be called at the end of a rebalance on the set of partitions being revoked iff the
+     * set is non-empty.
+     * For examples on usage of this API, see Usage Examples section of {@link org.apache.kafka.clients.consumer.KafkaConsumer
+     * KafkaConsumer}.
+     * <p>
+     * It is common for the revocation callback to use the consumer instance in order to commit offsets. It is possible
+     * for a {@link org.apache.kafka.common.errors.WakeupException} or {@link org.apache.kafka.common.errors.InterruptException}
+     * to be raised from one of these nested invocations. In this case, the exception will be propagated to the current
+     * invocation of {@link org.apache.kafka.clients.consumer.KafkaConsumer#poll(java.time.Duration)} in which this callback is
+     * being executed. This means it is not
+     * necessary to catch these exceptions and re-attempt to wakeup or interrupt the consumer thread.
      *
-     * @param consumer underlying consumer
-     * @param topicPartitions set of revoked topic partitions
-     * @return A {@link Uni} indicating operations complete or failure
+     * <strong>IMPORTANT</strong>: The behavior must be blocking. Callback invoked from the polling thread.
+     *
+     * @param partitions The list of partitions that were assigned to the consumer and now need to be revoked (may not
+     *        include all currently assigned partitions, i.e. there may still be some partitions left)
+     * @throws org.apache.kafka.common.errors.WakeupException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+     * @throws org.apache.kafka.common.errors.InterruptException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
      */
-    Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions);
+    default void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<org.apache.kafka.common.TopicPartition> partitions) {
+
+    }
+
+    /**
+     * A callback method you can implement to provide handling of cleaning up resources for partitions that have already
+     * been reassigned to other consumers. This method will not be called during normal execution as the owned partitions would
+     * first be revoked by calling the {@link #onPartitionsRevoked}, before being reassigned
+     * to other consumers during a rebalance event. However, during exceptional scenarios when the consumer realized that it
+     * does not own this partition any longer, i.e. not revoked via a normal rebalance event, then this method would be invoked.
+     * <p>
+     * For example, this function is called if a consumer's session timeout has expired, or if a fatal error has been
+     * received indicating the consumer is no longer part of the group.
+     * <p>
+     * By default it will just trigger {@link #onPartitionsRevoked}; for users who want to distinguish
+     * the handling logic of revoked partitions v.s. lost partitions, they can override the default implementation.
+     * <p>
+     * It is possible
+     * for a {@link org.apache.kafka.common.errors.WakeupException} or {@link org.apache.kafka.common.errors.InterruptException}
+     * to be raised from one of these nested invocations. In this case, the exception will be propagated to the current
+     * invocation of {@link org.apache.kafka.clients.consumer.KafkaConsumer#poll(java.time.Duration)} in which this callback is
+     * being executed. This means it is not
+     * necessary to catch these exceptions and re-attempt to wakeup or interrupt the consumer thread.
+     *
+     * @param partitions The list of partitions that were assigned to the consumer and now have been reassigned
+     *        to other consumers. With the current protocol this will always include all of the consumer's
+     *        previously assigned partitions, but this may change in future protocols (ie there would still
+     *        be some partitions left)
+     * @throws org.apache.kafka.common.errors.WakeupException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+     * @throws org.apache.kafka.common.errors.InterruptException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+     */
+    default void onPartitionsLost(Consumer<?, ?> consumer, Collection<org.apache.kafka.common.TopicPartition> partitions) {
+        onPartitionsRevoked(consumer, partitions);
+    }
+
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
@@ -2,12 +2,11 @@ package io.smallrye.reactive.messaging.kafka.commit;
 
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions.ex;
 
-import java.util.Set;
+import java.util.Collection;
 import java.util.concurrent.CompletionStage;
 
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
 import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.core.Context;
 
 public interface KafkaCommitHandler {
 
@@ -34,8 +33,8 @@ public interface KafkaCommitHandler {
         return record;
     }
 
-    default void partitionsAssigned(Context context, Set<TopicPartition> partitions) {
-
+    default void partitionsAssigned(Collection<TopicPartition> partitions) {
+        // Do nothing by default
     }
 
     <K, V> CompletionStage<Void> handle(IncomingKafkaRecord<K, V> record);

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
@@ -1,0 +1,146 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.enterprise.inject.AmbiguousResolutionException;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.literal.NamedLiteral;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
+
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
+import io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler;
+import io.vertx.kafka.client.consumer.KafkaReadStream;
+import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+
+public class RebalanceListeners {
+
+    static ConsumerRebalanceListener createRebalanceListener(
+            Vertx vertx,
+            KafkaConnectorIncomingConfiguration config,
+            String consumerGroup,
+            Instance<KafkaConsumerRebalanceListener> instances,
+            KafkaConsumer<?, ?> consumer,
+            KafkaCommitHandler commitHandler) {
+        Optional<KafkaConsumerRebalanceListener> rebalanceListener = findMatchingListener(config, consumerGroup, instances);
+
+        if (rebalanceListener.isPresent()) {
+            KafkaConsumerRebalanceListener listener = rebalanceListener.get();
+            return new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                    log.executingConsumerRevokedRebalanceListener(consumerGroup);
+
+                    try {
+                        listener.onPartitionsRevoked(consumer.getDelegate().unwrap(), partitions);
+                        log.executedConsumerRevokedRebalanceListener(consumerGroup);
+                    } catch (RuntimeException e) {
+                        log.unableToExecuteConsumerRevokedRebalanceListener(consumerGroup, e);
+                        throw e;
+                    }
+                }
+
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                    final long currentDemand = consumer.demand();
+                    consumer.pause(); // TODO Do we need to pause all?
+                    Collection<io.vertx.kafka.client.common.TopicPartition> tps = wrap(partitions);
+                    commitHandler.partitionsAssigned(tps);
+                    try {
+                        listener.onPartitionsAssigned(consumer.getDelegate().unwrap(), partitions);
+                        log.executedConsumerAssignedRebalanceListener(consumerGroup);
+                    } catch (RuntimeException e) {
+                        log.reEnablingConsumerforGroup(consumerGroup);
+                        throw e;
+                    } finally {
+                        consumer.fetch(currentDemand);
+                    }
+                }
+            };
+        } else {
+            return new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                    // TODO throlling and latest must commit sync
+                }
+
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                    Collection<io.vertx.kafka.client.common.TopicPartition> tps = wrap(partitions);
+                    commitHandler.partitionsAssigned(tps);
+                }
+            };
+        }
+    }
+
+    private static Set<io.vertx.kafka.client.common.TopicPartition> wrap(Collection<TopicPartition> partitions) {
+        return partitions.stream().map(tp -> new io.vertx.kafka.client.common.TopicPartition(tp.topic(), tp.partition()))
+                .collect(Collectors.toSet());
+    }
+
+    private static Optional<KafkaConsumerRebalanceListener> findMatchingListener(
+            KafkaConnectorIncomingConfiguration config, String consumerGroup,
+            Instance<KafkaConsumerRebalanceListener> instances) {
+        return config.getConsumerRebalanceListenerName()
+                .map(name -> {
+                    log.loadingConsumerRebalanceListenerFromConfiguredName(name);
+                    Instance<KafkaConsumerRebalanceListener> matching = instances.select(NamedLiteral.of(name));
+                    // We want to fail if a name if set, but no match or too many matches
+                    if (matching.isUnsatisfied()) {
+                        // TODO Extract
+                        throw new UnsatisfiedResolutionException(
+                                "Unable to find the rebalance listener " + name + " for channel " + config.getChannel());
+                    } else if (matching.stream().count() > 1) {
+                        // TODO Extract
+                        throw new AmbiguousResolutionException(
+                                "Unable to select the rebalance listener " + name + " for channel "
+                                        + config.getChannel() + " - too many matches");
+                    } else if (matching.stream().count() == 1) {
+                        return Optional.of(matching.get());
+                    } else {
+                        return Optional.<KafkaConsumerRebalanceListener> empty();
+                    }
+                })
+                .orElseGet(() -> {
+                    Instance<KafkaConsumerRebalanceListener> matching = instances.select(NamedLiteral.of(consumerGroup));
+                    if (!matching.isUnsatisfied()) {
+                        log.loadingConsumerRebalanceListenerFromGroupId(consumerGroup);
+                        return Optional.of(matching.get());
+                    }
+                    return Optional.empty();
+                });
+    }
+
+    /**
+     * HACK - inject the listener using reflection to replace the one set by vert.x
+     *
+     * @param consumer the consumer
+     * @param listener the listener
+     */
+    @SuppressWarnings("rawtypes")
+    public static void inject(KafkaConsumer<?, ?> consumer, ConsumerRebalanceListener listener) {
+        KafkaReadStream readStream = consumer.getDelegate().asStream();
+        if (readStream instanceof KafkaReadStreamImpl) {
+            try {
+                Field field = readStream.getClass().getDeclaredField("rebalanceListener");
+                field.setAccessible(true);
+                field.set(readStream, listener);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Cannot inject rebalance listener", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Cannot inject rebalance listener - not a Kafka Read Stream");
+        }
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
@@ -1,15 +1,14 @@
 package io.smallrye.reactive.messaging.kafka;
 
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 
-import io.smallrye.mutiny.Uni;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
 @ApplicationScoped
 @Named("ConsumptionConsumerRebalanceListener")
@@ -18,18 +17,8 @@ public class ConsumptionConsumerRebalanceListener implements KafkaConsumerRebala
     private final Map<Integer, TopicPartition> assigned = new ConcurrentHashMap<>();
 
     @Override
-    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
-        set.forEach(topicPartition -> this.assigned.put(topicPartition.getPartition(), topicPartition));
-        return Uni
-                .createFrom()
-                .nullItem();
-    }
-
-    @Override
-    public Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
-        return Uni
-                .createFrom()
-                .nullItem();
+    public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> set) {
+        set.forEach(topicPartition -> this.assigned.put(topicPartition.partition(), topicPartition));
     }
 
     public Map<Integer, TopicPartition> getAssigned() {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaCommitHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaCommitHandlerTest.java
@@ -213,6 +213,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
                 .with("group.id", "test-source-with-throttled-latest-processed-commit-without-acking")
                 .with("value.deserializer", IntegerDeserializer.class.getName())
                 .with("commit-strategy", "throttled")
+                .with("throttled.unprocessed-record-max-age.ms", 4000)
                 .with("max.poll.records", "16");
 
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
@@ -227,11 +228,11 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         new Thread(() -> usage.produceIntegers(10, null,
                 () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
-        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> messages.size() >= 10);
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
                 .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-        await().atMost(2, TimeUnit.MINUTES)
+        await().atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     HealthReport.HealthReportBuilder healthReportBuilder = HealthReport.builder();
                     source.isAlive(healthReportBuilder);
@@ -241,9 +242,9 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         new Thread(() -> usage.produceIntegers(30, null,
                 () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
-        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 30);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> messages.size() >= 30);
 
-        await().atMost(2, TimeUnit.MINUTES)
+        await().atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     HealthReport.HealthReportBuilder healthReportBuilder = HealthReport.builder();
                     source.isAlive(healthReportBuilder);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -13,14 +13,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.enterprise.inject.UnsatisfiedResolutionException;
 import javax.enterprise.inject.literal.NamedLiteral;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.jboss.weld.exceptions.DeploymentException;
-import org.jboss.weld.exceptions.UnsatisfiedResolutionException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,6 @@ import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
 import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
 import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
-import io.vertx.kafka.client.common.TopicPartition;
 
 public class KafkaSourceTest extends KafkaTestBase {
 
@@ -302,7 +302,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         for (int i = 0; i < 2; i++) {
             TopicPartition topicPartition = consumptionConsumerRebalanceListener.getAssigned().get(i);
             assertThat(topicPartition).isNotNull();
-            assertThat(topicPartition.getTopic()).isEqualTo("data-2");
+            assertThat(topicPartition.topic()).isEqualTo("data-2");
         }
     }
 
@@ -363,7 +363,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         assertThat(
                 getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
                         "my-group-starting-on-fifth-fail-on-first-attempt")
-                                .getRebalanceCount()).isEqualTo(1);
+                                .getRebalanceCount()).isEqualTo(2);
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
@@ -1,14 +1,13 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import java.util.Set;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 
-import io.smallrye.mutiny.Uni;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
 @ApplicationScoped
 @Named("my-group-starting-on-fifth-fail-on-first-attempt")
@@ -18,20 +17,12 @@ public class StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListen
     private final AtomicBoolean failOnFirstAttempt = new AtomicBoolean(true);
 
     @Override
-    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
+    public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> set) {
         // will perform the underlying operation but simulate an error on the first attempt
-        return super.onPartitionsAssigned(consumer, set)
-                .onItem()
-                .transformToUni(a -> {
-                    if (!set.isEmpty() && failOnFirstAttempt.getAndSet(false)) {
-                        return Uni
-                                .createFrom()
-                                .failure(new Exception("testing failure"));
-                    } else {
-                        return Uni
-                                .createFrom()
-                                .item(a);
-                    }
-                });
+        super.onPartitionsAssigned(consumer, set);
+
+        if (!set.isEmpty() && failOnFirstAttempt.getAndSet(false)) {
+            throw new IllegalStateException("testing failure");
+        }
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.java
@@ -1,14 +1,13 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import java.util.Set;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 
-import io.smallrye.mutiny.Uni;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
 @ApplicationScoped
 @Named("my-group-starting-on-fifth-fail-until-second-rebalance")
@@ -17,14 +16,12 @@ public class StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRe
     private final AtomicBoolean failOnFirstAttempt = new AtomicBoolean(true);
 
     @Override
-    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
+    public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> set) {
         if (!set.isEmpty() && failOnFirstAttempt.getAndSet(false)) {
             // will perform the underlying operation but simulate an error
-            return super.onPartitionsAssigned(consumer, set)
-                    .onItem()
-                    .failWith(a -> new Exception("testing failure"));
+            super.onPartitionsAssigned(consumer, set);
+            throw new IllegalStateException("testing failure");
         }
-        return super.onPartitionsAssigned(consumer, set);
-
+        super.onPartitionsAssigned(consumer, set);
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
@@ -1,42 +1,26 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import java.util.Set;
+import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 
-import io.smallrye.mutiny.Uni;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
 @ApplicationScoped
 @Named("my-group-starting-on-fifth-happy-path")
 public class StartFromFifthOffsetFromLatestConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
 
-    private AtomicInteger rebalanceCount = new AtomicInteger();
+    private final AtomicInteger rebalanceCount = new AtomicInteger();
 
     @Override
-    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
+    public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> set) {
         rebalanceCount.incrementAndGet();
-        return Uni
-                .combine()
-                .all()
-                .unis(set
-                        .stream()
-                        .map(topicPartition -> consumer.endOffsets(topicPartition)
-                                .onItem()
-                                .transformToUni(o -> consumer.seek(topicPartition, Math.max(0L, o - 5L))))
-                        .collect(Collectors.toList()))
-                .combinedWith(a -> null);
-    }
-
-    @Override
-    public Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions) {
-        return Uni
-                .createFrom()
-                .nullItem();
+        Map<TopicPartition, Long> offsets = consumer.endOffsets(set);
+        offsets.forEach((t, o) -> consumer.seek(t, Math.max(0L, o - 5L)));
     }
 
     public int getRebalanceCount() {


### PR DESCRIPTION
This PR is not intended to be merged for now. It includes breaking changes

- Make the rebalance listeners blocking.

Next step: extend tests.


**Breaking Changes:**

* Change the `KafkaRebalanceListener` interface to be blocking


**Hacks:** 

* Replace the built-in rebalance listener used by Vert.x by ours as the Vert.x one does not follow the rebalance protocol correctly. 

CC @pcasaes 

