### PR TITLE
CDI Events for Consumer/Producer

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaCDIEvents.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaCDIEvents.java
@@ -1,0 +1,28 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+
+@ApplicationScoped
+public class KafkaCDIEvents {
+    @Inject
+    Event<Consumer<?, ?>> consumerEvent;
+
+    @Inject
+    Event<Producer<?, ?>> producerEvent;
+
+    public Event<Consumer<?, ?>> consumer() {
+        return consumerEvent;
+    }
+
+    public Event<Producer<?, ?>> producer() {
+        return producerEvent;
+    }
+
+    public KafkaCDIEvents() {
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
@@ -30,6 +30,7 @@ import io.smallrye.mutiny.subscription.UniEmitter;
 import io.smallrye.reactive.messaging.TracingMetadata;
 import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
 import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.kafka.KafkaCDIEvents;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorOutgoingConfiguration;
 import io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecordMetadata;
 import io.smallrye.reactive.messaging.kafka.Record;
@@ -56,7 +57,7 @@ public class KafkaSink {
     private final boolean writeCloudEvents;
     private final boolean mandatoryCloudEventAttributeSet;
 
-    public KafkaSink(Vertx vertx, KafkaConnectorOutgoingConfiguration config) {
+    public KafkaSink(Vertx vertx, KafkaConnectorOutgoingConfiguration config, KafkaCDIEvents kafkaCDIEvents) {
         JsonObject kafkaConfiguration = extractProducerConfiguration(config);
 
         Map<String, Object> kafkaConfigurationMap = kafkaConfiguration.getMap();
@@ -67,8 +68,10 @@ public class KafkaSink {
             } else {
                 log.unableToWrite(config.getChannel(), e);
             }
-
         });
+
+        // fire producer event (e.g. bind metrics)
+        kafkaCDIEvents.producer().fire(stream.unwrap());
 
         partition = config.getPartition();
         retries = config.getRetries();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/CountKafkaCdiEvents.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/CountKafkaCdiEvents.java
@@ -1,0 +1,89 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.lang.annotation.Annotation;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.LongAdder;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.event.NotificationOptions;
+import javax.enterprise.util.TypeLiteral;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+
+public class CountKafkaCdiEvents extends KafkaCDIEvents {
+    public static final KafkaCDIEvents noCdiEvents = new CountKafkaCdiEvents();
+
+    public final LongAdder firedConsumerEvents = new LongAdder();
+    public final LongAdder firedProducerEvents = new LongAdder();
+
+    public CountKafkaCdiEvents() {
+        this.consumerEvent = new Event<Consumer<?, ?>>() {
+            @Override
+            public void fire(Consumer<?, ?> event) {
+                firedConsumerEvents.increment();
+            }
+
+            @Override
+            public <U extends Consumer<?, ?>> CompletionStage<U> fireAsync(U event) {
+                firedConsumerEvents.increment();
+                return null;
+            }
+
+            @Override
+            public <U extends Consumer<?, ?>> CompletionStage<U> fireAsync(U event, NotificationOptions options) {
+                firedConsumerEvents.increment();
+                return null;
+            }
+
+            @Override
+            public Event<Consumer<?, ?>> select(Annotation... qualifiers) {
+                return null;
+            }
+
+            @Override
+            public <U extends Consumer<?, ?>> Event<U> select(Class<U> subtype, Annotation... qualifiers) {
+                return null;
+            }
+
+            @Override
+            public <U extends Consumer<?, ?>> Event<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+                return null;
+            }
+        };
+
+        this.producerEvent = new Event<Producer<?, ?>>() {
+            @Override
+            public void fire(Producer<?, ?> event) {
+                firedProducerEvents.increment();
+            }
+
+            @Override
+            public <U extends Producer<?, ?>> CompletionStage<U> fireAsync(U event) {
+                firedProducerEvents.increment();
+                return null;
+            }
+
+            @Override
+            public <U extends Producer<?, ?>> CompletionStage<U> fireAsync(U event, NotificationOptions options) {
+                firedProducerEvents.increment();
+                return null;
+            }
+
+            @Override
+            public Event<Producer<?, ?>> select(Annotation... qualifiers) {
+                return null;
+            }
+
+            @Override
+            public <U extends Producer<?, ?>> Event<U> select(Class<U> subtype, Annotation... qualifiers) {
+                return null;
+            }
+
+            @Override
+            public <U extends Producer<?, ?>> Event<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+                return null;
+            }
+        };
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
@@ -61,7 +61,7 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("partition", 0)
                 .with("channel-name", "testSinkUsingInteger");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 10)
@@ -87,7 +87,7 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("value.deserializer", IntegerDeserializer.class.getName())
                 .with("partition", 0);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 10)
@@ -114,7 +114,7 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("partition", 0)
                 .with("channel-name", "testSinkUsingString");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 10)
