### PR TITLE
Fix how configuration property coming from environment variables are handled

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -91,8 +91,14 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>compile</scope>
+      <version>${version.junit5}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.7.0</version>
       <!-- used in snippets -->
       <scope>compile</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,9 @@
     <testcontainers.version>1.15.0-rc2</testcontainers.version>
 
     <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <mockito.version>1.10.19</mockito.version>
+    <junit-pioneer.version>1.0.0</junit-pioneer.version>
+    <junit-platform-commons.version>1.7.0</junit-platform-commons.version>
   </properties>
 
   <modules>
@@ -313,6 +316,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+      <version>${version.junit5}</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
@@ -325,6 +334,24 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>${junit-pioneer.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <version>${junit-platform-commons.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -67,12 +67,6 @@
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelper.java
@@ -6,14 +6,20 @@ import org.eclipse.microprofile.config.Config;
 
 import io.vertx.core.json.JsonObject;
 
+/**
+ * Be aware that this class is kafka specific.
+ */
 public class JsonHelper {
 
     public static JsonObject asJsonObject(Config config) {
         JsonObject json = new JsonObject();
         Iterable<String> propertyNames = config.getPropertyNames();
-        for (String key : propertyNames) {
+        for (String originalKey : propertyNames) {
+            // Transform keys that may comes from environment variables.
+            // As kafka properties use `.`, transform "_" into "."
+            String key = originalKey.toLowerCase().replace("_", ".");
             try {
-                Optional<Integer> i = config.getOptionalValue(key, Integer.class);
+                Optional<Integer> i = config.getOptionalValue(originalKey, Integer.class);
                 if (i.isPresent()) {
                     json.put(key, i.get());
                     continue;
@@ -23,7 +29,7 @@ public class JsonHelper {
             }
 
             try {
-                Optional<Double> d = config.getOptionalValue(key, Double.class);
+                Optional<Double> d = config.getOptionalValue(originalKey, Double.class);
                 if (d.isPresent()) {
                     json.put(key, d.get());
                     continue;
@@ -33,7 +39,7 @@ public class JsonHelper {
             }
 
             try {
-                String value = config.getOptionalValue(key, String.class).orElse("").trim();
+                String value = config.getOptionalValue(originalKey, String.class).orElse("").trim();
                 if (value.equalsIgnoreCase("false")) {
                     json.put(key, false);
                 } else if (value.equalsIgnoreCase("true")) {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/EnvConfigTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/EnvConfigTest.java
@@ -1,0 +1,51 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
+
+public class EnvConfigTest extends KafkaTestBase {
+
+    public static final String TOPIC_IN = "EnvConfigTest-IN";
+
+    @Test
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_KAFKA_TOPIC", value = TOPIC_IN)
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_KAFKA_VALUE_DESERIALIZER", value = "org.apache.kafka.common.serialization.StringDeserializer")
+    public void testConsumer() {
+        KafkaConsumer bean = runApplication(MapBasedConfig.builder("mp.messaging.incoming.kafka")
+                .put(
+                        "auto.offset.reset", "earliest")
+                .build(), KafkaConsumer.class);
+
+        await().until(this::isReady);
+        await().until(this::isAlive);
+    }
+
+    @ApplicationScoped
+    public static class KafkaConsumer {
+
+        private final List<Message<String>> messages = new CopyOnWriteArrayList<>();
+
+        @Incoming("kafka")
+        public CompletionStage<Void> consume(Message<String> incoming) {
+            messages.add(incoming);
+            return incoming.ack();
+        }
+
+        public List<Message<String>> getMessages() {
+            return messages;
+        }
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelperTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelperTest.java
@@ -1,0 +1,35 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.kafka.base.MapBasedConfig;
+import io.vertx.core.json.JsonObject;
+
+class JsonHelperTest {
+
+    @Test
+    public void test() {
+        MapBasedConfig config = MapBasedConfig.builder()
+                .put("bootstrap.servers", "not-important")
+                .put("key", "value")
+                .put("int", 10)
+                .put("double", 23.4)
+                .put("trueasstring", "true")
+                .put("falseasstring", "false")
+                .put("FOO_BAR", "value")
+                .build();
+
+        JsonObject object = JsonHelper.asJsonObject(config);
+        assertThat(object.getString("key")).isEqualTo("value");
+        assertThat(object.getInteger("int")).isEqualTo(10);
+        assertThat(object.getDouble("double")).isEqualTo(23.4);
+        assertThat(object.getBoolean("trueasstring")).isTrue();
+        assertThat(object.getBoolean("falseasstring")).isFalse();
+        assertThat(object.getString("foo.bar")).isEqualTo("value");
+        assertThat(object.getString("bootstrap.servers")).isEqualTo("not-important");
+
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/extension/HealthWithSubscriberTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/extension/HealthWithSubscriberTest.java
@@ -30,7 +30,6 @@ public class HealthWithSubscriberTest extends WeldTestBaseWithoutTails {
         HealthCenter center = container.getBeanManager().createInstance().select(HealthCenter.class).get();
         MyBean bean = container.getBeanManager().createInstance().select(MyBean.class).get();
 
-        center.getLiveness().getChannels().forEach(c -> System.out.println(c.getChannel() + " " + c.getMessage()));
         assertThat(center.getLiveness().isOk()).isTrue();
         assertThat(center.getLiveness().getChannels()).isEmpty();
         assertThat(center.getReadiness().isOk()).isTrue();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/impl/ConnectorConfigTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/impl/ConnectorConfigTest.java
@@ -1,0 +1,75 @@
+package io.smallrye.reactive.messaging.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class ConnectorConfigTest {
+
+    @Test
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_ATTR", value = "new-value")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_AT_TR", value = "another-value")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_KEY", value = "another-value-from-connector")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_OTHER_KEY", value = "another-value-other")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR1", value = "should not be used")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR3", value = "used")
+    public void testPropertyNames() {
+        Map<String, String> cfg = new HashMap<>();
+        cfg.put("mp.messaging.incoming.bar.connector", "some-connector");
+        cfg.put("mp.messaging.incoming.bar.test", "test");
+        cfg.put("mp.messaging.incoming.foo.connector", "some-connector");
+        cfg.put("mp.messaging.incoming.foo.attr1", "value");
+        cfg.put("mp.messaging.incoming.foo.attr2", "23");
+        cfg.put("mp.messaging.incoming.foo.attr.2", "test");
+        cfg.put("mp.messaging.incoming.foo.at-tr", "test");
+        cfg.put("mp.messaging.connector.some-connector.key", "value");
+        cfg.put("mp.messaging.connector.some-connector.some-key", "should not be used");
+
+        SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
+        builder.addDefaultSources();
+        builder.withSources(new ConfigSource() {
+            @Override
+            public Map<String, String> getProperties() {
+                return cfg;
+            }
+
+            @Override
+            public String getValue(String s) {
+                return cfg.get(s);
+            }
+
+            @Override
+            public String getName() {
+                return "test";
+            }
+        });
+        SmallRyeConfig c = builder.build();
+
+        ConnectorConfig result = new ConnectorConfig("mp.messaging.incoming.", c, "foo");
+        Iterable<String> names = result.getPropertyNames();
+        assertThat(names)
+                .containsExactlyInAnyOrder("connector", "ATTR1", "attr2", "attr.2", "ATTR", "AT_TR", "key", "SOME_KEY",
+                        "SOME_OTHER_KEY", "ATTR3", "channel-name");
+
+        assertThat(result.getOptionalValue("connector", String.class)).hasValue("some-connector");
+        assertThat(result.getOptionalValue("attr1", String.class)).hasValue("value");
+        assertThat(result.getOptionalValue("attr2", Integer.class)).hasValue(23);
+        assertThat(result.getOptionalValue("attr.2", String.class)).hasValue("test");
+        assertThat(result.getOptionalValue("at-tr", String.class)).hasValue("another-value");
+        assertThat(result.getOptionalValue("AT_TR", String.class)).hasValue("another-value");
+        assertThat(result.getOptionalValue("some-key", String.class)).hasValue("another-value-from-connector");
+        assertThat(result.getOptionalValue("SOME_KEY", String.class)).hasValue("another-value-from-connector");
+        assertThat(result.getOptionalValue("key", String.class)).hasValue("value");
+        assertThat(result.getOptionalValue("attr3", String.class)).hasValue("used");
+        assertThat(result.getOptionalValue("ATTR3", String.class)).hasValue("used");
+    }
+
+}


### PR DESCRIPTION
Fix how are handled configuration properties defined in environment variables (uppercase with underscores). Unfortunately, how we extract the Kafka object configuration (consumer, producer, admin) is based on the property names which was filtered to only contain the properties for the specific channel. In the case of env var, the keys were filtered out as they were not matching the expected prefix. This PR fixes this. 


Fix https://github.com/quarkusio/quarkus/issues/12678