### PR TITLE
update AmqpCreditTest to use a test server rather than full broker

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpBrokerTestBase.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpBrokerTestBase.java
@@ -1,0 +1,77 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
+import io.vertx.mutiny.core.Vertx;
+
+public class AmqpBrokerTestBase {
+
+    public static final AmqpBroker broker = new AmqpBroker();
+
+    ExecutionHolder executionHolder;
+    final static String host = "127.0.0.1";
+    final static int port = 5672;
+    final static String username = "artemis";
+    final static String password = "artemis";
+    AmqpUsage usage;
+
+    @BeforeAll
+    public static void startBroker() {
+        broker.start();
+        System.setProperty("amqp-host", host);
+        System.setProperty("amqp-port", Integer.toString(port));
+        System.setProperty("amqp-user", username);
+        System.setProperty("amqp-pwd", password);
+    }
+
+    @AfterAll
+    public static void stopBroker() {
+        broker.stop();
+        System.clearProperty("amqp-host");
+        System.clearProperty("amqp-port");
+    }
+
+    @BeforeEach
+    public void setup() {
+        executionHolder = new ExecutionHolder(Vertx.vertx());
+
+        usage = new AmqpUsage(executionHolder.vertx(), host, port, username, password);
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+        MapBasedConfig.clear();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        usage.close();
+        executionHolder.terminate(null);
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+        MapBasedConfig.clear();
+    }
+
+    public boolean isAmqpConnectorReady(WeldContainer container) {
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        return health.getReadiness().isOk();
+    }
+
+    public boolean isAmqpConnectorReady(AmqpConnector connector) {
+        return connector.getReadiness().isOk();
+    }
+
+    public boolean isAmqpConnectorAlive(WeldContainer container) {
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        return health.getLiveness().isOk();
+    }
+
+    public boolean isAmqpConnectorAlive(AmqpConnector connector) {
+        return connector.getLiveness().isOk();
+    }
+
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpCreditTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpCreditTest.java
@@ -1,28 +1,34 @@
 package io.smallrye.reactive.messaging.amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
-import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Section;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Subscriber;
 
-import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.mutiny.Multi;
+import io.vertx.core.Vertx;
 
 public class AmqpCreditTest extends AmqpTestBase {
 
     private AmqpConnector provider;
+    private MockServer server;
 
     @AfterEach
     public void cleanup() {
@@ -30,45 +36,87 @@ public class AmqpCreditTest extends AmqpTestBase {
             provider.terminate(null);
         }
 
-        MapBasedConfig.clear();
-        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+        if (server != null) {
+            server.close();
+        }
     }
 
     @Test
-    public void testCreditBasedFlowControl() {
-        String topic = UUID.randomUUID().toString();
-        AtomicInteger expected = new AtomicInteger(0);
-        usage.consumeIntegers(topic,
-                v -> expected.getAndIncrement());
+    @Timeout(30)
+    public void testCreditBasedFlowControl() throws Exception {
+        int msgCount = 5000;
+        CountDownLatch msgsReceived = new CountDownLatch(msgCount);
+        List<Object> payloadsReceived = new ArrayList<>(msgCount);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(topic);
+        server = setupMockServer(msgCount, msgsReceived, payloadsReceived, executionHolder.vertx().getDelegate());
+
+        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+                server.actualPort());
         //noinspection unchecked
-        Multi.createFrom().range(0, 5000)
+        Multi.createFrom().range(0, msgCount)
                 .map(Message::of)
                 .subscribe((Subscriber<? super Message<Integer>>) sink.build());
 
-        await()
-                .atMost(Duration.ofMinutes(1))
-                .until(() -> {
-                    System.out.println("Expected is " + expected.get());
-                    return expected.get() == 5000;
-                });
-        assertThat(expected).hasValue(5000);
+        assertThat(msgsReceived.await(20, TimeUnit.SECONDS))
+                .withFailMessage("Sent %s msgs but %s remain outstanding", msgCount, msgsReceived.getCount()).isTrue();
+        List<Integer> expectedPayloads = IntStream.range(0, msgCount).mapToObj(Integer::valueOf).collect(Collectors.toList());
+        assertThat(payloadsReceived).containsAll(expectedPayloads);
     }
 
-    private SubscriberBuilder<? extends Message<?>, Void> createProviderAndSink(String topic) {
+    private SubscriberBuilder<? extends Message<?>, Void> createProviderAndSink(String topic, int port) {
         Map<String, Object> config = new HashMap<>();
         config.put(ConnectorFactory.CHANNEL_NAME_ATTRIBUTE, topic);
         config.put("address", topic);
         config.put("name", "the name");
-        config.put("host", host);
-        config.put("durable", false);
+        config.put("host", "localhost");
         config.put("port", port);
-        config.put("username", username);
-        config.put("password", password);
 
         this.provider = new AmqpConnector();
         provider.setup(executionHolder);
-        return this.provider.getSubscriberBuilder(new MapBasedConfig(config));
+
+        return provider.getSubscriberBuilder(new MapBasedConfig(config));
+    }
+
+    private MockServer setupMockServer(int msgCount, CountDownLatch latch, List<Object> payloads, Vertx vertx)
+            throws Exception {
+        assertThat(msgCount % 10 == 0).isTrue();
+        int creditBatch = msgCount / 10;
+
+        return new MockServer(vertx, serverConnection -> {
+            serverConnection.openHandler(serverSender -> {
+                serverConnection.closeHandler(x -> serverConnection.close());
+                serverConnection.open();
+            });
+
+            serverConnection.sessionOpenHandler(serverSession -> {
+                serverSession.closeHandler(x -> serverSession.close());
+                serverSession.open();
+            });
+
+            serverConnection.receiverOpenHandler(serverReceiver -> {
+                // Disable the default 'prefetch' credit handling, do it ourselves in batches as used up
+                serverReceiver.setPrefetch(0);
+
+                serverReceiver.handler((delivery, message) -> {
+                    Section body = message.getBody();
+                    if (body instanceof AmqpValue) {
+                        payloads.add(((AmqpValue) body).getValue());
+                    } else {
+                        payloads.add(body);
+                    }
+
+                    latch.countDown();
+
+                    // Previous credit batch used up, give more
+                    if (serverReceiver.getCredit() <= 0) {
+                        serverReceiver.flow(creditBatch);
+                    }
+                });
+
+                serverReceiver.open();
+
+                serverReceiver.flow(creditBatch);
+            });
+        });
     }
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpFailureHandlerTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpFailureHandlerTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.reactive.messaging.extension.MediatorManager;
 
-public class AmqpFailureHandlerTest extends AmqpTestBase {
+public class AmqpFailureHandlerTest extends AmqpBrokerTestBase {
 
     private WeldContainer container;
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpLinkTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpLinkTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 
-public class AmqpLinkTest extends AmqpTestBase {
+public class AmqpLinkTest extends AmqpBrokerTestBase {
 
     private WeldContainer container;
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkTest.java
@@ -32,7 +32,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.amqp.AmqpMessageBuilder;
 import io.vertx.mutiny.core.buffer.Buffer;
 
-public class AmqpSinkTest extends AmqpTestBase {
+public class AmqpSinkTest extends AmqpBrokerTestBase {
 
     private static final String HELLO = "hello-";
     private WeldContainer container;

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
@@ -36,7 +36,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.amqp.AmqpMessage;
 import io.vertx.mutiny.core.buffer.Buffer;
 
-public class AmqpSourceTest extends AmqpTestBase {
+public class AmqpSourceTest extends AmqpBrokerTestBase {
 
     private AmqpConnector provider;
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpTestBase.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpTestBase.java
@@ -1,77 +1,29 @@
 package io.smallrye.reactive.messaging.amqp;
 
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.weld.environment.se.WeldContainer;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
-import io.smallrye.reactive.messaging.extension.HealthCenter;
 import io.vertx.mutiny.core.Vertx;
 
 public class AmqpTestBase {
 
-    public static final AmqpBroker broker = new AmqpBroker();
-
     ExecutionHolder executionHolder;
-    final static String host = "127.0.0.1";
-    final static int port = 5672;
-    final static String username = "artemis";
-    final static String password = "artemis";
-    AmqpUsage usage;
-
-    @BeforeAll
-    public static void startBroker() {
-        broker.start();
-        System.setProperty("amqp-host", host);
-        System.setProperty("amqp-port", Integer.toString(port));
-        System.setProperty("amqp-user", username);
-        System.setProperty("amqp-pwd", password);
-    }
-
-    @AfterAll
-    public static void stopBroker() {
-        broker.stop();
-        System.clearProperty("amqp-host");
-        System.clearProperty("amqp-port");
-    }
 
     @BeforeEach
     public void setup() {
         executionHolder = new ExecutionHolder(Vertx.vertx());
 
-        usage = new AmqpUsage(executionHolder.vertx(), host, port, username, password);
         SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
         MapBasedConfig.clear();
     }
 
     @AfterEach
     public void tearDown() {
-        usage.close();
         executionHolder.terminate(null);
         SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
         MapBasedConfig.clear();
     }
-
-    public boolean isAmqpConnectorReady(WeldContainer container) {
-        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
-        return health.getReadiness().isOk();
-    }
-
-    public boolean isAmqpConnectorReady(AmqpConnector connector) {
-        return connector.getReadiness().isOk();
-    }
-
-    public boolean isAmqpConnectorAlive(WeldContainer container) {
-        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
-        return health.getLiveness().isOk();
-    }
-
-    public boolean isAmqpConnectorAlive(AmqpConnector connector) {
-        return connector.getLiveness().isOk();
-    }
-
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/FutureHandler.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/FutureHandler.java
@@ -1,0 +1,77 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import java.util.concurrent.*;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+abstract public class FutureHandler<T, X> implements Future<T>, Handler<X> {
+
+    protected ExecutionException exception;
+    protected T result;
+    protected CountDownLatch latch = new CountDownLatch(1);
+
+    public static <T> FutureHandler<T, T> simple() {
+        return new FutureHandler<T, T>() {
+            @Override
+            synchronized public void handle(T t) {
+                result = t;
+                latch.countDown();
+            }
+        };
+    }
+
+    public static <T> FutureHandler<T, AsyncResult<T>> asyncResult() {
+        return new FutureHandler<T, AsyncResult<T>>() {
+            @Override
+            synchronized public void handle(AsyncResult<T> t) {
+                if (t.succeeded()) {
+                    result = t.result();
+                } else {
+                    exception = new ExecutionException(t.cause());
+                }
+                latch.countDown();
+            }
+        };
+    }
+
+    @Override
+    abstract public void handle(X t);
+
+    public T get() throws InterruptedException, ExecutionException {
+        latch.await();
+        return result();
+    }
+
+    private T result() throws ExecutionException {
+        synchronized (this) {
+            if (exception != null) {
+                throw exception;
+            }
+            return result;
+        }
+    }
+
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException, ExecutionException {
+        if (latch.await(timeout, unit)) {
+            return result();
+        } else {
+            throw new TimeoutException();
+        }
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return false;
+    }
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/HeaderPropagationAmqpToAmqpTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/HeaderPropagationAmqpToAmqpTest.java
@@ -21,7 +21,7 @@ import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.mutiny.Multi;
 import io.vertx.core.json.JsonObject;
 
-public class HeaderPropagationAmqpToAmqpTest extends AmqpTestBase {
+public class HeaderPropagationAmqpToAmqpTest extends AmqpBrokerTestBase {
 
     private WeldContainer container;
     private final Weld weld = new Weld();

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/HeaderPropagationAmqpToAppToAmqpTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/HeaderPropagationAmqpToAppToAmqpTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.vertx.core.json.JsonObject;
 
-public class HeaderPropagationAmqpToAppToAmqpTest extends AmqpTestBase {
+public class HeaderPropagationAmqpToAppToAmqpTest extends AmqpBrokerTestBase {
 
     private WeldContainer container;
     private final Weld weld = new Weld();

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/MockServer.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/MockServer.java
@@ -1,0 +1,50 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import java.util.concurrent.ExecutionException;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonServer;
+import io.vertx.proton.ProtonServerOptions;
+
+public class MockServer {
+    private ProtonServer server;
+
+    // Toggle to (re)use a fixed port, e.g for capture.
+    private int bindPort = 0;
+    private boolean reuseAddress = false;
+
+    public MockServer(Vertx vertx, Handler<ProtonConnection> connectionHandler)
+            throws ExecutionException, InterruptedException {
+        this(vertx, connectionHandler, null);
+    }
+
+    public MockServer(Vertx vertx, Handler<ProtonConnection> connectionHandler, ProtonServerOptions protonServerOptions)
+            throws ExecutionException, InterruptedException {
+        if (protonServerOptions == null) {
+            protonServerOptions = new ProtonServerOptions();
+        }
+
+        protonServerOptions.setReuseAddress(reuseAddress);
+        server = ProtonServer.create(vertx, protonServerOptions);
+        server.connectHandler(connectionHandler);
+
+        FutureHandler<ProtonServer, AsyncResult<ProtonServer>> handler = FutureHandler.asyncResult();
+        server.listen(bindPort, handler);
+        handler.get();
+    }
+
+    public int actualPort() {
+        return server.actualPort();
+    }
+
+    public void close() {
+        server.close();
+    }
+
+    ProtonServer getProtonServer() {
+        return server;
+    }
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ObjectExchangeTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ObjectExchangeTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.vertx.core.json.JsonObject;
 
-public class ObjectExchangeTest extends AmqpTestBase {
+public class ObjectExchangeTest extends AmqpBrokerTestBase {
 
     private WeldContainer container;
     private final Weld weld = new Weld();


### PR DESCRIPTION
Updates test of credit handling for outgoing/sending (AmqpCreditTest) to use a test server rather than a full broker. Also renames the test base class to represent its use of a broker, and adds (presents as a modification) a simpler base for tests that dont, more of which could be transitioned over time.

Using a test server allows for much more specific tests of what the connector actually does than observing its effect from the other side of a broker intermediary does, with the bonus of also being much faster due to having fewer parts and doing less work overall. In this particular case, running AmqpCreditTest in isolation the observed time taken was reduced from ~13sec to ~1.5sec.