### PR TITLE
Remove and commit revoked partitions from the throttled offset store

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -121,11 +121,11 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
     public void partitionsRevoked(Set<TopicPartition> partitions) {
         stopFlushAndCheckHealthTimer();
 
-        // Remove all handled partitions that are not in the given list of partitions
+        // Remove all handled partitions that are in the given list of revoked partitions
         Map<TopicPartition, OffsetAndMetadata> toCommit = new HashMap<>();
-        for (TopicPartition partition : new HashSet<>(offsetStores.keySet())) {
-            if (!partitions.contains(partition)) {
-                OffsetStore store = offsetStores.remove(partition);
+        for (TopicPartition partition : partitions) {
+            OffsetStore store = offsetStores.remove(partition);
+            if (store != null) {
                 long largestOffset = store.clearLesserSequentiallyProcessedOffsetsAndReturnLargestOffset();
                 if (largestOffset > -1) {
                     toCommit.put(partition, new OffsetAndMetadata(largestOffset + 1L, null));


### PR DESCRIPTION
@cescoffier Noticed this bug when testing #797 out.

We should be removing the revoked partitions from the store and committing any offset we have for those.