### PR TITLE
Make the rebalance listeners blocking 

### DIFF
--- a/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumerRebalanceListener.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumerRebalanceListener.java
@@ -1,21 +1,15 @@
 package inbound;
 
-import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 @ApplicationScoped
 @Named("rebalanced-example.rebalancer")
@@ -27,10 +21,11 @@ public class KafkaRebalancedConsumerRebalanceListener implements KafkaConsumerRe
      * When receiving a list of partitions will search for the earliest offset within 10 minutes
      * and seek the consumer to it.
      *
-     * @param consumer        underlying consumer
+     * @param consumer   underlying consumer
      * @param partitions set of assigned topic partitions
      */
-    @Override public void onPartitionsAssigned(Consumer<?, ?> consumer,
+    @Override
+    public void onPartitionsAssigned(Consumer<?, ?> consumer,
         Collection<org.apache.kafka.common.TopicPartition> partitions) {
         long now = System.currentTimeMillis();
         long shouldStartAt = now - 600_000L; //10 minute ago

--- a/documentation/src/main/doc/modules/kafka/pages/consumer-rebalance-listener.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/consumer-rebalance-listener.adoc
@@ -1,17 +1,27 @@
 [#kafka-consumer-rebalance-listener]
 === Consumer Rebalance Listener
 
-An implementation of the consumer re-balance listener can be provided which affords us fine grain controls of the assigned
-offset. Common uses are storing offsets in a separate store to enable deliver exactly-once semantics, and starting from
-a specific time window.
+To handle offset commit and assigned partitions yourself, you can provide a consumer rebalance listener.
+To achieve this, implement the `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener` interface and exposed it as a `@Named` bean.
+A usual use case is to store offset in a separate data store to implement exactly-once semantic, or starting the processing at a specific offset.
 
-Whenever the topic partitions assigned method is called the consumer will pause. It will only resume once the returned
-Uni succeeds. In the case of failure it will retry until success or until the consumer session times out in which case
-it will resume again forcing a new consumer re-balance.
+The listener is invoked every time the consumer topic/partition assignment changes.
+For example, when the application starts, it invokes the `partitionsAssigned` callback with the initial set of topics/partitions associated with the consumer.
+If, later, this set changes, it calls the `partitionsRevoked` and `partitionsAssigned` callbacks again, so you can implement custom logic.
+
+Note that the rebalance listener methods are called from the Kafka _polling_ thread and must block the caller thread until completion.
+That's because the rebalance protocol has synchronization barriers, and using asynchronous code in a rebalance listener may be executed after the synchronization barrier.
+
+When topics/partitions are assigned or revoked from a consumer, it pauses the message delivery and restarts once the rebalance completes.
+
+If the rebalance listener handles offset commit on behalf of the user (using the `ignore` commit strategy), the rebalance listener **must** commit the offset synchronously in the `partitionsRevoked` callback.
+We also recommend applying the same logic when the application stops.
+
+Unlike the `ConsumerRebalanceListener`  from Apache Kafka, the `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener` methods pass the Kafka `Consumer` and the set of topics/partitions.
 
 ==== Example
 
-In this example we will set-up a consumer that always starts on messages from at most 10 minutes ago. First we need to provide
+In this example we set-up a consumer that always starts on messages from at most 10 minutes ago (of offset 0). First we need to provide
 a bean managed implementation of `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener` annotated with
 `javax.inject.Named`. We then must configure our inbound connector to use this named bean.
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
@@ -1,8 +1,10 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import java.util.Set;
+import java.time.Duration;
+import java.util.Collection;
 
-import io.smallrye.mutiny.Uni;
+import org.apache.kafka.clients.consumer.Consumer;
+
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 
@@ -35,33 +37,105 @@ import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 public interface KafkaConsumerRebalanceListener {
 
     /**
-     * Called when the consumer is assigned topic partitions
-     * This method might be called for each consumer available to the connector
+     * A callback method the user can implement to provide handling of customized offsets on completion of a successful
+     * partition re-assignment. This method will be called after the partition re-assignment completes and before the
+     * consumer starts fetching data, and only as the result of a {@link Consumer#poll(java.time.Duration) poll(long)} call.
+     * <p>
+     * It is guaranteed that under normal conditions all the processes in a consumer group will execute their
+     * {@link #onPartitionsRevoked(Consumer, Collection)} callback before any instance executes this
+     * callback. During exceptional scenarios, partitions may be migrated
+     * without the old owner being notified (i.e. their {@link #onPartitionsRevoked(Consumer, Collection)} callback not
+     * triggered),
+     * and later when the old owner consumer realized this event, the {@link #onPartitionsLost(Consumer, Collection)}
+     * (Collection)} callback
+     * will be triggered by the consumer then.
+     * <p>
+     * It is common for the assignment callback to use the consumer instance in order to query offsets. It is possible
+     * for a {@link org.apache.kafka.common.errors.WakeupException} or {@link org.apache.kafka.common.errors.InterruptException}
+     * to be raised from one of these nested invocations. In this case, the exception will be propagated to the current
+     * invocation of {@link org.apache.kafka.clients.consumer.KafkaConsumer#poll(java.time.Duration)} in which this callback is
+     * being executed. This means it is not
+     * necessary to catch these exceptions and re-attempt to wakeup or interrupt the consumer thread.
      *
-     * The consumer will be paused until the returned {@link Uni}
-     * indicates success. On failure will retry using an exponential back off until the consumer can
-     * be considered timed-out by Kafka, in which case will resume anyway triggering a new re-balance.
+     * <strong>IMPORTANT</strong>: The behavior must be blocking. Callback invoked from the polling thread.
      *
-     * @see KafkaConsumer#pause()
-     * @see KafkaConsumer#resume()
-     *
-     * @param consumer underlying consumer
-     * @param topicPartitions set of assigned topic partitions
-     * @return A {@link Uni} indicating operations complete or failure
+     * @param partitions The list of partitions that are now assigned to the consumer (previously owned partitions will
+     *        NOT be included, i.e. this list will only include newly added partitions)
+     * @throws org.apache.kafka.common.errors.WakeupException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+     * @throws org.apache.kafka.common.errors.InterruptException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
      */
-    Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions);
+    default void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<org.apache.kafka.common.TopicPartition> partitions) {
+
+    }
 
     /**
-     * Called when the consumer is revoked topic partitions
-     * This method might be called for each consumer available to the connector.
+     * A callback method the user can implement to provide handling of offset commits to a customized store.
+     * This method will be called during a rebalance operation when the consumer has to give up some partitions.
+     * It can also be called when consumer is being closed
+     * ({@link org.apache.kafka.clients.consumer.KafkaConsumer#close(Duration)})
+     * or is unsubscribing ({@link org.apache.kafka.clients.consumer.KafkaConsumer#unsubscribe()}).
+     * It is recommended that offsets should be committed in this callback to either Kafka or a
+     * custom offset store to prevent duplicate data.
+     * <p>
+     * In eager rebalancing, it will always be called at the start of a rebalance and after the consumer stops fetching data.
+     * In cooperative rebalancing, it will be called at the end of a rebalance on the set of partitions being revoked iff the
+     * set is non-empty.
+     * For examples on usage of this API, see Usage Examples section of {@link org.apache.kafka.clients.consumer.KafkaConsumer
+     * KafkaConsumer}.
+     * <p>
+     * It is common for the revocation callback to use the consumer instance in order to commit offsets. It is possible
+     * for a {@link org.apache.kafka.common.errors.WakeupException} or {@link org.apache.kafka.common.errors.InterruptException}
+     * to be raised from one of these nested invocations. In this case, the exception will be propagated to the current
+     * invocation of {@link org.apache.kafka.clients.consumer.KafkaConsumer#poll(java.time.Duration)} in which this callback is
+     * being executed. This means it is not
+     * necessary to catch these exceptions and re-attempt to wakeup or interrupt the consumer thread.
      *
-     * If the implementation handles its own offsets and commit, it must use the `ignored` commit strategy.
-     * In this case, implementation <strong>must</strong> commits the offset of the processed records coming from the
-     * revoked partitions in this method.
+     * <strong>IMPORTANT</strong>: The behavior must be blocking. Callback invoked from the polling thread.
      *
-     * @param consumer underlying consumer
-     * @param topicPartitions set of revoked topic partitions
-     * @return A {@link Uni} indicating operations complete or failure
+     * @param partitions The list of partitions that were assigned to the consumer and now need to be revoked (may not
+     *        include all currently assigned partitions, i.e. there may still be some partitions left)
+     * @throws org.apache.kafka.common.errors.WakeupException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+     * @throws org.apache.kafka.common.errors.InterruptException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
      */
-    Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions);
+    default void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<org.apache.kafka.common.TopicPartition> partitions) {
+
+    }
+
+    /**
+     * A callback method you can implement to provide handling of cleaning up resources for partitions that have already
+     * been reassigned to other consumers. This method will not be called during normal execution as the owned partitions would
+     * first be revoked by calling the {@link #onPartitionsRevoked}, before being reassigned
+     * to other consumers during a rebalance event. However, during exceptional scenarios when the consumer realized that it
+     * does not own this partition any longer, i.e. not revoked via a normal rebalance event, then this method would be invoked.
+     * <p>
+     * For example, this function is called if a consumer's session timeout has expired, or if a fatal error has been
+     * received indicating the consumer is no longer part of the group.
+     * <p>
+     * By default it will just trigger {@link #onPartitionsRevoked}; for users who want to distinguish
+     * the handling logic of revoked partitions v.s. lost partitions, they can override the default implementation.
+     * <p>
+     * It is possible
+     * for a {@link org.apache.kafka.common.errors.WakeupException} or {@link org.apache.kafka.common.errors.InterruptException}
+     * to be raised from one of these nested invocations. In this case, the exception will be propagated to the current
+     * invocation of {@link org.apache.kafka.clients.consumer.KafkaConsumer#poll(java.time.Duration)} in which this callback is
+     * being executed. This means it is not
+     * necessary to catch these exceptions and re-attempt to wakeup or interrupt the consumer thread.
+     *
+     * @param partitions The list of partitions that were assigned to the consumer and now have been reassigned
+     *        to other consumers. With the current protocol this will always include all of the consumer's
+     *        previously assigned partitions, but this may change in future protocols (ie there would still
+     *        be some partitions left)
+     * @throws org.apache.kafka.common.errors.WakeupException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+     * @throws org.apache.kafka.common.errors.InterruptException If raised from a nested call to
+     *         {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+     */
+    default void onPartitionsLost(Consumer<?, ?> consumer, Collection<org.apache.kafka.common.TopicPartition> partitions) {
+        onPartitionsRevoked(consumer, partitions);
+    }
+
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ContextHolder.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ContextHolder.java
@@ -1,11 +1,8 @@
 package io.smallrye.reactive.messaging.kafka.commit;
 
 import java.lang.reflect.Field;
