### PR TITLE
Cleanup acknowledgement test to avoid polluting the log with pointless exceptions

### DIFF
--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningCompletionStage.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningCompletionStage.java
@@ -31,7 +31,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     @Incoming(MANUAL_ACKNOWLEDGMENT)
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public CompletionStage<Void> subWithAck(Message<String> message) {
-        return CompletableFuture.runAsync(() -> processed(MANUAL_ACKNOWLEDGMENT, message), EXECUTOR)
+        return CompletableFuture.runAsync(() -> processed(MANUAL_ACKNOWLEDGMENT, message), executor)
                 .thenCompose(x -> message.ack());
     }
 
@@ -67,7 +67,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     @Incoming(PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
     @Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
     public CompletionStage<Void> preProcessingWithMessage(Message<String> message) {
-        return CompletableFuture.runAsync(() -> processed(PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message), EXECUTOR);
+        return CompletableFuture.runAsync(() -> processed(PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message), executor);
     }
 
     @Outgoing(PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
@@ -78,7 +78,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     @Incoming(PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
     @Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
     public CompletionStage<Void> preProcessingWithPayload(String payload) {
-        return CompletableFuture.runAsync(() -> processed(PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD, payload), EXECUTOR);
+        return CompletableFuture.runAsync(() -> processed(PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD, payload), executor);
     }
 
     @Outgoing(PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
@@ -89,7 +89,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     @Incoming(POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
     @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
     public CompletionStage<Void> postProcessingWithMessage(Message<String> message) {
-        return CompletableFuture.runAsync(() -> processed(POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message), EXECUTOR);
+        return CompletableFuture.runAsync(() -> processed(POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message), executor);
     }
 
     @Outgoing(POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
@@ -100,7 +100,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     @Incoming(POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
     @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
     public CompletionStage<Void> postProcessingWithPayload(String payload) {
-        return CompletableFuture.runAsync(() -> processed(POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD, payload), EXECUTOR);
+        return CompletableFuture.runAsync(() -> processed(POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD, payload), executor);
     }
 
     @Outgoing(POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
@@ -111,7 +111,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     @Incoming(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
     public CompletionStage<Void> defaultProcessingWithMessage(Message<String> message) {
         return CompletableFuture.runAsync(
-                () -> processed(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message), EXECUTOR)
+                () -> processed(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message), executor)
                 .thenCompose(x -> message.ack());
     }
 
@@ -123,7 +123,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     @Incoming(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
     public CompletionStage<Void> defaultProcessingWithPayload(String payload) {
         return CompletableFuture
-                .runAsync(() -> processed(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD, payload), EXECUTOR);
+                .runAsync(() -> processed(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD, payload), executor);
     }
 
     @Outgoing(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningUni.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningUni.java
@@ -33,7 +33,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Uni<Void> subWithAck(Message<String> message) {
         return Uni.createFrom().item(message)
-                .emitOn(EXECUTOR)
+                .emitOn(executor)
                 .onItem().invoke((m) -> processed(MANUAL_ACKNOWLEDGMENT, message))
                 .onItem().transformToUni(m -> Uni.createFrom().completionStage(m.ack()));
     }
@@ -47,7 +47,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     @Acknowledgment(Acknowledgment.Strategy.NONE)
     public Uni<Void> subWithNoAckMessage(Message<String> message) {
         return Uni.createFrom().item(message)
-                .emitOn(EXECUTOR)
+                .emitOn(executor)
                 .onItem().invoke((m) -> processed(NO_ACKNOWLEDGMENT_MESSAGE, message))
                 .onItem().delayIt().by(Duration.ofMillis(10))
                 .onItem().ignore().andContinueWithNull();
@@ -75,7 +75,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     @Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
     public Uni<Void> preProcessingWithMessage(Message<String> message) {
         return Uni.createFrom().<Void> item(() -> null)
-                .emitOn(EXECUTOR)
+                .emitOn(executor)
                 .onItem().invoke(x -> processed(PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message));
     }
 
@@ -88,7 +88,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     @Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
     public Uni<Void> preProcessingWithPayload(String payload) {
         return Uni.createFrom().<Void> item(() -> null)
-                .emitOn(EXECUTOR)
+                .emitOn(executor)
                 .onItem().invoke(x -> processed(PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD, payload));
     }
 
@@ -101,7 +101,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
     public Uni<Void> postProcessingWithMessage(Message<String> message) {
         return Uni.createFrom().<Void> item(() -> null)
-                .emitOn(EXECUTOR)
+                .emitOn(executor)
                 .onItem().invoke(x -> processed(POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message));
     }
 
@@ -114,7 +114,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
     public Uni<Void> postProcessingWithPayload(String payload) {
         return Uni.createFrom().<Void> item(() -> null)
-                .emitOn(EXECUTOR)
+                .emitOn(executor)
                 .onItem().invoke(x -> processed(POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD, payload));
     }
 
@@ -126,7 +126,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     @Incoming(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
     public Uni<Void> defaultProcessingWithMessage(Message<String> message) {
         return Uni.createFrom().<Void> item(() -> null)
-                .emitOn(EXECUTOR)
+                .emitOn(executor)
                 .onItem().invoke(x -> processed(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE, message))
                 .onItem().transformToUni(x -> Uni.createFrom().completionStage(message.ack()));
     }
@@ -139,7 +139,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     @Incoming(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
     public Uni<Void> defaultProcessingWithPayload(String payload) {
         return Uni.createFrom().<Void> item(() -> null)
-                .emitOn(EXECUTOR)
+                .emitOn(executor)
                 .onItem().invoke(x -> processed(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD, payload));
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberWithCompletionStageMethodAcknowledgementTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberWithCompletionStageMethodAcknowledgementTest.java
@@ -17,56 +17,52 @@ public class SubscriberWithCompletionStageMethodAcknowledgementTest extends Ackn
     private final Class<SubscriberBeanWithMethodsReturningCompletionStage> beanClass = SubscriberBeanWithMethodsReturningCompletionStage.class;
 
     @Test
-    public void testManual() {
+    public void test() {
         SubscriberBeanWithMethodsReturningCompletionStage bean = installInitializeAndGet(beanClass);
+        testManual(bean);
+        testNoAcknowledgementMessage(bean);
+        testNoAcknowledgementPayload(bean);
+        testPreProcessingAcknowledgementMessage(bean);
+        testPreProcessingAcknowledgementPayload(bean);
+        testPostProcessingAcknowledgementMessage(bean);
+        testPostProcessingAcknowledgementPayload(bean);
+        testDefaultProcessingAcknowledgementMessage(bean);
+        testDefaultProcessingAcknowledgementPayload(bean);
+    }
+
+    public void testManual(SpiedBeanHelper bean) {
         assertAcknowledgment(bean, MANUAL_ACKNOWLEDGMENT);
     }
 
-    @Test
-    public void testNoAcknowledgementMessage() {
-        SubscriberBeanWithMethodsReturningCompletionStage bean = installInitializeAndGet(beanClass);
+    public void testNoAcknowledgementMessage(SpiedBeanHelper bean) {
         assertNoAcknowledgment(bean, NO_ACKNOWLEDGMENT_MESSAGE);
     }
 
-    @Test
-    public void testNoAcknowledgementPayload() {
-        SubscriberBeanWithMethodsReturningCompletionStage bean = installInitializeAndGet(beanClass);
+    public void testNoAcknowledgementPayload(SpiedBeanHelper bean) {
         assertNoAcknowledgment(bean, NO_ACKNOWLEDGMENT_PAYLOAD);
     }
 
-    @Test
-    public void testPreProcessingAcknowledgementMessage() {
-        SubscriberBeanWithMethodsReturningCompletionStage bean = installInitializeAndGet(beanClass);
+    public void testPreProcessingAcknowledgementMessage(SpiedBeanHelper bean) {
         assertPreAcknowledgment(bean, PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
-    @Test
-    public void testPreProcessingAcknowledgementPayload() {
-        SubscriberBeanWithMethodsReturningCompletionStage bean = installInitializeAndGet(beanClass);
+    public void testPreProcessingAcknowledgementPayload(SpiedBeanHelper bean) {
         assertPreAcknowledgment(bean, PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 
-    @Test
-    public void testPostProcessingAcknowledgementMessage() {
-        SubscriberBeanWithMethodsReturningCompletionStage bean = installInitializeAndGet(beanClass);
+    public void testPostProcessingAcknowledgementMessage(SpiedBeanHelper bean) {
         assertPostAcknowledgment(bean, POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
-    @Test
-    public void testPostProcessingAcknowledgementPayload() {
-        SubscriberBeanWithMethodsReturningCompletionStage bean = installInitializeAndGet(beanClass);
+    public void testPostProcessingAcknowledgementPayload(SpiedBeanHelper bean) {
         assertPostAcknowledgment(bean, POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 
-    @Test
-    public void testDefaultProcessingAcknowledgementMessage() {
-        SubscriberBeanWithMethodsReturningCompletionStage bean = installInitializeAndGet(beanClass);
+    public void testDefaultProcessingAcknowledgementMessage(SpiedBeanHelper bean) {
         assertPostAcknowledgment(bean, DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
-    @Test
-    public void testDefaultProcessingAcknowledgementPayload() {
-        SubscriberBeanWithMethodsReturningCompletionStage bean = installInitializeAndGet(beanClass);
+    public void testDefaultProcessingAcknowledgementPayload(SpiedBeanHelper bean) {
         assertPostAcknowledgment(bean, DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberWithUniMethodAcknowledgementTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberWithUniMethodAcknowledgementTest.java
@@ -9,56 +9,52 @@ public class SubscriberWithUniMethodAcknowledgementTest extends AcknowledgmentTe
     private final Class<SubscriberBeanWithMethodsReturningUni> beanClass = SubscriberBeanWithMethodsReturningUni.class;
 
     @Test
-    public void testManual() {
+    public void test() {
         SubscriberBeanWithMethodsReturningUni bean = installInitializeAndGet(beanClass);
+        testManual(bean);
+        testNoAcknowledgementMessage(bean);
+        testNoAcknowledgementPayload(bean);
+        testPreProcessingAcknowledgementMessage(bean);
+        testPreProcessingAcknowledgementPayload(bean);
+        testPostProcessingAcknowledgementMessage(bean);
+        testPostProcessingAcknowledgementPayload(bean);
+        testDefaultProcessingAcknowledgementMessage(bean);
+        testDefaultProcessingAcknowledgementPayload(bean);
+    }
+
+    public void testManual(SpiedBeanHelper bean) {
         assertAcknowledgment(bean, MANUAL_ACKNOWLEDGMENT);
     }
 
-    @Test
-    public void testNoAcknowledgementMessage() {
-        SubscriberBeanWithMethodsReturningUni bean = installInitializeAndGet(beanClass);
+    public void testNoAcknowledgementMessage(SpiedBeanHelper bean) {
         assertNoAcknowledgment(bean, NO_ACKNOWLEDGMENT_MESSAGE);
     }
 
-    @Test
-    public void testNoAcknowledgementPayload() {
-        SubscriberBeanWithMethodsReturningUni bean = installInitializeAndGet(beanClass);
+    public void testNoAcknowledgementPayload(SpiedBeanHelper bean) {
         assertNoAcknowledgment(bean, NO_ACKNOWLEDGMENT_PAYLOAD);
     }
 
-    @Test
-    public void testPreProcessingAcknowledgementMessage() {
-        SubscriberBeanWithMethodsReturningUni bean = installInitializeAndGet(beanClass);
+    public void testPreProcessingAcknowledgementMessage(SpiedBeanHelper bean) {
         assertPreAcknowledgment(bean, PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
-    @Test
-    public void testPreProcessingAcknowledgementPayload() {
-        SubscriberBeanWithMethodsReturningUni bean = installInitializeAndGet(beanClass);
+    public void testPreProcessingAcknowledgementPayload(SpiedBeanHelper bean) {
         assertPreAcknowledgment(bean, PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 
-    @Test
-    public void testPostProcessingAcknowledgementMessage() {
-        SubscriberBeanWithMethodsReturningUni bean = installInitializeAndGet(beanClass);
+    public void testPostProcessingAcknowledgementMessage(SpiedBeanHelper bean) {
         assertPostAcknowledgment(bean, POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
-    @Test
-    public void testPostProcessingAcknowledgementPayload() {
-        SubscriberBeanWithMethodsReturningUni bean = installInitializeAndGet(beanClass);
+    public void testPostProcessingAcknowledgementPayload(SpiedBeanHelper bean) {
         assertPostAcknowledgment(bean, POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 
-    @Test
-    public void testDefaultProcessingAcknowledgementMessage() {
-        SubscriberBeanWithMethodsReturningUni bean = installInitializeAndGet(beanClass);
+    public void testDefaultProcessingAcknowledgementMessage(SpiedBeanHelper bean) {
         assertPostAcknowledgment(bean, DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
-    @Test
-    public void testDefaultProcessingAcknowledgementPayload() {
-        SubscriberBeanWithMethodsReturningUni bean = installInitializeAndGet(beanClass);
+    public void testDefaultProcessingAcknowledgementPayload(SpiedBeanHelper bean) {
         assertPostAcknowledgment(bean, DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 


### PR DESCRIPTION
Some acknowledgment tests were throwing exceptions because the current test was not waiting for the asynchronous processing. This commit fixes this, and avoid polluting the log output with many useless exceptions.	
﻿
