### PR TITLE
Improve the latest commit strategy

### DIFF
--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -77,9 +77,18 @@ include::example$inbound/KafkaMetadataExample.java[tags=code]
 If a message produced from a Kafka record is _acked_, a commit strategy is applied.
 The Kafka connector supports 3 strategies:
 
-* `latest` - Will commit to the latest offset received by the Kafka consumer. This offset may be greater than the currently _acked_ message. This strategy does not guarantee _at-least-once delivery_.
-* `ignore` - Performs no commit. Is the default when `enable.auto.commit` is `true`. This strategy provides _at-least-once delivery_ if the channel processes the message without performing any asynchronous operations and when `enable.auto.commit` is `true`.
-* `throttled` -  Will keep track of received messages and commit to the next offset after the latest _acked_ message in sequence. Will commit periodically as defined by `auto.commit.interval.ms` (default: 5000). This strategy mimics the behavior of the kafka consumer when `enable.auto.commit` is `true`. The connector will be marked as unhealthy in the presence of any received record that has gone too long without being processed as defined by `throttled.unprocessed-record-max-age.ms` (default: 60000). If `throttled.unprocessed-record-max-age.ms` is set to less than or equal to 0 then will not perform any health check (this might lead to running out of memory). This strategy guarantees _at-least-once delivery_ even if the channel performs asynchronous processing.
+* `latest` - Will commit the record offset received by the Kafka consumer (if higher than the previously committed offset).
+This strategy provides at-least-once delivery if the channel processes the message without performing  any asynchronous processing.
+This strategy should not be used on high-load as offset commit is expensive.
+* `ignore` - Performs no commit.
+Is the default when `enable.auto.commit` is `true`.
+This strategy provides _at-least-once delivery_ if the channel processes the message without performing any asynchronous operations and when `enable.auto.commit` is `true`.
+* `throttled` -  Will keep track of received messages and commit to the next offset after the latest _acked_ message in sequence.
+Will commit periodically as defined by `auto.commit.interval.ms` (default: 5000). T
+his strategy mimics the behavior of the kafka consumer when `enable.auto.commit` is `true`.
+The connector will be marked as unhealthy in the presence of any received record that has gone too long without being processed as defined by `throttled.unprocessed-record-max-age.ms` (default: 60000).
+If `throttled.unprocessed-record-max-age.ms` is set to less than or equal to 0 then will not perform any health check (this might lead to running out of memory).
+This strategy guarantees _at-least-once delivery_ even if the channel performs asynchronous processing.
 
 IMPORTANT: The Kafka connector disables the Kafka _auto commit_ is not explicitly enabled.
 This behavior differs from the traditional Kafka consumer.

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ContextHolder.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ContextHolder.java
@@ -1,0 +1,39 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
+
+/**
+ * A class holding a vert.x context to make sure methods are always run from the same one.
+ */
+public class ContextHolder {
+
+    protected final Vertx vertx;
+    protected volatile Context context;
+
+    public ContextHolder(Vertx vertx) {
+        this.vertx = vertx;
+    }
+
+    public Context getContext() {
+        Context ctx = this.context;
+        if (ctx == null) {
+            synchronized (this) {
+                ctx = this.context;
+                if (ctx == null) {
+                    this.context = ctx = vertx.getOrCreateContext();
+                }
+            }
+        }
+        return ctx;
+    }
+
+    public void runOnContext(Runnable runnable) {
+        if (Vertx.currentContext() == getContext()) {
+            runnable.run();
+        } else {
+            getContext().runOnContext(x -> runnable.run());
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
@@ -7,7 +7,6 @@ import java.util.concurrent.CompletionStage;
 
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
 import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.core.Context;
 
 public interface KafkaCommitHandler {
 
@@ -36,9 +35,10 @@ public interface KafkaCommitHandler {
     }
 
     default void terminate() {
+        // Do nothing by default.
     }
 
-    default void partitionsAssigned(Context context, Set<TopicPartition> partitions) {
+    default void partitionsAssigned(Set<TopicPartition> partitions) {
 
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
@@ -1,30 +1,74 @@
 package io.smallrye.reactive.messaging.kafka.commit;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
-import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.OffsetAndMetadata;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
 
 /**
- * Will commit to the latest offset received by the Kafka consumer.
+ * Will commit the record offset received by the Kafka consumer (if higher than the previously committed offset).
  * This offset may be greater than the currently ACKed message.
  *
  * This handler is the default when `enable.auto.commit` is `false`.
+ * This strategy provides at-least-once delivery if the channel processes the message without performing
+ * any asynchronous processing.
  *
- * This strategy does not guarantee at-least-once delivery.
+ * This strategy should not be used on high-load as offset commit is expensive.
  *
  * To use set `commit-strategy` to `latest`.
  */
 public class KafkaLatestCommit implements KafkaCommitHandler {
 
     private final KafkaConsumer<?, ?> consumer;
+    private final Map<TopicPartition, Long> offsets = new HashMap<>();
+    private final Vertx vertx;
+    private Context context;
 
-    public KafkaLatestCommit(KafkaConsumer<?, ?> consumer) {
-        this.consumer = consumer;
+    public KafkaLatestCommit(Vertx vertx, io.vertx.mutiny.kafka.client.consumer.KafkaConsumer<?, ?> consumer) {
+        this.consumer = (KafkaConsumer<?, ?>) consumer.getDelegate();
+        this.vertx = vertx;
+    }
+
+    private synchronized Context getContext() {
+        if (context == null) {
+            context = vertx.getOrCreateContext();
+        }
+        return context;
     }
 
     @Override
     public <K, V> CompletionStage<Void> handle(IncomingKafkaRecord<K, V> record) {
-        return consumer.commit().subscribeAsCompletionStage();
+        Context ctxt = getContext();
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        ctxt.runOnContext((x) -> {
+            Map<TopicPartition, OffsetAndMetadata> map = new HashMap<>();
+            TopicPartition key = new TopicPartition(record.getTopic(), record.getPartition());
+            Long last = offsets.get(key);
+            // Verify that the latest committed offset before this one.
+            if (last == null || last < record.getOffset() + 1) {
+                offsets.put(key, record.getOffset() + 1);
+                map.put(key, new OffsetAndMetadata(record.getOffset() + 1, null));
+
+                consumer.commit(map, ar -> {
+                    if (ar.failed()) {
+                        future.completeExceptionally(ar.cause());
+                    } else {
+                        future.complete(null);
+                    }
+                });
+            } else {
+                future.complete(null);
+            }
+        });
+
+        return future;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
@@ -9,46 +9,39 @@ import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
-import io.vertx.mutiny.core.Context;
 import io.vertx.mutiny.core.Vertx;
 
 /**
  * Will commit the record offset received by the Kafka consumer (if higher than the previously committed offset).
  * This offset may be greater than the currently ACKed message.
- *
+ * <p>
  * This handler is the default when `enable.auto.commit` is `false`.
  * This strategy provides at-least-once delivery if the channel processes the message without performing
  * any asynchronous processing.
- *
+ * <p>
  * This strategy should not be used on high-load as offset commit is expensive.
- *
+ * <p>
  * To use set `commit-strategy` to `latest`.
  */
-public class KafkaLatestCommit implements KafkaCommitHandler {
+public class KafkaLatestCommit extends ContextHolder implements KafkaCommitHandler {
 
     private final KafkaConsumer<?, ?> consumer;
+
+    /**
+     * Stores the last offset for each topic/partition.
+     * This map must always be accessed from the same thread (Vert.x context).
+     */
     private final Map<TopicPartition, Long> offsets = new HashMap<>();
-    private final Vertx vertx;
-    private Context context;
 
     public KafkaLatestCommit(Vertx vertx, io.vertx.mutiny.kafka.client.consumer.KafkaConsumer<?, ?> consumer) {
+        super(vertx);
         this.consumer = (KafkaConsumer<?, ?>) consumer.getDelegate();
-        this.vertx = vertx;
-    }
-
-    private synchronized Context getContext() {
-        if (context == null) {
-            context = vertx.getOrCreateContext();
-        }
-        return context;
     }
 
     @Override
     public <K, V> CompletionStage<Void> handle(IncomingKafkaRecord<K, V> record) {
-        Context ctxt = getContext();
-
         CompletableFuture<Void> future = new CompletableFuture<>();
-        ctxt.runOnContext((x) -> {
+        runOnContext(() -> {
             Map<TopicPartition, OffsetAndMetadata> map = new HashMap<>();
             TopicPartition key = new TopicPartition(record.getTopic(), record.getPartition());
             Long last = offsets.get(key);

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -2,13 +2,7 @@ package io.smallrye.reactive.messaging.kafka.commit;
 
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.OptionalLong;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,6 +15,7 @@ import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
+import io.vertx.mutiny.core.Context;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 
@@ -53,7 +48,8 @@ public class KafkaThrottledLatestProcessedCommit implements KafkaCommitHandler {
     private final int autoCommitInterval;
     private final Vertx vertx;
 
-    private long timerId = -1;
+    private Context context;
+    private volatile long timerId = -1;
 
     private KafkaThrottledLatestProcessedCommit(
             Vertx vertx,
@@ -153,7 +149,8 @@ public class KafkaThrottledLatestProcessedCommit implements KafkaCommitHandler {
     @Override
     public <K, V> CompletionStage<Void> handle(final IncomingKafkaRecord<K, V> record) {
         CompletableFuture<Void> future = new CompletableFuture<>();
-        vertx.runOnContext(v -> {
+        Context ctxt = getContext();
+        ctxt.runOnContext(v -> {
             offsetStores
                     .get(getTopicPartition(record))
                     .processed(record.getOffset());
@@ -163,26 +160,37 @@ public class KafkaThrottledLatestProcessedCommit implements KafkaCommitHandler {
 
     }
 
+    private synchronized Context getContext() {
+        if (context == null) {
+            context = vertx.getOrCreateContext();
+        }
+        return context;
+    }
+
     private void flushAndCheckHealth(long timerId) {
-        Map<TopicPartition, Long> offsetsMapping = clearLesserSequentiallyProcessedOffsetsAndReturnLargestOffsetMapping();
+        // The timer may be on another context, so make sure we are on the right one to access the store.
+        getContext().runOnContext(x -> {
+            Map<TopicPartition, Long> offsetsMapping = clearLesserSequentiallyProcessedOffsetsAndReturnLargestOffsetMapping();
 
-        if (!offsetsMapping.isEmpty()) {
-            Map<TopicPartition, OffsetAndMetadata> offsets = offsetsMapping
-                    .entrySet().stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey,
-                            e -> new OffsetAndMetadata().setOffset(e.getValue() + 1L)));
-            consumer.getDelegate().commit(offsets, a -> this.startFlushAndCheckHealthTimer());
-        } else {
-            this.startFlushAndCheckHealthTimer();
-        }
+            if (!offsetsMapping.isEmpty()) {
+                Map<TopicPartition, OffsetAndMetadata> offsets = offsetsMapping
+                        .entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey,
+                                e -> new OffsetAndMetadata().setOffset(e.getValue() + 1L)));
+                consumer.getDelegate().commit(offsets, a -> this.startFlushAndCheckHealthTimer());
+            } else {
+                this.startFlushAndCheckHealthTimer();
+            }
 
-        if (this.unprocessedRecordMaxAge > 0) {
-            offsetStores
-                    .values()
-                    .stream()
-                    .filter(OffsetStore::hasTooManyMessagesWithoutAck)
-                    .forEach(o -> this.source.reportFailure(new TooManyMessagesWithoutAckException()));
-        }
+            if (this.unprocessedRecordMaxAge > 0) {
+                offsetStores
+                        .values()
+                        .stream()
+                        .filter(OffsetStore::hasTooManyMessagesWithoutAck)
+                        .forEach(o -> this.source.reportFailure(new TooManyMessagesWithoutAckException()));
+            }
+        });
+
     }
 
     private static class OffsetReceivedAt {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaAdminHelper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaAdminHelper.java
@@ -3,6 +3,8 @@ package io.smallrye.reactive.messaging.kafka.impl;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.kafka.clients.admin.AdminClientConfig;
+
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.kafka.admin.KafkaAdminClient;
 
@@ -16,17 +18,10 @@ public class KafkaAdminHelper {
             Map<String, Object> kafkaConfigurationMap) {
         Map<String, String> copy = new HashMap<>();
         for (Map.Entry<String, Object> entry : kafkaConfigurationMap.entrySet()) {
-            copy.put(entry.getKey(), entry.getValue().toString());
+            if (AdminClientConfig.configNames().contains(entry.getKey())) {
+                copy.put(entry.getKey(), entry.getValue().toString());
+            }
         }
-        Map<String, String> adminConfiguration = new HashMap<>(copy);
-        adminConfiguration.remove("key.serializer");
-        adminConfiguration.remove("value.serializer");
-        adminConfiguration.remove("key.deserializer");
-        adminConfiguration.remove("value.deserializer");
-        adminConfiguration.remove("acks");
-        adminConfiguration.remove("max.in.flight.requests.per.connection");
-        adminConfiguration.remove("group.id");
-        return KafkaAdminClient.create(vertx, adminConfiguration);
-
+        return KafkaAdminClient.create(vertx, copy);
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -122,7 +122,7 @@ public class KafkaSource<K, V> {
         kafkaConfiguration.remove("consumer-rebalance-listener.name");
 
         final KafkaConsumer<K, V> kafkaConsumer = KafkaConsumer.create(vertx, kafkaConfiguration);
-        commitHandler = createCommitHandler(kafkaConsumer, group, config, commitStrategy);
+        commitHandler = createCommitHandler(vertx, kafkaConsumer, group, config, commitStrategy);
 
         Optional<KafkaConsumerRebalanceListener> rebalanceListener = config
                 .getConsumerRebalanceListenerName()
@@ -166,7 +166,7 @@ public class KafkaSource<K, V> {
                 final long currentDemand = kafkaConsumer.demand();
                 kafkaConsumer.pause();
 
-                commitHandler.partitionsAssigned(vertx.getOrCreateContext(), set);
+                commitHandler.partitionsAssigned(set);
 
                 log.executingConsumerAssignedRebalanceListener(group);
                 listener.onPartitionsAssigned(kafkaConsumer, set)
@@ -194,11 +194,10 @@ public class KafkaSource<K, V> {
                                 t -> log.unableToExecuteConsumerRevokedRebalanceListener(group, t));
             });
         } else {
-            kafkaConsumer.partitionsAssignedHandler(set -> commitHandler.partitionsAssigned(vertx.getOrCreateContext(), set));
+            kafkaConsumer.partitionsAssignedHandler(commitHandler::partitionsAssigned);
         }
 
         failureHandler = createFailureHandler(config, vertx, kafkaConfiguration);
-
         Map<String, Object> adminConfiguration = new HashMap<>(kafkaConfiguration);
         if (config.getHealthEnabled() && config.getHealthReadinessEnabled()) {
             // Do not create the client if the readiness health checks are disabled
@@ -250,11 +249,9 @@ public class KafkaSource<K, V> {
                         return this.consumer.subscribe(topics);
                     }
                 })
-                .map(rec -> {
-                    return commitHandler
-                            .received(new IncomingKafkaRecord<>(rec, commitHandler, failureHandler, config.getCloudEvents(),
-                                    config.getTracingEnabled()));
-                });
+                .map(rec -> commitHandler
+                        .received(new IncomingKafkaRecord<>(rec, commitHandler, failureHandler, config.getCloudEvents(),
+                                config.getTracingEnabled())));
 
         if (config.getTracingEnabled()) {
             incomingMulti = incomingMulti.onItem().invoke(this::incomingTrace);
@@ -346,7 +343,9 @@ public class KafkaSource<K, V> {
 
     }
 
-    private KafkaCommitHandler createCommitHandler(KafkaConsumer<K, V> consumer,
+    private KafkaCommitHandler createCommitHandler(
+            Vertx vertx,
+            KafkaConsumer<K, V> consumer,
             String group,
             KafkaConnectorIncomingConfiguration config,
             String strategy) {
@@ -357,7 +356,7 @@ public class KafkaSource<K, V> {
             case IGNORE:
                 return new KafkaIgnoreCommit();
             case THROTTLED:
-                return KafkaThrottledLatestProcessedCommit.create(consumer, group, config, this);
+                return KafkaThrottledLatestProcessedCommit.create(vertx, consumer, group, config, this);
             default:
                 throw ex.illegalArgumentInvalidCommitStrategy(strategy);
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -352,7 +352,7 @@ public class KafkaSource<K, V> {
         KafkaCommitHandler.Strategy actualStrategy = KafkaCommitHandler.Strategy.from(strategy);
         switch (actualStrategy) {
             case LATEST:
-                return new KafkaLatestCommit(consumer);
+                return new KafkaLatestCommit(vertx, consumer);
             case IGNORE:
                 return new KafkaIgnoreCommit();
             case THROTTLED:
@@ -431,5 +431,14 @@ public class KafkaSource<K, V> {
         }
 
         // If health is disable do not add anything to the builder.
+    }
+
+    /**
+     * For testing purpose only
+     *
+     * @return get the underlying consumer.
+     */
+    public KafkaConsumer<K, V> getConsumer() {
+        return this.consumer;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -1,0 +1,309 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.inject.Named;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
+import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.WeldTestBase;
+import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
+import io.vertx.kafka.client.consumer.KafkaReadStream;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+
+public class CommitStrategiesTest extends WeldTestBase {
+
+    private static final String TOPIC = "my-topic";
+
+    public Vertx vertx;
+    private MockConsumer<String, String> consumer;
+
+    @BeforeEach
+    public void initializing() {
+        vertx = Vertx.vertx();
+        consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    }
+
+    @AfterEach
+    void closing() {
+        vertx.closeAndAwait();
+    }
+
+    @Test
+    void testLatestCommitStrategy() {
+        MapBasedConfig config = commonConfiguration();
+        KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getStream()
+                .subscribe().with(list::add);
+
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp1 = new TopicPartition(TOPIC, 1);
+        TopicPartition tp2 = new TopicPartition(TOPIC, 2);
+        Map<TopicPartition, Long> beginning = new HashMap<>();
+        beginning.put(tp0, 0L);
+        beginning.put(tp1, 0L);
+        beginning.put(tp2, 0L);
+        consumer.updateBeginningOffsets(beginning);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Arrays.asList(tp0, tp1, tp2));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v0"));
+        });
+
+        await().until(() -> list.size() == 1);
+        assertThat(list).hasSize(1);
+
+        list.get(0).ack().toCompletableFuture().join();
+
+        Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp0));
+        assertThat(committed.get(tp0).offset()).isEqualTo(1);
+
+        consumer.schedulePollTask(() -> {
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, "k", "v1"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, "k", "v2"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 3, "k", "v3"));
+        });
+
+        await().until(() -> list.size() == 4);
+
+        Message<?> message = list.get(1);
+        message.ack().toCompletableFuture().join();
+        committed = consumer.committed(Collections.singleton(tp0));
+        assertThat(committed.get(tp0).offset()).isEqualTo(2);
+
+        // latest commit strategy, 3 is not acked, but offset 4 got committed.
+
+        list.get(3).ack().toCompletableFuture().join();
+        committed = consumer.committed(Collections.singleton(tp0));
+        assertThat(committed.get(tp0).offset()).isEqualTo(4);
+
+        // Do not change anything.
+        list.get(2).ack().toCompletableFuture().join();
+        committed = consumer.committed(Collections.singleton(tp0));
+        assertThat(committed.get(tp0).offset()).isEqualTo(4);
+
+        // Do not change anything.
+        list.get(1).ack().toCompletableFuture().join();
+        committed = consumer.committed(Collections.singleton(tp0));
+        assertThat(committed.get(tp0).offset()).isEqualTo(4);
+
+        consumer.schedulePollTask(() -> {
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 1, 0, "k", "v4"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 2, 0, "k", "v5"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 1, 1, "k", "v6"));
+        });
+
+        await().until(() -> list.size() == 7);
+
+        Message<?> v6 = list.stream().filter(m -> m.getPayload().equals("v6")).findFirst().orElse(null);
+        assertThat(v6).isNotNull();
+        v6.ack().toCompletableFuture().join();
+        committed = consumer.committed(new HashSet<>(Arrays.asList(tp0, tp1, tp2)));
+        assertThat(committed.get(tp0).offset()).isEqualTo(4);
+        assertThat(committed.get(tp1).offset()).isEqualTo(2);
+        assertThat(committed.get(tp2)).isNull();
+
+        Message<?> v5 = list.stream().filter(m -> m.getPayload().equals("v5")).findFirst().orElse(null);
+        assertThat(v5).isNotNull();
+        v5.ack().toCompletableFuture().join();
+        committed = consumer.committed(new HashSet<>(Arrays.asList(tp0, tp1, tp2)));
+        assertThat(committed.get(tp0).offset()).isEqualTo(4);
+        assertThat(committed.get(tp1).offset()).isEqualTo(2);
+        assertThat(committed.get(tp2).offset()).isEqualTo(1);
+    }
+
+    @Test
+    void testThrottledStrategy() {
+        MapBasedConfig config = commonConfiguration()
+                .with("commit-strategy", "throttled")
+                .with("auto.commit.interval.ms", 100);
+        KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getStream()
+                .subscribe().with(list::add);
+
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+        consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v0"));
+        });
+
+        await().until(() -> list.size() == 1);
+        assertThat(list).hasSize(1);
+
+        list.get(0).ack().toCompletableFuture().join();
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp));
+            assertThat(committed.get(tp)).isNotNull();
+            assertThat(committed.get(tp).offset()).isEqualTo(1);
+        });
+
+        consumer.schedulePollTask(() -> {
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, "k", "v1"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, "k", "v2"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 3, "k", "v3"));
+        });
+
+        await().until(() -> list.size() == 4);
+
+        list.get(2).ack().toCompletableFuture().join();
+        list.get(1).ack().toCompletableFuture().join();
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp));
+            assertThat(committed.get(tp)).isNotNull();
+            assertThat(committed.get(tp).offset()).isEqualTo(3);
+        });
+
+        list.get(3).ack().toCompletableFuture().join();
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp));
+            assertThat(committed.get(tp)).isNotNull();
+            assertThat(committed.get(tp).offset()).isEqualTo(4);
+        });
+
+    }
+
+    @Test
+    public void testFailureWhenNoRebalanceListenerMatchGivenName() {
+        MapBasedConfig config = commonConfiguration();
+        config.with("consumer-rebalance-listener.name", "my-missing-name");
+        assertThatThrownBy(() -> {
+            new KafkaSource<>(vertx, "my-group",
+                    new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+        }).isInstanceOf(UnsatisfiedResolutionException.class);
+    }
+
+    @Test
+    public void testFailureWhenMultipleRebalanceListenerMatchGivenName() {
+        MapBasedConfig config = commonConfiguration();
+        addBeans(NamedRebalanceListener.class, SameNameRebalanceListener.class);
+        config.with("consumer-rebalance-listener.name", "mine");
+        assertThatThrownBy(() -> {
+            new KafkaSource<>(vertx, "my-group",
+                    new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+        }).isInstanceOf(DeploymentException.class).hasMessageContaining("mine");
+    }
+
+    @Test
+    public void testWithRebalanceListenerMatchGivenName() {
+        addBeans(NamedRebalanceListener.class);
+        MapBasedConfig config = commonConfiguration();
+        config.with("consumer-rebalance-listener.name", "mine");
+        KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getStream()
+                .subscribe().with(list::add);
+
+        Map<TopicPartition, Long> offsets = new HashMap<>();
+        offsets.put(new TopicPartition(TOPIC, 0), 0L);
+        offsets.put(new TopicPartition(TOPIC, 1), 0L);
+        consumer.updateBeginningOffsets(offsets);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v"));
+        });
+
+        await().until(() -> list.size() == 1);
+        assertThat(list).hasSize(1);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 1)));
+            ConsumerRecord<String, String> record = new ConsumerRecord<>(TOPIC, 1, 0, "k", "v");
+            consumer.addRecord(record);
+        });
+
+        await().until(() -> list.size() == 2);
+        assertThat(list).hasSize(2);
+    }
+
+    private MapBasedConfig commonConfiguration() {
+        return new MapBasedConfig()
+                .with("channel-name", "channel")
+                .with("topic", TOPIC)
+                .with("health-enabled", false)
+                .with("value.deserializer", StringDeserializer.class.getName());
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void injectMockConsumer(KafkaSource<String, String> source, MockConsumer<String, String> consumer) {
+        try {
+            KafkaConsumer<String, String> cons = source.getConsumer();
+            KafkaReadStream stream = cons.getDelegate().asStream();
+            Field field = stream.getClass().getDeclaredField("consumer");
+            field.setAccessible(true);
+            field.set(stream, consumer);
+            // Close the initial consumer.
+            cons.closeAndAwait();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to inject mock consumer", e);
+        }
+    }
+
+    public Instance<KafkaConsumerRebalanceListener> getConsumerRebalanceListeners() {
+        return getBeanManager().createInstance().select(KafkaConsumerRebalanceListener.class);
+    }
+
+    @ApplicationScoped
+    @Named("mine")
+    public static class NamedRebalanceListener implements KafkaConsumerRebalanceListener {
+
+        @Override
+        public Uni<Void> onPartitionsAssigned(
+                KafkaConsumer<?, ?> consumer, Set<io.vertx.kafka.client.common.TopicPartition> topicPartitions) {
+            return Uni.createFrom().nullItem();
+        }
+
+        @Override
+        public Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer,
+                Set<io.vertx.kafka.client.common.TopicPartition> topicPartitions) {
+            return Uni.createFrom().nullItem();
+        }
+    }
+
+    @ApplicationScoped
+    @Named("mine")
+    public static class SameNameRebalanceListener extends NamedRebalanceListener implements KafkaConsumerRebalanceListener {
+
+    }
+
+}


### PR DESCRIPTION
Instead of committing the last polled offset, commit for each partition the higher offset. 

Also, improve the tests and fix unknown properties in the admin client.

@pcasaes can you have a look?