-import java.time.Duration;
 import java.util.concurrent.*;
 
-import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.errors.WakeupException;
 
 import io.vertx.kafka.client.consumer.KafkaReadStream;
@@ -22,10 +19,9 @@ public class ContextHolder {
     private final int timeout;
     protected volatile Context context;
 
-    public ContextHolder(Vertx vertx, KafkaConnectorIncomingConfiguration configuration) {
+    public ContextHolder(Vertx vertx, int defaultTimeout) {
         this.vertx = vertx;
-        this.timeout = configuration.config().getOptionalValue(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, Integer.class)
-            .orElse(60000);
+        this.timeout = defaultTimeout;
     }
 
     public void capture(KafkaReadStream<?, ?> stream) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ContextHolder.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ContextHolder.java
@@ -3,7 +3,7 @@ package io.smallrye.reactive.messaging.kafka.commit;
 import java.lang.reflect.Field;
 import java.util.concurrent.*;
 
-import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.errors.InterruptException;
 
 import io.vertx.kafka.client.consumer.KafkaReadStream;
 import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
@@ -57,8 +57,8 @@ public class ContextHolder {
         try {
             return task.get(timeout, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new WakeupException();
+            // The InterruptException reset the interruption flag.
+            throw new InterruptException(e);
         } catch (ExecutionException | TimeoutException e) {
             throw new CompletionException(e);
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.kafka.commit;
 
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions.ex;
 
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
@@ -38,11 +39,11 @@ public interface KafkaCommitHandler {
         // Do nothing by default.
     }
 
-    default void partitionsAssigned(Set<TopicPartition> partitions) {
+    default void partitionsAssigned(Collection<TopicPartition> partitions) {
         // Do nothing by default.
     }
 
-    default void partitionsRevoked(Set<TopicPartition> partitions) {
+    default void partitionsRevoked(Collection<TopicPartition> partitions) {
         // Do nothing by default.
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
@@ -3,7 +3,6 @@ package io.smallrye.reactive.messaging.kafka.commit;
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions.ex;
 
 import java.util.Collection;
-import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
@@ -5,7 +5,10 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
@@ -33,8 +36,10 @@ public class KafkaLatestCommit extends ContextHolder implements KafkaCommitHandl
      */
     private final Map<TopicPartition, Long> offsets = new HashMap<>();
 
-    public KafkaLatestCommit(Vertx vertx, io.vertx.mutiny.kafka.client.consumer.KafkaConsumer<?, ?> consumer) {
-        super(vertx);
+    public KafkaLatestCommit(Vertx vertx, KafkaConnectorIncomingConfiguration configuration,
+            io.vertx.mutiny.kafka.client.consumer.KafkaConsumer<?, ?> consumer) {
+        super(vertx, configuration.config()
+                .getOptionalValue(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, Integer.class).orElse(60000));
         this.consumer = (KafkaConsumer<?, ?>) consumer.getDelegate();
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -1,5 +1,12 @@
 package io.smallrye.reactive.messaging.kafka.commit;
 
+import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+
 import io.smallrye.mutiny.tuples.Tuple2;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
@@ -10,12 +17,6 @@ import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-
-import java.util.*;
-import java.util.concurrent.*;
-
-import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
 /**
  * Will keep track of received messages and commit to the next offset after the latest
@@ -47,12 +48,12 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
     private volatile long timerId = -1;
 
     private KafkaThrottledLatestProcessedCommit(
-        Vertx vertx,
-        KafkaConsumer<?, ?> consumer,
-        KafkaSource<?, ?> source,
-        int unprocessedRecordMaxAge,
-        int autoCommitInterval,
-        int defaultTimeout) {
+            Vertx vertx,
+            KafkaConsumer<?, ?> consumer,
+            KafkaSource<?, ?> source,
+            int unprocessedRecordMaxAge,
+            int autoCommitInterval,
+            int defaultTimeout) {
         super(vertx, defaultTimeout);
         this.consumer = consumer;
         this.source = source;
@@ -65,19 +66,19 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
     }
 
     public static KafkaThrottledLatestProcessedCommit create(
-        Vertx vertx,
-        KafkaConsumer<?, ?> consumer,
-        String groupId,
-        KafkaConnectorIncomingConfiguration config,
-        KafkaSource<?, ?> source) {
+            Vertx vertx,
+            KafkaConsumer<?, ?> consumer,
+            String groupId,
+            KafkaConnectorIncomingConfiguration config,
+            KafkaSource<?, ?> source) {
 
         int unprocessedRecordMaxAge = config.getThrottledUnprocessedRecordMaxAgeMs();
         int autoCommitInterval = config.config()
-            .getOptionalValue(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, Integer.class)
-            .orElse(5000);
+                .getOptionalValue(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, Integer.class)
+                .orElse(5000);
         int defaultTimeout = config.config()
-            .getOptionalValue(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, Integer.class)
-            .orElse(60000);
+                .getOptionalValue(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, Integer.class)
+                .orElse(60000);
         log.settingCommitInterval(groupId, autoCommitInterval);
         if (unprocessedRecordMaxAge <= 0) {
             log.disableThrottledCommitStrategyHealthCheck(groupId);
@@ -85,14 +86,14 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
             log.setThrottledCommitStrategyReceivedRecordMaxAge(groupId, unprocessedRecordMaxAge);
         }
         return new KafkaThrottledLatestProcessedCommit(vertx, consumer, source, unprocessedRecordMaxAge,
-            autoCommitInterval, defaultTimeout);
+                autoCommitInterval, defaultTimeout);
 
     }
 
     private <K, V> TopicPartition getTopicPartition(IncomingKafkaRecord<K, V> record) {
         return TOPIC_PARTITIONS_CACHE
-            .computeIfAbsent(record.getTopic(), topic -> new ConcurrentHashMap<>())
-            .computeIfAbsent(record.getPartition(), partition -> new TopicPartition(record.getTopic(), partition));
+                .computeIfAbsent(record.getTopic(), topic -> new ConcurrentHashMap<>())
+                .computeIfAbsent(record.getPartition(), partition -> new TopicPartition(record.getTopic(), partition));
     }
 
     /**
@@ -100,7 +101,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
      * This method is called from the Kafka pool thread.
      *
      * @param partitions the list of partitions that are now assigned to the consumer
-     *                   (may include partitions previously assigned to the consumer)
+     *        (may include partitions previously assigned to the consumer)
      */
     @Override
     public void partitionsAssigned(Collection<TopicPartition> partitions) {
@@ -162,15 +163,14 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
      * @return the converted map.
      */
     private static Map<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata> unwrap(
-        Map<TopicPartition, OffsetAndMetadata> map) {
+            Map<TopicPartition, OffsetAndMetadata> map) {
         HashMap<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata> result = new HashMap<>();
         for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : map.entrySet()) {
             TopicPartition tp = entry.getKey();
             OffsetAndMetadata off = entry.getValue();
             result.put(
-                new org.apache.kafka.common.TopicPartition(tp.getTopic(), tp.getPartition()),
-                new org.apache.kafka.clients.consumer.OffsetAndMetadata(off.getOffset(), off.getMetadata())
-            );
+                    new org.apache.kafka.common.TopicPartition(tp.getTopic(), tp.getPartition()),
+                    new org.apache.kafka.clients.consumer.OffsetAndMetadata(off.getOffset(), off.getMetadata()));
         }
         return result;
     }
@@ -200,8 +200,8 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
      * This method is called from a Vert.x event loop.
      *
      * @param record the record
-     * @param <K>    the key
-     * @param <V>    the value
+     * @param <K> the key
+     * @param <V> the value
      * @return the record
      */
     @Override
@@ -209,8 +209,8 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
         TopicPartition recordsTopicPartition = getTopicPartition(record);
 
         offsetStores
-            .computeIfAbsent(recordsTopicPartition, k -> new OffsetStore(k, unprocessedRecordMaxAge))
-            .received(record.getOffset());
+                .computeIfAbsent(recordsTopicPartition, k -> new OffsetStore(k, unprocessedRecordMaxAge))
+                .received(record.getOffset());
 
         if (timerId < 0) {
             startFlushAndCheckHealthTimer();
@@ -229,7 +229,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
 
         for (Map.Entry<TopicPartition, OffsetStore> entry : offsetStores.entrySet()) {
             long offset = entry.getValue()
-                .clearLesserSequentiallyProcessedOffsetsAndReturnLargestOffset();
+                    .clearLesserSequentiallyProcessedOffsetsAndReturnLargestOffset();
             if (offset > -1) {
                 offsetsMapping.put(entry.getKey(), offset);
             }
@@ -243,8 +243,8 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
      * This method is NOT necessarily called on an event loop.
      *
      * @param record the record
-     * @param <K>    the key
-     * @param <V>    the value
+     * @param <K> the key
+     * @param <V> the value
      * @return a completion stage indicating when the commit complete
      */
     @Override
@@ -254,8 +254,8 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
         // or partition assignment.
         runOnContext(() -> {
             offsetStores
-                .get(getTopicPartition(record))
-                .processed(record.getOffset());
+                    .get(getTopicPartition(record))
+                    .processed(record.getOffset());
             future.complete(null);
         });
         return future;
@@ -279,10 +279,10 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
 
         if (this.unprocessedRecordMaxAge > 0) {
             offsetStores
-                .values()
-                .stream()
-                .filter(OffsetStore::hasTooManyMessagesWithoutAck)
-                .forEach(o -> this.source.reportFailure(new TooManyMessagesWithoutAckException()));
+                    .values()
+                    .stream()
+                    .filter(OffsetStore::hasTooManyMessagesWithoutAck)
+                    .forEach(o -> this.source.reportFailure(new TooManyMessagesWithoutAckException()));
         }
 
     }
@@ -381,7 +381,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
 
     private void commitAllAndAwait() {
         Map<TopicPartition, Long> offsetsMapping = runOnContextAndAwait(
-            this::clearLesserSequentiallyProcessedOffsetsAndReturnLargestOffsetMapping);
+                this::clearLesserSequentiallyProcessedOffsetsAndReturnLargestOffsetMapping);
         commitAndAwait(offsetsMapping);
     }
 
@@ -393,7 +393,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
             consumer.getDelegate().commit(offsets, new Handler<AsyncResult<Map<TopicPartition, OffsetAndMetadata>>>() {
                 @Override
                 public void handle(
-                    AsyncResult<Map<TopicPartition, OffsetAndMetadata>> event) {
+                        AsyncResult<Map<TopicPartition, OffsetAndMetadata>> event) {
                     if (event.failed()) {
                         stage.completeExceptionally(event.cause());
                     } else {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -38,7 +38,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
 
     private static final Map<String, Map<Integer, TopicPartition>> TOPIC_PARTITIONS_CACHE = new ConcurrentHashMap<>();
 
-    private final Map<TopicPartition, OffsetStore> offsetStores = new HashMap<>();
+    private final Map<TopicPartition, OffsetStore> offsetStores = new ConcurrentHashMap<>();
 
     private final KafkaConsumer<?, ?> consumer;
     private final KafkaSource<?, ?> source;
@@ -98,12 +98,12 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
 
     /**
      * New partitions are assigned.
-     * This method is called from a Vert.x event loop (the one used by the Kafka client)
+     * This method is called from the Kafka pool thread.
      *
      * @param partitions the partitions
      */
     @Override
-    public void partitionsAssigned(Set<TopicPartition> partitions) {
+    public void partitionsAssigned(Collection<TopicPartition> partitions) {
         stopFlushAndCheckHealthTimer();
 
         if (!partitions.isEmpty() || !offsetStores.isEmpty()) {
@@ -113,12 +113,12 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
 
     /**
      * Revoked partitions.
-     * This method is called from a Vert.x event loop (the one used by the Kafka client)
+     * This method is called from the Kafka pool thread.
      *
      * @param partitions the partitions that we will no longer receive
      */
     @Override
-    public void partitionsRevoked(Set<TopicPartition> partitions) {
+    public void partitionsRevoked(Collection<TopicPartition> partitions) {
         stopFlushAndCheckHealthTimer();
 
         // Remove all handled partitions that are in the given list of revoked partitions

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -282,7 +282,7 @@ public class KafkaSource<K, V> {
         KafkaCommitHandler.Strategy actualStrategy = KafkaCommitHandler.Strategy.from(strategy);
         switch (actualStrategy) {
             case LATEST:
-                return new KafkaLatestCommit(vertx, consumer);
+                return new KafkaLatestCommit(vertx, configuration, consumer);
             case IGNORE:
                 return new KafkaIgnoreCommit();
             case THROTTLED:

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -11,9 +11,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.literal.NamedLiteral;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
@@ -37,7 +37,6 @@ import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.kafka.admin.KafkaAdminClient;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 
 public class KafkaSource<K, V> {
     private final Multi<IncomingKafkaRecord<K, V>> stream;
@@ -127,7 +126,7 @@ public class KafkaSource<K, V> {
         }
         this.consumer = kafkaConsumer;
         ConsumerRebalanceListener listener = RebalanceListeners
-            .createRebalanceListener(config, consumerGroup, consumerRebalanceListeners, consumer, commitHandler);
+                .createRebalanceListener(config, consumerGroup, consumerRebalanceListeners, consumer, commitHandler);
         RebalanceListeners.inject(this.consumer, listener);
 
         Multi<KafkaConsumerRecord<K, V>> multi = consumer.toMulti()

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
@@ -4,7 +4,6 @@ import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
 import java.lang.reflect.Field;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import javax.enterprise.inject.AmbiguousResolutionException;
 import javax.enterprise.inject.Instance;
@@ -19,17 +18,16 @@ import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler;
 import io.vertx.kafka.client.consumer.KafkaReadStream;
 import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
-import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 
 public class RebalanceListeners {
 
     static ConsumerRebalanceListener createRebalanceListener(
-        KafkaConnectorIncomingConfiguration config,
-        String consumerGroup,
-        Instance<KafkaConsumerRebalanceListener> instances,
-        KafkaConsumer<?, ?> consumer,
-        KafkaCommitHandler commitHandler) {
+            KafkaConnectorIncomingConfiguration config,
+            String consumerGroup,
+            Instance<KafkaConsumerRebalanceListener> instances,
+            KafkaConsumer<?, ?> consumer,
+            KafkaCommitHandler commitHandler) {
         Optional<KafkaConsumerRebalanceListener> rebalanceListener = findMatchingListener(config, consumerGroup, instances);
 
         if (rebalanceListener.isPresent()) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
@@ -1,0 +1,163 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import javax.enterprise.inject.AmbiguousResolutionException;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.literal.NamedLiteral;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
+
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
+import io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler;
+import io.vertx.kafka.client.consumer.KafkaReadStream;
+import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+
+public class RebalanceListeners {
+
+    static ConsumerRebalanceListener createRebalanceListener(
+        KafkaConnectorIncomingConfiguration config,
+        String consumerGroup,
+        Instance<KafkaConsumerRebalanceListener> instances,
+        KafkaConsumer<?, ?> consumer,
+        KafkaCommitHandler commitHandler) {
+        Optional<KafkaConsumerRebalanceListener> rebalanceListener = findMatchingListener(config, consumerGroup, instances);
+
+        if (rebalanceListener.isPresent()) {
+            KafkaConsumerRebalanceListener listener = rebalanceListener.get();
+            return new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                    long demand = consumer.demand();
+                    consumer.pause();
+                    log.executingConsumerRevokedRebalanceListener(consumerGroup);
+
+                    try {
+                        listener.onPartitionsRevoked(consumer.getDelegate().unwrap(), partitions);
+                        log.executedConsumerRevokedRebalanceListener(consumerGroup);
+                    } catch (RuntimeException e) {
+                        log.unableToExecuteConsumerRevokedRebalanceListener(consumerGroup, e);
+                        throw e;
+                    } finally {
+                        consumer.fetch(demand);
+                    }
+                }
+
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                    long demand = consumer.demand();
+                    consumer.pause();
+                    Collection<io.vertx.kafka.client.common.TopicPartition> tps = wrap(partitions);
+                    commitHandler.partitionsAssigned(tps);
+                    try {
+                        listener.onPartitionsAssigned(consumer.getDelegate().unwrap(), partitions);
+                        log.executedConsumerAssignedRebalanceListener(consumerGroup);
+                    } catch (RuntimeException e) {
+                        log.reEnablingConsumerForGroup(consumerGroup);
+                        throw e;
+                    } finally {
+                        consumer.fetch(demand);
+                    }
+                }
+            };
+        } else {
+            return new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                    Collection<io.vertx.kafka.client.common.TopicPartition> tps = wrap(partitions);
+                    long demand = consumer.demand();
+                    consumer.pause();
+                    try {
+                        commitHandler.partitionsRevoked(tps);
+                    } finally {
+                        consumer.fetch(demand);
+                    }
+                }
+
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                    Collection<io.vertx.kafka.client.common.TopicPartition> tps = wrap(partitions);
+                    long demand = consumer.demand();
+                    consumer.pause();
+                    try {
+                        commitHandler.partitionsAssigned(tps);
+                    } finally {
+                        consumer.fetch(demand);
+                    }
+                }
+            };
+        }
+    }
+
+    private static Collection<io.vertx.kafka.client.common.TopicPartition> wrap(Collection<TopicPartition> partitions) {
+        List<io.vertx.kafka.client.common.TopicPartition> tps = new ArrayList<>(partitions.size());
+        for (TopicPartition partition : partitions) {
+            tps.add(new io.vertx.kafka.client.common.TopicPartition(partition.topic(), partition.partition()));
+        }
+        return tps;
+    }
+
+    private static Optional<KafkaConsumerRebalanceListener> findMatchingListener(
+            KafkaConnectorIncomingConfiguration config, String consumerGroup,
+            Instance<KafkaConsumerRebalanceListener> instances) {
+        return config.getConsumerRebalanceListenerName()
+                .map(name -> {
+                    log.loadingConsumerRebalanceListenerFromConfiguredName(name);
+                    Instance<KafkaConsumerRebalanceListener> matching = instances.select(NamedLiteral.of(name));
+                    // We want to fail if a name if set, but no match or too many matches
+                    if (matching.isUnsatisfied()) {
+                        // TODO Extract
+                        throw new UnsatisfiedResolutionException(
+                                "Unable to find the rebalance listener " + name + " for channel " + config.getChannel());
+                    } else if (matching.stream().count() > 1) {
+                        // TODO Extract
+                        throw new AmbiguousResolutionException(
+                                "Unable to select the rebalance listener " + name + " for channel "
+                                        + config.getChannel() + " - too many matches");
+                    } else if (matching.stream().count() == 1) {
+                        return Optional.of(matching.get());
+                    } else {
+                        return Optional.<KafkaConsumerRebalanceListener> empty();
+                    }
+                })
+                .orElseGet(() -> {
+                    Instance<KafkaConsumerRebalanceListener> matching = instances.select(NamedLiteral.of(consumerGroup));
+                    if (!matching.isUnsatisfied()) {
+                        log.loadingConsumerRebalanceListenerFromGroupId(consumerGroup);
+                        return Optional.of(matching.get());
+                    }
+                    return Optional.empty();
+                });
+    }
+
+    /**
+     * HACK - inject the listener using reflection to replace the one set by vert.x
+     *
+     * @param consumer the consumer
+     * @param listener the listener
+     */
+    @SuppressWarnings("rawtypes")
+    public static void inject(KafkaConsumer<?, ?> consumer, ConsumerRebalanceListener listener) {
+        KafkaReadStream readStream = consumer.getDelegate().asStream();
+        if (readStream instanceof KafkaReadStreamImpl) {
+            try {
+                Field field = readStream.getClass().getDeclaredField("rebalanceListener");
+                field.setAccessible(true);
+                field.set(readStream, listener);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Cannot inject rebalance listener", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Cannot inject rebalance listener - not a Kafka Read Stream");
+        }
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
@@ -1,15 +1,14 @@
 package io.smallrye.reactive.messaging.kafka;
 
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 
-import io.smallrye.mutiny.Uni;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
 @ApplicationScoped
 @Named("ConsumptionConsumerRebalanceListener")
@@ -18,19 +17,11 @@ public class ConsumptionConsumerRebalanceListener implements KafkaConsumerRebala
     private final Map<Integer, TopicPartition> assigned = new ConcurrentHashMap<>();
 
     @Override
-    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
-        set.forEach(topicPartition -> this.assigned.put(topicPartition.getPartition(), topicPartition));
-        return Uni
-                .createFrom()
-                .nullItem();
+    public void onPartitionsAssigned(Consumer<?, ?> consumer,
+        Collection<TopicPartition> partitions) {
+        partitions.forEach(topicPartition -> this.assigned.put(topicPartition.partition(), topicPartition));
     }
 
-    @Override
-    public Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
-        return Uni
-                .createFrom()
-                .nullItem();
-    }
 
     public Map<Integer, TopicPartition> getAssigned() {
         return assigned;

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
@@ -18,10 +18,9 @@ public class ConsumptionConsumerRebalanceListener implements KafkaConsumerRebala
 
     @Override
     public void onPartitionsAssigned(Consumer<?, ?> consumer,
-        Collection<TopicPartition> partitions) {
+            Collection<TopicPartition> partitions) {
         partitions.forEach(topicPartition -> this.assigned.put(topicPartition.partition(), topicPartition));
     }
-
 
     public Map<Integer, TopicPartition> getAssigned() {
         return assigned;

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -1,23 +1,9 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
-import io.smallrye.reactive.messaging.health.HealthReport;
-import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
-import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
-import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
-import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.IntegerDeserializer;
-import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
-import org.jboss.weld.exceptions.DeploymentException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
-import javax.enterprise.inject.UnsatisfiedResolutionException;
-import javax.enterprise.inject.literal.NamedLiteral;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +14,24 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.await;
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.literal.NamedLiteral;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.jboss.weld.exceptions.DeploymentException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
+import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
 
 public class KafkaSourceTest extends KafkaTestBase {
 
@@ -51,78 +52,78 @@ public class KafkaSourceTest extends KafkaTestBase {
     @Test
     public void testSource() {
         MapBasedConfig config = newCommonConfigForSource()
-            .with("value.deserializer", IntegerDeserializer.class.getName());
+                .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-            .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testSourceWithPartitions() {
         MapBasedConfig config = newCommonConfigForSource()
-            .with("value.deserializer", IntegerDeserializer.class.getName())
-            .with("partitions", 4);
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .with("partitions", 4);
 
         createTopic(topic, 3);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(1000, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 1000);
 
         List<Integer> expected = IntStream.range(0, 1000).boxed().collect(Collectors.toList());
         // Because of partitions we cannot enforce the order.
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-            .collect(Collectors.toList())).containsExactlyInAnyOrderElementsOf(expected);
+                .collect(Collectors.toList())).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     @SuppressWarnings("rawtypes")
     @Test
     public void testSourceWithChannelName() {
         MapBasedConfig config = newCommonConfigForSource()
-            .with("value.deserializer", IntegerDeserializer.class.getName());
+                .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<KafkaRecord> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
         assertThat(messages.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-            .containsExactly(0, 1, 2, 3, 4,
-                5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4,
+                        5, 6, 7, 8, 9);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testBroadcast() {
         MapBasedConfig config = newCommonConfigForSource()
-            .with("value.deserializer", IntegerDeserializer.class.getName())
-            .with("broadcast", true);
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .with("broadcast", true);
 
         CountKafkaCdiEvents testEvents = new CountKafkaCdiEvents();
 
@@ -134,7 +135,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         connector.init();
 
         PublisherBuilder<? extends KafkaRecord> builder = (PublisherBuilder<? extends KafkaRecord>) connector
-            .getPublisherBuilder(config);
+                .getPublisherBuilder(config);
 
         List<KafkaRecord> messages1 = new ArrayList<>();
         List<KafkaRecord> messages2 = new ArrayList<>();
@@ -143,15 +144,15 @@ public class KafkaSourceTest extends KafkaTestBase {
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 10);
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages2.size() >= 10);
         assertThat(messages1.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-            .containsExactly(0, 1, 2, 3, 4,
-                5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4,
+                        5, 6, 7, 8, 9);
         assertThat(messages2.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-            .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
         assertThat(testEvents.firedConsumerEvents.sum()).isEqualTo(1);
         assertThat(testEvents.firedProducerEvents.sum()).isEqualTo(0);
@@ -162,9 +163,9 @@ public class KafkaSourceTest extends KafkaTestBase {
     public void testBroadcastWithPartitions() {
         createTopic(topic, 2);
         MapBasedConfig config = newCommonConfigForSource()
-            .with("value.deserializer", IntegerDeserializer.class.getName())
-            .with("broadcast", true)
-            .with("partitions", 2);
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .with("broadcast", true)
+                .with("partitions", 2);
 
         connector = new KafkaConnector();
         connector.executionHolder = new ExecutionHolder(vertx);
@@ -174,7 +175,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         connector.init();
 
         PublisherBuilder<? extends KafkaRecord> builder = (PublisherBuilder<? extends KafkaRecord>) connector
-            .getPublisherBuilder(config);
+                .getPublisherBuilder(config);
 
         List<KafkaRecord> messages1 = new ArrayList<>();
         List<KafkaRecord> messages2 = new ArrayList<>();
@@ -183,41 +184,41 @@ public class KafkaSourceTest extends KafkaTestBase {
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 10);
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages2.size() >= 10);
         assertThat(messages1.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-            .containsExactlyInAnyOrder(0, 1, 2, 3, 4,
-                5, 6, 7, 8, 9);
+                .containsExactlyInAnyOrder(0, 1, 2, 3, 4,
+                        5, 6, 7, 8, 9);
         assertThat(messages2.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-            .containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     @SuppressWarnings({ "rawtypes" })
     @Test
     public void testRetry() {
         MapBasedConfig config = newCommonConfigForSource()
-            .with("value.deserializer", IntegerDeserializer.class.getName())
-            .with("retry", true)
-            .with("retry-attempts", 100)
-            .with("retry-max-wait", 30);
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .with("retry", true)
+                .with("retry-attempts", 100)
+                .with("retry-max-wait", 30);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
         List<KafkaRecord> messages1 = new ArrayList<>();
         source.getStream().subscribe().with(messages1::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 10);
 
         restart(2);
 
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 20);
         assertThat(messages1.size()).isGreaterThanOrEqualTo(20);
@@ -264,7 +265,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         assertThat(list).isEmpty();
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>("data", counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>("data", counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
         assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -290,12 +291,12 @@ public class KafkaSourceTest extends KafkaTestBase {
     public void testABeanConsumingTheKafkaMessagesWithPartitions() {
         createTopic("data-2", 2);
         ConsumptionBean bean = run(
-            myKafkaSourceConfig(2, ConsumptionConsumerRebalanceListener.class.getSimpleName(), null));
+                myKafkaSourceConfig(2, ConsumptionConsumerRebalanceListener.class.getSimpleName(), null));
         List<Integer> list = bean.getResults();
         assertThat(list).isEmpty();
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>("data-2", counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>("data-2", counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
         assertThat(list).containsOnly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -319,8 +320,8 @@ public class KafkaSourceTest extends KafkaTestBase {
     @Test
     public void testABeanConsumingWithMissingRebalanceListenerConfiguredByName() throws Throwable {
         assertThatThrownBy(() -> run(myKafkaSourceConfig(0, "not exists", "my-group")))
-            .isInstanceOf(DeploymentException.class)
-            .hasCauseInstanceOf(UnsatisfiedResolutionException.class);
+                .isInstanceOf(DeploymentException.class)
+                .hasCauseInstanceOf(UnsatisfiedResolutionException.class);
     }
 
     @Test
@@ -328,21 +329,21 @@ public class KafkaSourceTest extends KafkaTestBase {
         AtomicInteger counter = new AtomicInteger();
         AtomicBoolean callback = new AtomicBoolean(false);
         new Thread(() -> usage.produceIntegers(10, () -> callback.set(true),
-            () -> new ProducerRecord<>("data-starting-on-fifth-happy-path", counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>("data-starting-on-fifth-happy-path", counter.getAndIncrement()))).start();
 
         await()
-            .atMost(2, TimeUnit.MINUTES)
-            .until(callback::get);
+                .atMost(2, TimeUnit.MINUTES)
+                .until(callback::get);
         /*
          * Will use StartFromFifthOffsetFromLatestConsumerRebalanceListener
          */
         ConsumptionBeanWithoutAck bean = runWithoutAck(
-            myKafkaSourceConfigWithoutAck("happy-path", false));
+                myKafkaSourceConfigWithoutAck("happy-path", false));
         List<Integer> list = bean.getResults();
 
         await()
-            .atMost(2, TimeUnit.MINUTES)
-            .until(() -> list.size() >= 5);
+                .atMost(2, TimeUnit.MINUTES)
+                .until(() -> list.size() >= 5);
 
         assertThat(list).containsExactly(6, 7, 8, 9, 10);
     }
@@ -352,29 +353,29 @@ public class KafkaSourceTest extends KafkaTestBase {
         AtomicInteger counter = new AtomicInteger();
         AtomicBoolean callback = new AtomicBoolean(false);
         new Thread(() -> usage.produceIntegers(10, () -> callback.set(true),
-            () -> new ProducerRecord<>("data-starting-on-fifth-fail-on-first-attempt", counter.getAndIncrement())))
-            .start();
+                () -> new ProducerRecord<>("data-starting-on-fifth-fail-on-first-attempt", counter.getAndIncrement())))
+                        .start();
 
         await()
-            .atMost(2, TimeUnit.MINUTES)
-            .until(callback::get);
+                .atMost(2, TimeUnit.MINUTES)
+                .until(callback::get);
         /*
          * Will use StartFromFifthOffsetFromLatestConsumerRebalanceListener
          */
         ConsumptionBeanWithoutAck bean = runWithoutAck(
-            myKafkaSourceConfigWithoutAck("fail-on-first-attempt", false));
+                myKafkaSourceConfigWithoutAck("fail-on-first-attempt", false));
         List<Integer> list = bean.getResults();
 
         await()
-            .atMost(2, TimeUnit.MINUTES)
-            .until(() -> list.size() >= 5);
+                .atMost(2, TimeUnit.MINUTES)
+                .until(() -> list.size() >= 5);
 
         assertThat(list).containsExactly(6, 7, 8, 9, 10);
 
         assertThat(
-            getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
-                "my-group-starting-on-fifth-fail-on-first-attempt")
-                .getRebalanceCount()).isEqualTo(1);
+                getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
+                        "my-group-starting-on-fifth-fail-on-first-attempt")
+                                .getRebalanceCount()).isEqualTo(1);
     }
 
     @Test
@@ -382,72 +383,72 @@ public class KafkaSourceTest extends KafkaTestBase {
         AtomicInteger counter = new AtomicInteger();
         AtomicBoolean callback = new AtomicBoolean(false);
         new Thread(() -> usage.produceIntegers(10, () -> callback.set(true),
-            () -> new ProducerRecord<>("data-starting-on-fifth-fail-until-second-rebalance",
-                counter.getAndIncrement())))
-            .start();
+                () -> new ProducerRecord<>("data-starting-on-fifth-fail-until-second-rebalance",
+                        counter.getAndIncrement())))
+                                .start();
 
         await()
-            .atMost(2, TimeUnit.MINUTES)
-            .until(callback::get);
+                .atMost(2, TimeUnit.MINUTES)
+                .until(callback::get);
         /*
          * Will use StartFromFifthOffsetFromLatestConsumerRebalanceListener
          */
         ConsumptionBeanWithoutAck bean = runWithoutAck(
-            myKafkaSourceConfigWithoutAck("fail-until-second-rebalance", true));
+                myKafkaSourceConfigWithoutAck("fail-until-second-rebalance", true));
         List<Integer> list = bean.getResults();
 
         await()
-            .atMost(2, TimeUnit.MINUTES)
-            .until(() -> list.size() >= 5);
+                .atMost(2, TimeUnit.MINUTES)
+                .until(() -> list.size() >= 5);
 
         // The rebalance listener failed, no retry
         assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
         // Failed, not called and there is no retry
         assertThat(getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
-            "my-group-starting-on-fifth-fail-until-second-rebalance").getRebalanceCount()).isEqualTo(0);
+                "my-group-starting-on-fifth-fail-until-second-rebalance").getRebalanceCount()).isEqualTo(0);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testInvalidIncomingType() {
         MapBasedConfig config = newCommonConfigForSource()
-            .with("value.deserializer", IntegerDeserializer.class.getName());
+                .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(2, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 2);
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-            .collect(Collectors.toList())).containsExactly(0, 1);
+                .collect(Collectors.toList())).containsExactly(0, 1);
 
         new Thread(() -> usage.produceStrings(1, null, () -> new ProducerRecord<>(topic, "hello"))).start();
 
         new Thread(() -> usage.produceIntegers(2, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         // no other message received
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-            .collect(Collectors.toList())).containsExactly(0, 1);
+                .collect(Collectors.toList())).containsExactly(0, 1);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testABeanConsumingTheKafkaMessagesWithRawMessage() {
         ConsumptionBeanUsingRawMessage bean = runApplication(myKafkaSourceConfig(0, null, "my-group"),
-            ConsumptionBeanUsingRawMessage.class);
+                ConsumptionBeanUsingRawMessage.class);
         List<Integer> list = bean.getResults();
         assertThat(list).isEmpty();
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>("data", counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>("data", counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
         assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -455,7 +456,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         List<Message<Integer>> messages = bean.getKafkaMessages();
         messages.forEach(m -> {
             IncomingKafkaRecordMetadata<String, Integer> metadata = m.getMetadata(IncomingKafkaRecordMetadata.class)
-                .orElseThrow(() -> new AssertionError("Metadata expected"));
+                    .orElseThrow(() -> new AssertionError("Metadata expected"));
             assertThat(metadata.getTopic()).isEqualTo("data");
             assertThat(metadata.getTimestamp()).isAfter(Instant.EPOCH);
             assertThat(metadata.getPartition()).isGreaterThan(-1);
@@ -476,41 +477,41 @@ public class KafkaSourceTest extends KafkaTestBase {
     @Test
     public void testSourceWithEmptyOptionalConfiguration() {
         MapBasedConfig config = newCommonConfigForSource()
-            .with("value.deserializer", IntegerDeserializer.class.getName())
-            .with("sasl.jaas.config", "") //optional configuration
-            .with("sasl.mechanism", ""); //optional configuration
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .with("sasl.jaas.config", "") //optional configuration
+                .with("sasl.mechanism", ""); //optional configuration
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-            .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     private ConsumptionConsumerRebalanceListener getConsumptionConsumerRebalanceListener() {
         return getBeanManager()
-            .createInstance()
-            .select(ConsumptionConsumerRebalanceListener.class)
-            .select(NamedLiteral.of(ConsumptionConsumerRebalanceListener.class.getSimpleName()))
-            .get();
+                .createInstance()
+                .select(ConsumptionConsumerRebalanceListener.class)
+                .select(NamedLiteral.of(ConsumptionConsumerRebalanceListener.class.getSimpleName()))
+                .get();
 
     }
 
     private StartFromFifthOffsetFromLatestConsumerRebalanceListener getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
-        String name) {
+            String name) {
         return getBeanManager()
-            .createInstance()
-            .select(StartFromFifthOffsetFromLatestConsumerRebalanceListener.class)
-            .select(NamedLiteral.of(name))
-            .get();
+                .createInstance()
+                .select(StartFromFifthOffsetFromLatestConsumerRebalanceListener.class)
+                .select(NamedLiteral.of(name))
+                .get();
 
     }
 
@@ -522,9 +523,9 @@ public class KafkaSourceTest extends KafkaTestBase {
 
     private ConsumptionBeanWithoutAck runWithoutAck(MapBasedConfig config) {
         addBeans(ConsumptionBeanWithoutAck.class, ConsumptionConsumerRebalanceListener.class,
-            StartFromFifthOffsetFromLatestConsumerRebalanceListener.class,
-            StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.class,
-            StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.class);
+                StartFromFifthOffsetFromLatestConsumerRebalanceListener.class,
+                StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.class,
+                StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.class);
         runApplication(config);
         return get(ConsumptionBeanWithoutAck.class);
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -1,8 +1,23 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.awaitility.Awaitility.await;
+import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
+import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.jboss.weld.exceptions.DeploymentException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.literal.NamedLiteral;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,24 +28,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import javax.enterprise.inject.literal.NamedLiteral;
-
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.IntegerDeserializer;
-import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
-import org.jboss.weld.exceptions.DeploymentException;
-import org.jboss.weld.exceptions.UnsatisfiedResolutionException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-
-import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
-import io.smallrye.reactive.messaging.health.HealthReport;
-import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
-import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
-import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
-import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
-import io.vertx.kafka.client.common.TopicPartition;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 public class KafkaSourceTest extends KafkaTestBase {
 
@@ -51,78 +51,78 @@ public class KafkaSourceTest extends KafkaTestBase {
     @Test
     public void testSource() {
         MapBasedConfig config = newCommonConfigForSource()
-                .with("value.deserializer", IntegerDeserializer.class.getName());
+            .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-                .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+            .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testSourceWithPartitions() {
         MapBasedConfig config = newCommonConfigForSource()
-                .with("value.deserializer", IntegerDeserializer.class.getName())
-                .with("partitions", 4);
+            .with("value.deserializer", IntegerDeserializer.class.getName())
+            .with("partitions", 4);
 
         createTopic(topic, 3);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(1000, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 1000);
 
         List<Integer> expected = IntStream.range(0, 1000).boxed().collect(Collectors.toList());
         // Because of partitions we cannot enforce the order.
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-                .collect(Collectors.toList())).containsExactlyInAnyOrderElementsOf(expected);
+            .collect(Collectors.toList())).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     @SuppressWarnings("rawtypes")
     @Test
     public void testSourceWithChannelName() {
         MapBasedConfig config = newCommonConfigForSource()
-                .with("value.deserializer", IntegerDeserializer.class.getName());
+            .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<KafkaRecord> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
         assertThat(messages.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-                .containsExactly(0, 1, 2, 3, 4,
-                        5, 6, 7, 8, 9);
+            .containsExactly(0, 1, 2, 3, 4,
+                5, 6, 7, 8, 9);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testBroadcast() {
         MapBasedConfig config = newCommonConfigForSource()
-                .with("value.deserializer", IntegerDeserializer.class.getName())
-                .with("broadcast", true);
+            .with("value.deserializer", IntegerDeserializer.class.getName())
+            .with("broadcast", true);
 
         CountKafkaCdiEvents testEvents = new CountKafkaCdiEvents();
 
@@ -134,7 +134,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         connector.init();
 
         PublisherBuilder<? extends KafkaRecord> builder = (PublisherBuilder<? extends KafkaRecord>) connector
-                .getPublisherBuilder(config);
+            .getPublisherBuilder(config);
 
         List<KafkaRecord> messages1 = new ArrayList<>();
         List<KafkaRecord> messages2 = new ArrayList<>();
@@ -143,15 +143,15 @@ public class KafkaSourceTest extends KafkaTestBase {
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 10);
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages2.size() >= 10);
         assertThat(messages1.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-                .containsExactly(0, 1, 2, 3, 4,
-                        5, 6, 7, 8, 9);
+            .containsExactly(0, 1, 2, 3, 4,
+                5, 6, 7, 8, 9);
         assertThat(messages2.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+            .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
         assertThat(testEvents.firedConsumerEvents.sum()).isEqualTo(1);
         assertThat(testEvents.firedProducerEvents.sum()).isEqualTo(0);
@@ -162,9 +162,9 @@ public class KafkaSourceTest extends KafkaTestBase {
     public void testBroadcastWithPartitions() {
         createTopic(topic, 2);
         MapBasedConfig config = newCommonConfigForSource()
-                .with("value.deserializer", IntegerDeserializer.class.getName())
-                .with("broadcast", true)
-                .with("partitions", 2);
+            .with("value.deserializer", IntegerDeserializer.class.getName())
+            .with("broadcast", true)
+            .with("partitions", 2);
 
         connector = new KafkaConnector();
         connector.executionHolder = new ExecutionHolder(vertx);
@@ -174,7 +174,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         connector.init();
 
         PublisherBuilder<? extends KafkaRecord> builder = (PublisherBuilder<? extends KafkaRecord>) connector
-                .getPublisherBuilder(config);
+            .getPublisherBuilder(config);
 
         List<KafkaRecord> messages1 = new ArrayList<>();
         List<KafkaRecord> messages2 = new ArrayList<>();
@@ -183,41 +183,41 @@ public class KafkaSourceTest extends KafkaTestBase {
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 10);
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages2.size() >= 10);
         assertThat(messages1.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-                .containsExactlyInAnyOrder(0, 1, 2, 3, 4,
-                        5, 6, 7, 8, 9);
+            .containsExactlyInAnyOrder(0, 1, 2, 3, 4,
+                5, 6, 7, 8, 9);
         assertThat(messages2.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
-                .containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+            .containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     @SuppressWarnings({ "rawtypes" })
     @Test
     public void testRetry() {
         MapBasedConfig config = newCommonConfigForSource()
-                .with("value.deserializer", IntegerDeserializer.class.getName())
-                .with("retry", true)
-                .with("retry-attempts", 100)
-                .with("retry-max-wait", 30);
+            .with("value.deserializer", IntegerDeserializer.class.getName())
+            .with("retry", true)
+            .with("retry-attempts", 100)
+            .with("retry-max-wait", 30);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
         List<KafkaRecord> messages1 = new ArrayList<>();
         source.getStream().subscribe().with(messages1::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 10);
 
         restart(2);
 
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 20);
         assertThat(messages1.size()).isGreaterThanOrEqualTo(20);
@@ -264,7 +264,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         assertThat(list).isEmpty();
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>("data", counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>("data", counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
         assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -290,12 +290,12 @@ public class KafkaSourceTest extends KafkaTestBase {
     public void testABeanConsumingTheKafkaMessagesWithPartitions() {
         createTopic("data-2", 2);
         ConsumptionBean bean = run(
-                myKafkaSourceConfig(2, ConsumptionConsumerRebalanceListener.class.getSimpleName(), null));
+            myKafkaSourceConfig(2, ConsumptionConsumerRebalanceListener.class.getSimpleName(), null));
         List<Integer> list = bean.getResults();
         assertThat(list).isEmpty();
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>("data-2", counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>("data-2", counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
         assertThat(list).containsOnly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -310,16 +310,17 @@ public class KafkaSourceTest extends KafkaTestBase {
         ConsumptionConsumerRebalanceListener consumptionConsumerRebalanceListener = getConsumptionConsumerRebalanceListener();
         assertThat(consumptionConsumerRebalanceListener.getAssigned().size()).isEqualTo(2);
         for (int i = 0; i < 2; i++) {
-            TopicPartition topicPartition = consumptionConsumerRebalanceListener.getAssigned().get(i);
-            assertThat(topicPartition).isNotNull();
-            assertThat(topicPartition.getTopic()).isEqualTo("data-2");
+            TopicPartition partition = consumptionConsumerRebalanceListener.getAssigned().get(i);
+            assertThat(partition).isNotNull();
+            assertThat(partition.topic()).isEqualTo("data-2");
         }
     }
 
     @Test
     public void testABeanConsumingWithMissingRebalanceListenerConfiguredByName() throws Throwable {
-        assertThatThrownBy(() -> run(myKafkaSourceConfig(0, "not exists", "my-group"))).isInstanceOf(DeploymentException.class)
-                .hasCauseInstanceOf(UnsatisfiedResolutionException.class);
+        assertThatThrownBy(() -> run(myKafkaSourceConfig(0, "not exists", "my-group")))
+            .isInstanceOf(DeploymentException.class)
+            .hasCauseInstanceOf(UnsatisfiedResolutionException.class);
     }
 
     @Test
@@ -327,21 +328,21 @@ public class KafkaSourceTest extends KafkaTestBase {
         AtomicInteger counter = new AtomicInteger();
         AtomicBoolean callback = new AtomicBoolean(false);
         new Thread(() -> usage.produceIntegers(10, () -> callback.set(true),
-                () -> new ProducerRecord<>("data-starting-on-fifth-happy-path", counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>("data-starting-on-fifth-happy-path", counter.getAndIncrement()))).start();
 
         await()
-                .atMost(2, TimeUnit.MINUTES)
-                .until(callback::get);
+            .atMost(2, TimeUnit.MINUTES)
+            .until(callback::get);
         /*
          * Will use StartFromFifthOffsetFromLatestConsumerRebalanceListener
          */
         ConsumptionBeanWithoutAck bean = runWithoutAck(
-                myKafkaSourceConfigWithoutAck("happy-path", false));
+            myKafkaSourceConfigWithoutAck("happy-path", false));
         List<Integer> list = bean.getResults();
 
         await()
-                .atMost(2, TimeUnit.MINUTES)
-                .until(() -> list.size() >= 5);
+            .atMost(2, TimeUnit.MINUTES)
+            .until(() -> list.size() >= 5);
 
         assertThat(list).containsExactly(6, 7, 8, 9, 10);
     }
@@ -351,29 +352,29 @@ public class KafkaSourceTest extends KafkaTestBase {
         AtomicInteger counter = new AtomicInteger();
         AtomicBoolean callback = new AtomicBoolean(false);
         new Thread(() -> usage.produceIntegers(10, () -> callback.set(true),
-                () -> new ProducerRecord<>("data-starting-on-fifth-fail-on-first-attempt", counter.getAndIncrement())))
-                        .start();
+            () -> new ProducerRecord<>("data-starting-on-fifth-fail-on-first-attempt", counter.getAndIncrement())))
+            .start();
 
         await()
-                .atMost(2, TimeUnit.MINUTES)
-                .until(callback::get);
+            .atMost(2, TimeUnit.MINUTES)
+            .until(callback::get);
         /*
          * Will use StartFromFifthOffsetFromLatestConsumerRebalanceListener
          */
         ConsumptionBeanWithoutAck bean = runWithoutAck(
-                myKafkaSourceConfigWithoutAck("fail-on-first-attempt", false));
+            myKafkaSourceConfigWithoutAck("fail-on-first-attempt", false));
         List<Integer> list = bean.getResults();
 
         await()
-                .atMost(2, TimeUnit.MINUTES)
-                .until(() -> list.size() >= 5);
+            .atMost(2, TimeUnit.MINUTES)
+            .until(() -> list.size() >= 5);
 
         assertThat(list).containsExactly(6, 7, 8, 9, 10);
 
         assertThat(
-                getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
-                        "my-group-starting-on-fifth-fail-on-first-attempt")
-                                .getRebalanceCount()).isEqualTo(1);
+            getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
+                "my-group-starting-on-fifth-fail-on-first-attempt")
+                .getRebalanceCount()).isEqualTo(1);
     }
 
     @Test
@@ -381,70 +382,72 @@ public class KafkaSourceTest extends KafkaTestBase {
         AtomicInteger counter = new AtomicInteger();
         AtomicBoolean callback = new AtomicBoolean(false);
         new Thread(() -> usage.produceIntegers(10, () -> callback.set(true),
-                () -> new ProducerRecord<>("data-starting-on-fifth-fail-until-second-rebalance",
-                        counter.getAndIncrement())))
-                                .start();
+            () -> new ProducerRecord<>("data-starting-on-fifth-fail-until-second-rebalance",
+                counter.getAndIncrement())))
+            .start();
 
         await()
-                .atMost(2, TimeUnit.MINUTES)
-                .until(callback::get);
+            .atMost(2, TimeUnit.MINUTES)
+            .until(callback::get);
         /*
          * Will use StartFromFifthOffsetFromLatestConsumerRebalanceListener
          */
         ConsumptionBeanWithoutAck bean = runWithoutAck(
-                myKafkaSourceConfigWithoutAck("fail-until-second-rebalance", true));
+            myKafkaSourceConfigWithoutAck("fail-until-second-rebalance", true));
         List<Integer> list = bean.getResults();
 
         await()
-                .atMost(2, TimeUnit.MINUTES)
-                .until(() -> list.size() >= 5);
+            .atMost(2, TimeUnit.MINUTES)
+            .until(() -> list.size() >= 5);
 
-        assertThat(list).containsExactly(6, 7, 8, 9, 10);
+        // The rebalance listener failed, no retry
+        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
+        // Failed, not called and there is no retry
         assertThat(getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
-                "my-group-starting-on-fifth-fail-until-second-rebalance").getRebalanceCount()).isEqualTo(2);
+            "my-group-starting-on-fifth-fail-until-second-rebalance").getRebalanceCount()).isEqualTo(0);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testInvalidIncomingType() {
         MapBasedConfig config = newCommonConfigForSource()
-                .with("value.deserializer", IntegerDeserializer.class.getName());
+            .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(2, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 2);
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-                .collect(Collectors.toList())).containsExactly(0, 1);
+            .collect(Collectors.toList())).containsExactly(0, 1);
 
         new Thread(() -> usage.produceStrings(1, null, () -> new ProducerRecord<>(topic, "hello"))).start();
 
         new Thread(() -> usage.produceIntegers(2, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         // no other message received
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-                .collect(Collectors.toList())).containsExactly(0, 1);
+            .collect(Collectors.toList())).containsExactly(0, 1);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testABeanConsumingTheKafkaMessagesWithRawMessage() {
         ConsumptionBeanUsingRawMessage bean = runApplication(myKafkaSourceConfig(0, null, "my-group"),
-                ConsumptionBeanUsingRawMessage.class);
+            ConsumptionBeanUsingRawMessage.class);
         List<Integer> list = bean.getResults();
         assertThat(list).isEmpty();
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>("data", counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>("data", counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
         assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -452,7 +455,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         List<Message<Integer>> messages = bean.getKafkaMessages();
         messages.forEach(m -> {
             IncomingKafkaRecordMetadata<String, Integer> metadata = m.getMetadata(IncomingKafkaRecordMetadata.class)
-                    .orElseThrow(() -> new AssertionError("Metadata expected"));
+                .orElseThrow(() -> new AssertionError("Metadata expected"));
             assertThat(metadata.getTopic()).isEqualTo("data");
             assertThat(metadata.getTimestamp()).isAfter(Instant.EPOCH);
             assertThat(metadata.getPartition()).isGreaterThan(-1);
@@ -473,41 +476,41 @@ public class KafkaSourceTest extends KafkaTestBase {
     @Test
     public void testSourceWithEmptyOptionalConfiguration() {
         MapBasedConfig config = newCommonConfigForSource()
-                .with("value.deserializer", IntegerDeserializer.class.getName())
-                .with("sasl.jaas.config", "") //optional configuration
-                .with("sasl.mechanism", ""); //optional configuration
+            .with("value.deserializer", IntegerDeserializer.class.getName())
+            .with("sasl.jaas.config", "") //optional configuration
+            .with("sasl.mechanism", ""); //optional configuration
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+            getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(10, null,
-                () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
+            () -> new ProducerRecord<>(topic, counter.getAndIncrement()))).start();
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
-                .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+            .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     private ConsumptionConsumerRebalanceListener getConsumptionConsumerRebalanceListener() {
         return getBeanManager()
-                .createInstance()
-                .select(ConsumptionConsumerRebalanceListener.class)
-                .select(NamedLiteral.of(ConsumptionConsumerRebalanceListener.class.getSimpleName()))
-                .get();
+            .createInstance()
+            .select(ConsumptionConsumerRebalanceListener.class)
+            .select(NamedLiteral.of(ConsumptionConsumerRebalanceListener.class.getSimpleName()))
+            .get();
 
     }
 
     private StartFromFifthOffsetFromLatestConsumerRebalanceListener getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
-            String name) {
+        String name) {
         return getBeanManager()
-                .createInstance()
-                .select(StartFromFifthOffsetFromLatestConsumerRebalanceListener.class)
-                .select(NamedLiteral.of(name))
-                .get();
+            .createInstance()
+            .select(StartFromFifthOffsetFromLatestConsumerRebalanceListener.class)
+            .select(NamedLiteral.of(name))
+            .get();
 
     }
 
@@ -519,9 +522,9 @@ public class KafkaSourceTest extends KafkaTestBase {
 
     private ConsumptionBeanWithoutAck runWithoutAck(MapBasedConfig config) {
         addBeans(ConsumptionBeanWithoutAck.class, ConsumptionConsumerRebalanceListener.class,
-                StartFromFifthOffsetFromLatestConsumerRebalanceListener.class,
-                StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.class,
-                StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.class);
+            StartFromFifthOffsetFromLatestConsumerRebalanceListener.class,
+            StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.class,
+            StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.class);
         runApplication(config);
         return get(ConsumptionBeanWithoutAck.class);
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MultiTopicsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MultiTopicsTest.java
@@ -4,19 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.DeploymentException;
 
-import io.smallrye.mutiny.Multi;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -32,8 +29,8 @@ import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
  */
 @SuppressWarnings("rawtypes")
 public class MultiTopicsTest extends KafkaTestBase {
-    
-    @RepeatedTest(10)
+
+    @RepeatedTest(50)
     public void testWithThreeTopicsInConfiguration() {
         String topic1 = UUID.randomUUID().toString();
         String topic2 = UUID.randomUUID().toString();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MultiTopicsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MultiTopicsTest.java
@@ -4,16 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.DeploymentException;
 
+import io.smallrye.mutiny.Multi;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -29,7 +32,7 @@ import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
  */
 @SuppressWarnings("rawtypes")
 public class MultiTopicsTest extends KafkaTestBase {
-
+    
     @RepeatedTest(10)
     public void testWithThreeTopicsInConfiguration() {
         String topic1 = UUID.randomUUID().toString();
@@ -79,12 +82,9 @@ public class MultiTopicsTest extends KafkaTestBase {
             }
         });
 
-        // Unfortunately we can't be sure of the exact number, as the rebalance listener are called on the event loop
-        // and does not block the polling thread, which means that there is a chance that a commit done during
-        // a partitionRevoke is not done in time, and the consumer will still restart from the old commit.
-        assertThat(top1).hasValueGreaterThanOrEqualTo(3);
-        assertThat(top2).hasValueGreaterThanOrEqualTo(3);
-        assertThat(top3).hasValueGreaterThanOrEqualTo(3);
+        assertThat(top1).hasValue(3);
+        assertThat(top2).hasValue(3);
+        assertThat(top3).hasValue(3);
     }
 
     @RepeatedTest(10)
@@ -132,9 +132,9 @@ public class MultiTopicsTest extends KafkaTestBase {
             }
         });
 
-        assertThat(top1).hasValueGreaterThanOrEqualTo(3);
+        assertThat(top1).hasValue(3);
         assertThat(top2).hasValue(0);
-        assertThat(top3).hasValueGreaterThanOrEqualTo(3);
+        assertThat(top3).hasValue(3);
     }
 
     @Test
@@ -193,9 +193,9 @@ public class MultiTopicsTest extends KafkaTestBase {
             }
         });
 
-        assertThat(top1).hasValueGreaterThanOrEqualTo(3);
-        assertThat(top2).hasValueGreaterThanOrEqualTo(3);
-        assertThat(top3).hasValueGreaterThanOrEqualTo(3);
+        assertThat(top1).hasValue(3);
+        assertThat(top2).hasValue(3);
+        assertThat(top3).hasValue(3);
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
@@ -1,16 +1,14 @@
 package io.smallrye.reactive.messaging.kafka;
 
 import java.util.Collection;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 
-import io.smallrye.mutiny.Uni;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.Consumer;
+
+import io.vertx.kafka.client.common.TopicPartition;
 
 @ApplicationScoped
 @Named("my-group-starting-on-fifth-fail-on-first-attempt")
@@ -19,10 +17,11 @@ public class StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListen
 
     private final AtomicBoolean failOnFirstAttempt = new AtomicBoolean(true);
 
-    @Override public void onPartitionsAssigned(Consumer<?, ?> consumer,
-        Collection<org.apache.kafka.common.TopicPartition> partitions) {
+    @Override
+    public void onPartitionsAssigned(Consumer<?, ?> consumer,
+            Collection<org.apache.kafka.common.TopicPartition> partitions) {
         super.onPartitionsAssigned(consumer, partitions);
-        if (! partitions.isEmpty()  && failOnFirstAttempt.getAndSet(false)) {
+        if (!partitions.isEmpty() && failOnFirstAttempt.getAndSet(false)) {
             throw new IllegalArgumentException("testing failure");
         }
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
@@ -1,5 +1,6 @@
 package io.smallrye.reactive.messaging.kafka;
 
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -9,6 +10,7 @@ import javax.inject.Named;
 import io.smallrye.mutiny.Uni;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.Consumer;
 
 @ApplicationScoped
 @Named("my-group-starting-on-fifth-fail-on-first-attempt")
@@ -17,21 +19,11 @@ public class StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListen
 
     private final AtomicBoolean failOnFirstAttempt = new AtomicBoolean(true);
 
-    @Override
-    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
-        // will perform the underlying operation but simulate an error on the first attempt
-        return super.onPartitionsAssigned(consumer, set)
-                .onItem()
-                .transformToUni(a -> {
-                    if (!set.isEmpty() && failOnFirstAttempt.getAndSet(false)) {
-                        return Uni
-                                .createFrom()
-                                .failure(new Exception("testing failure"));
-                    } else {
-                        return Uni
-                                .createFrom()
-                                .item(a);
-                    }
-                });
+    @Override public void onPartitionsAssigned(Consumer<?, ?> consumer,
+        Collection<org.apache.kafka.common.TopicPartition> partitions) {
+        super.onPartitionsAssigned(consumer, partitions);
+        if (! partitions.isEmpty()  && failOnFirstAttempt.getAndSet(false)) {
+            throw new IllegalArgumentException("testing failure");
+        }
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.java
@@ -1,23 +1,23 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.common.TopicPartition;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
 @ApplicationScoped
 @Named("my-group-starting-on-fifth-fail-until-second-rebalance")
 public class StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener
-    extends StartFromFifthOffsetFromLatestConsumerRebalanceListener {
+        extends StartFromFifthOffsetFromLatestConsumerRebalanceListener {
     private final AtomicBoolean failOnFirstAttempt = new AtomicBoolean(true);
 
     @Override
     public void onPartitionsAssigned(Consumer<?, ?> consumer,
-        Collection<TopicPartition> partitions) {
-        System.out.println("Assigned called:" + partitions + " / " + failOnFirstAttempt.get()) ;
+            Collection<TopicPartition> partitions) {
         if (failOnFirstAttempt.getAndSet(false)) {
             throw new IllegalArgumentException("testing failure");
         } else {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
@@ -1,42 +1,31 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
-
-import io.smallrye.mutiny.Uni;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @ApplicationScoped
 @Named("my-group-starting-on-fifth-happy-path")
 public class StartFromFifthOffsetFromLatestConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
 
-    private AtomicInteger rebalanceCount = new AtomicInteger();
+    private final AtomicInteger rebalanceCount = new AtomicInteger();
 
     @Override
-    public Uni<Void> onPartitionsAssigned(KafkaConsumer<?, ?> consumer, Set<TopicPartition> set) {
-        rebalanceCount.incrementAndGet();
-        return Uni
-                .combine()
-                .all()
-                .unis(set
-                        .stream()
-                        .map(topicPartition -> consumer.endOffsets(topicPartition)
-                                .onItem()
-                                .transformToUni(o -> consumer.seek(topicPartition, Math.max(0L, o - 5L))))
-                        .collect(Collectors.toList()))
-                .combinedWith(a -> null);
-    }
-
-    @Override
-    public Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer, Set<TopicPartition> topicPartitions) {
-        return Uni
-                .createFrom()
-                .nullItem();
+    public void onPartitionsAssigned(Consumer<?, ?> consumer,
+        Collection<TopicPartition> partitions) {
+        System.out.println("Assigning " + partitions + "  from " + Thread.currentThread().getName());
+        if (! partitions.isEmpty()) {
+            rebalanceCount.incrementAndGet();
+            Map<TopicPartition, Long> offsets = consumer.endOffsets(partitions);
+            for (Map.Entry<TopicPartition, Long> position : offsets.entrySet()) {
+                consumer.seek(position.getKey(), Math.max(0L, position.getValue() - 5L));
+            }
+        }
     }
 
     public int getRebalanceCount() {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
@@ -1,13 +1,14 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.common.TopicPartition;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
 @ApplicationScoped
 @Named("my-group-starting-on-fifth-happy-path")
@@ -17,9 +18,8 @@ public class StartFromFifthOffsetFromLatestConsumerRebalanceListener implements 
 
     @Override
     public void onPartitionsAssigned(Consumer<?, ?> consumer,
-        Collection<TopicPartition> partitions) {
-        System.out.println("Assigning " + partitions + "  from " + Thread.currentThread().getName());
-        if (! partitions.isEmpty()) {
+            Collection<TopicPartition> partitions) {
+        if (!partitions.isEmpty()) {
             rebalanceCount.incrementAndGet();
             Map<TopicPartition, Long> offsets = consumer.endOffsets(partitions);
             for (Map.Entry<TopicPartition, Long> position : offsets.entrySet()) {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.CountKafkaCdiEvents;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
@@ -367,13 +366,13 @@ public class CommitStrategiesTest extends WeldTestBase {
 
         @Override
         public void onPartitionsAssigned(Consumer<?, ?> consumer,
-            Collection<TopicPartition> partitions) {
+                Collection<TopicPartition> partitions) {
 
         }
 
         @Override
         public void onPartitionsRevoked(Consumer<?, ?> consumer,
-            Collection<TopicPartition> partitions) {
+                Collection<TopicPartition> partitions) {
 
         }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -14,10 +14,7 @@ import javax.enterprise.inject.UnsatisfiedResolutionException;
 import javax.enterprise.inject.spi.DeploymentException;
 import javax.inject.Named;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -369,16 +366,17 @@ public class CommitStrategiesTest extends WeldTestBase {
     public static class NamedRebalanceListener implements KafkaConsumerRebalanceListener {
 
         @Override
-        public Uni<Void> onPartitionsAssigned(
-                KafkaConsumer<?, ?> consumer, Set<io.vertx.kafka.client.common.TopicPartition> topicPartitions) {
-            return Uni.createFrom().nullItem();
+        public void onPartitionsAssigned(Consumer<?, ?> consumer,
+            Collection<TopicPartition> partitions) {
+
         }
 
         @Override
-        public Uni<Void> onPartitionsRevoked(KafkaConsumer<?, ?> consumer,
-                Set<io.vertx.kafka.client.common.TopicPartition> topicPartitions) {
-            return Uni.createFrom().nullItem();
+        public void onPartitionsRevoked(Consumer<?, ?> consumer,
+            Collection<TopicPartition> partitions) {
+
         }
+
     }
 
     @ApplicationScoped


### PR DESCRIPTION
- change the method signatures to make rebalance listener blocking (**breaking change**)
- substitute the internal rebalance listener used by the Vert.x client by our own
- invoke the rebalance listener from the Kafka polling threading thread.

~~The synchronization protocol in the throttled commit strategy is not completed yet.~~