@@ -229,7 +229,8 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("failure-strategy", "ignore")
                 .with("retries", 0L); // disable retry.
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        CountKafkaCdiEvents testCdiEvents = new CountKafkaCdiEvents();
+        sink = new KafkaSink(vertx, oc, testCdiEvents);
 
         await().until(() -> {
             HealthReport.HealthReportBuilder builder = HealthReport.builder();
@@ -262,6 +263,9 @@ public class KafkaSinkTest extends KafkaTestBase {
         await().until(() -> nacked.size() >= 2);
         assertThat(acked).containsExactly(0, 1, 2, 4);
         assertThat(nacked).contains("3", "5");
+
+        assertThat(testCdiEvents.firedConsumerEvents.sum()).isEqualTo(0);
+        assertThat(testCdiEvents.firedProducerEvents.sum()).isEqualTo(1);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -281,7 +285,7 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("retries", 0L)
                 .with("channel-name", "testInvalidTypeWithDefaultInflightMessages");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 5)

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -54,7 +54,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -78,7 +78,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         createTopic(topic, 3);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -102,7 +102,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<KafkaRecord> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -123,11 +123,16 @@ public class KafkaSourceTest extends KafkaTestBase {
         MapBasedConfig config = newCommonConfigForSource()
                 .with("value.deserializer", IntegerDeserializer.class.getName())
                 .with("broadcast", true);
+
+        CountKafkaCdiEvents testEvents = new CountKafkaCdiEvents();
+
         connector = new KafkaConnector();
         connector.executionHolder = new ExecutionHolder(vertx);
         connector.defaultKafkaConfiguration = UnsatisfiedInstance.instance();
         connector.consumerRebalanceListeners = getConsumerRebalanceListeners();
+        connector.kafkaCDIEvents = testEvents;
         connector.init();
+
         PublisherBuilder<? extends KafkaRecord> builder = (PublisherBuilder<? extends KafkaRecord>) connector
                 .getPublisherBuilder(config);
 
@@ -147,6 +152,9 @@ public class KafkaSourceTest extends KafkaTestBase {
                         5, 6, 7, 8, 9);
         assertThat(messages2.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
                 .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+        assertThat(testEvents.firedConsumerEvents.sum()).isEqualTo(1);
+        assertThat(testEvents.firedProducerEvents.sum()).isEqualTo(0);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -162,7 +170,9 @@ public class KafkaSourceTest extends KafkaTestBase {
         connector.executionHolder = new ExecutionHolder(vertx);
         connector.defaultKafkaConfiguration = UnsatisfiedInstance.instance();
         connector.consumerRebalanceListeners = getConsumerRebalanceListeners();
+        connector.kafkaCDIEvents = new CountKafkaCdiEvents();
         connector.init();
+
         PublisherBuilder<? extends KafkaRecord> builder = (PublisherBuilder<? extends KafkaRecord>) connector
                 .getPublisherBuilder(config);
 
@@ -194,7 +204,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("retry-max-wait", 30);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
         List<KafkaRecord> messages1 = new ArrayList<>();
         source.getStream().subscribe().with(messages1::add);
 
@@ -402,7 +412,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -468,7 +478,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("sasl.mechanism", ""); //optional configuration
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
@@ -22,6 +22,7 @@ import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
+import io.smallrye.reactive.messaging.kafka.KafkaCDIEvents;
 import io.smallrye.reactive.messaging.kafka.KafkaConnector;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaThrottledLatestProcessedCommit;
 
@@ -48,6 +49,7 @@ public class WeldTestBase {
         weld.addBeanClass(HealthCenter.class);
         weld.addExtension(new ReactiveMessagingExtension());
 
+        weld.addBeanClass(KafkaCDIEvents.class);
         weld.addBeanClass(KafkaConnector.class);
         weld.disableDiscovery();
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSinkWithCloudEventsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSinkWithCloudEventsTest.java
@@ -54,7 +54,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -101,7 +101,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -147,7 +147,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -195,7 +195,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Message<?> message = Message.of("hello").addMetadata(OutgoingCloudEventMetadata.builder()
                 .withSource(URI.create("test://test"))
@@ -228,7 +228,8 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
 
-        assertThatThrownBy(() -> new KafkaSink(vertx, oc)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -240,7 +241,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -286,7 +287,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-type", "my type");
         config.put("cloud-events-source", "http://acme.org");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -328,7 +329,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-type", "my type");
         config.put("cloud-events-source", "http://acme.org");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -366,7 +367,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -411,7 +412,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -451,7 +452,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -495,7 +496,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -540,7 +541,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-type", "my type");
         config.put("cloud-events-source", "http://acme.org");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -581,7 +582,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-type", "my type");
         config.put("cloud-events-source", "http://acme.org");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -617,7 +618,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Message<?> message = Message.of("hello").addMetadata(OutgoingCloudEventMetadata.builder()
                 .withSource(URI.create("test://test"))
@@ -651,7 +652,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("key", "my-key");
         config.put("cloud-events", false);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -685,7 +686,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc);
+        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceWithCloudEventsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceWithCloudEventsTest.java
@@ -53,7 +53,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -115,7 +115,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -173,7 +173,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -228,7 +228,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -264,7 +264,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -302,7 +302,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -367,7 +367,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -432,7 +432,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -573,7 +573,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events", false);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -617,7 +617,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events", false);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -663,7 +663,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.CountKafkaCdiEvents;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
 import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
@@ -56,7 +57,8 @@ public class CommitStrategiesTest extends WeldTestBase {
     void testLatestCommitStrategy() {
         MapBasedConfig config = commonConfiguration();
         KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents);
         injectMockConsumer(source, consumer);
 
         List<Message<?>> list = new ArrayList<>();
@@ -145,7 +147,8 @@ public class CommitStrategiesTest extends WeldTestBase {
                 .with("commit-strategy", "throttled")
                 .with("auto.commit.interval.ms", 100);
         KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents);
         injectMockConsumer(source, consumer);
 
         List<Message<?>> list = new ArrayList<>();
@@ -204,7 +207,8 @@ public class CommitStrategiesTest extends WeldTestBase {
         config.with("consumer-rebalance-listener.name", "my-missing-name");
         assertThatThrownBy(() -> {
             new KafkaSource<>(vertx, "my-group",
-                    new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+                    new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                    CountKafkaCdiEvents.noCdiEvents);
         }).isInstanceOf(UnsatisfiedResolutionException.class);
     }
 
@@ -215,7 +219,8 @@ public class CommitStrategiesTest extends WeldTestBase {
         config.with("consumer-rebalance-listener.name", "mine");
         assertThatThrownBy(() -> {
             new KafkaSource<>(vertx, "my-group",
-                    new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+                    new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                    CountKafkaCdiEvents.noCdiEvents);
         }).isInstanceOf(DeploymentException.class).hasMessageContaining("mine");
     }
 
@@ -225,7 +230,8 @@ public class CommitStrategiesTest extends WeldTestBase {
         MapBasedConfig config = commonConfiguration();
         config.with("consumer-rebalance-listener.name", "mine");
         KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners());
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents);
 
         injectMockConsumer(source, consumer);
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.kafka.CountKafkaCdiEvents;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.smallrye.reactive.messaging.kafka.KafkaRecord;
@@ -61,7 +62,8 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         source = new KafkaSource<>(vertx,
                 "test-source-with-auto-commit-enabled",
                 ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = Collections.synchronizedList(new ArrayList<>());
         source.getStream().subscribe().with(messages::add);
@@ -117,7 +119,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
 
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, "test-source-with-auto-commit-disabled", ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = Collections.synchronizedList(new ArrayList<>());
         source.getStream().subscribe().with(messages::add);
@@ -165,7 +167,8 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit", ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = Collections.synchronizedList(new ArrayList<>());
         source.getStream().subscribe().with(messages::add);
@@ -224,7 +227,8 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit-without-acking", ic,
-                getConsumerRebalanceListeners());
+                getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = Collections.synchronizedList(new ArrayList<>());
         source.getStream().subscribe().with(messages::add);


### PR DESCRIPTION
Skipping qualifier for create/delete for now.. so the event is only for create. 
Some other detection (or maybe a separate event entirely) would be needed for destroy.