### PR TITLE
lookup for CamelReactiveStreamsService before creating an instance

### DIFF
--- a/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/i18n/CamelExceptions.java
+++ b/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/i18n/CamelExceptions.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.camel.i18n;
 
 import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
 
@@ -17,5 +18,8 @@ public interface CamelExceptions {
 
     @Message(id = 17600, value = "Unknown failure strategy: %s")
     IllegalArgumentException illegalArgumentUnknownStrategy(CamelFailureHandler.Strategy strategy);
+
+    @Message(id = 17601, value = "Unable to register CamelReactiveStreamsService service")
+    IllegalStateException unableToRegisterService(@Cause Throwable cause);
 
 }

--- a/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/i18n/CamelLogging.java
+++ b/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/i18n/CamelLogging.java
@@ -48,4 +48,7 @@ public interface CamelLogging extends BasicLogger {
     @Message(id = 17807, value = "A message sent to channel `%s` has been nacked, fail-stop")
     void messageNackedFailStop(String channel);
 
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 17808, value = "The Camel Reactive Stream Service is already defined, skipping configuration")
+    void camelReactiveStreamsServiceAlreadyDefined();
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -288,7 +288,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 () -> new ProducerRecord<>("data-2", counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
-        assertThat(list).containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertThat(list).containsOnly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
         List<KafkaRecord<String, Integer>> messages = bean.getKafkaMessages();
         messages.forEach(m -> {


### PR DESCRIPTION
Also, register the created instance in the Camel service registry

Fix #781 