### PR TITLE
Set the consumer/producer/admin client.id when not set in the config

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -148,7 +148,7 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
 
         if (partitions == 1) {
             KafkaSource<Object, Object> source = new KafkaSource<>(vertx, group, ic, consumerRebalanceListeners,
-                    kafkaCDIEvents);
+                    kafkaCDIEvents, -1);
             sources.add(source);
 
             boolean broadcast = ic.getBroadcast();
@@ -163,7 +163,7 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
         List<Publisher<IncomingKafkaRecord<Object, Object>>> streams = new ArrayList<>();
         for (int i = 0; i < partitions; i++) {
             KafkaSource<Object, Object> source = new KafkaSource<>(vertx, group, ic, consumerRebalanceListeners,
-                    kafkaCDIEvents);
+                    kafkaCDIEvents, i);
             sources.add(source);
             streams.add(source.getStream());
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -162,4 +162,11 @@ public interface KafkaLogging extends BasicLogger {
     @Message(id = 18236, value = "Will mark throttled commit strategy for group '%s' as unhealthy if records go more than %d milliseconds without being processed.")
     void setThrottledCommitStrategyReceivedRecordMaxAge(String group, long unprocessedRecordMaxAge);
 
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18237, value = "Setting client.id for Kafka producer to %s")
+    void setKafkaProducerClientId(String name);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18238, value = "Setting client.id for Kafka consumer to %s")
+    void setKafkaConsumerClientId(String name);
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaAdminHelper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaAdminHelper.java
@@ -15,13 +15,14 @@ public class KafkaAdminHelper {
     }
 
     public static KafkaAdminClient createAdminClient(Vertx vertx,
-            Map<String, Object> kafkaConfigurationMap) {
+            Map<String, Object> kafkaConfigurationMap, String channel) {
         Map<String, String> copy = new HashMap<>();
         for (Map.Entry<String, Object> entry : kafkaConfigurationMap.entrySet()) {
             if (AdminClientConfig.configNames().contains(entry.getKey())) {
                 copy.put(entry.getKey(), entry.getValue().toString());
             }
         }
+        copy.put(AdminClientConfig.CLIENT_ID_CONFIG, "kafka-admin-" + channel);
         return KafkaAdminClient.create(vertx, copy);
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
@@ -106,7 +106,7 @@ public class KafkaSink {
 
         if (config.getHealthEnabled() && config.getHealthReadinessEnabled()) {
             // Do not create the client if the readiness health checks are disabled
-            this.admin = KafkaAdminHelper.createAdminClient(vertx, kafkaConfigurationMap);
+            this.admin = KafkaAdminHelper.createAdminClient(vertx, kafkaConfigurationMap, config.getChannel());
         } else {
             this.admin = null;
         }
@@ -315,6 +315,13 @@ public class KafkaSink {
         if (!kafkaConfiguration.containsKey(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION)) {
             kafkaConfiguration
                     .put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, config.getMaxInflightMessages());
+        }
+
+        if (!kafkaConfiguration.containsKey(ProducerConfig.CLIENT_ID_CONFIG)) {
+            String id = "kafka-producer-" + config.getChannel();
+            log.setKafkaProducerClientId(id);
+            kafkaConfiguration.put(ProducerConfig.CLIENT_ID_CONFIG, id);
+
         }
 
         return ConfigurationCleaner.cleanupProducerConfiguration(kafkaConfiguration);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -55,7 +55,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -79,7 +79,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         createTopic(topic, 3);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -103,7 +103,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<KafkaRecord> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -205,7 +205,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("retry-max-wait", 30);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
         List<KafkaRecord> messages1 = new ArrayList<>();
         source.getStream().subscribe().with(messages1::add);
 
@@ -416,7 +416,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -482,7 +482,7 @@ public class KafkaSourceTest extends KafkaTestBase {
                 .with("sasl.mechanism", ""); //optional configuration
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceWithCloudEventsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceWithCloudEventsTest.java
@@ -53,7 +53,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -115,7 +115,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -173,7 +173,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -228,7 +228,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -264,7 +264,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -302,7 +302,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -367,7 +367,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -432,7 +432,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -573,7 +573,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events", false);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -617,7 +617,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events", false);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);
@@ -663,7 +663,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = new ArrayList<>();
         source.getStream().subscribe().with(messages::add);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -55,7 +55,7 @@ public class CommitStrategiesTest extends WeldTestBase {
         MapBasedConfig config = commonConfiguration().with("commit-strategy", "latest");
         KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
                 new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
-                CountKafkaCdiEvents.noCdiEvents);
+                CountKafkaCdiEvents.noCdiEvents, -1);
         injectMockConsumer(source, consumer);
 
         List<Message<?>> list = new ArrayList<>();
@@ -145,7 +145,7 @@ public class CommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
                 new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
-                CountKafkaCdiEvents.noCdiEvents);
+                CountKafkaCdiEvents.noCdiEvents, -1);
         injectMockConsumer(source, consumer);
 
         List<Message<?>> list = new ArrayList<>();
@@ -206,7 +206,7 @@ public class CommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
                 new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
-                CountKafkaCdiEvents.noCdiEvents);
+                CountKafkaCdiEvents.noCdiEvents, -1);
         injectMockConsumer(source, consumer);
 
         List<Message<?>> list = new ArrayList<>();
@@ -279,7 +279,7 @@ public class CommitStrategiesTest extends WeldTestBase {
         assertThatThrownBy(() -> {
             new KafkaSource<>(vertx, "my-group",
                     new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
-                    CountKafkaCdiEvents.noCdiEvents);
+                    CountKafkaCdiEvents.noCdiEvents, -1);
         }).isInstanceOf(UnsatisfiedResolutionException.class);
     }
 
@@ -291,7 +291,7 @@ public class CommitStrategiesTest extends WeldTestBase {
         assertThatThrownBy(() -> {
             new KafkaSource<>(vertx, "my-group",
                     new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
-                    CountKafkaCdiEvents.noCdiEvents);
+                    CountKafkaCdiEvents.noCdiEvents, -1);
         }).isInstanceOf(DeploymentException.class).hasMessageContaining("mine");
     }
 
@@ -302,7 +302,7 @@ public class CommitStrategiesTest extends WeldTestBase {
         config.with("consumer-rebalance-listener.name", "mine");
         KafkaSource<String, String> source = new KafkaSource<>(vertx, "my-group",
                 new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
-                CountKafkaCdiEvents.noCdiEvents);
+                CountKafkaCdiEvents.noCdiEvents, -1);
 
         injectMockConsumer(source, consumer);
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
@@ -63,7 +63,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
                 "test-source-with-auto-commit-enabled",
                 ic,
                 getConsumerRebalanceListeners(),
-                CountKafkaCdiEvents.noCdiEvents);
+                CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = Collections.synchronizedList(new ArrayList<>());
         source.getStream().subscribe().with(messages::add);
@@ -86,7 +86,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         firstMessage.get().ack().whenComplete((a, t) -> ackFuture.complete(null));
         ackFuture.get(10, TimeUnit.SECONDS);
 
-        admin = KafkaAdminHelper.createAdminClient(vertx, config).getDelegate();
+        admin = KafkaAdminHelper.createAdminClient(vertx, config, topic).getDelegate();
         await().atMost(2, TimeUnit.MINUTES)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
@@ -119,7 +119,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
 
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, "test-source-with-auto-commit-disabled", ic,
-                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents);
+                getConsumerRebalanceListeners(), CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = Collections.synchronizedList(new ArrayList<>());
         source.getStream().subscribe().with(messages::add);
@@ -139,7 +139,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
 
         TopicPartition topicPartition = new TopicPartition(topic, 0);
         CompletableFuture<Map<TopicPartition, OffsetAndMetadata>> future = new CompletableFuture<>();
-        admin = KafkaAdminHelper.createAdminClient(vertx, config).getDelegate();
+        admin = KafkaAdminHelper.createAdminClient(vertx, config, topic).getDelegate();
         admin
                 .listConsumerGroupOffsets("test-source-with-auto-commit-disabled",
                         new ListConsumerGroupOffsetsOptions()
@@ -169,7 +169,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         source = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit", ic,
                 getConsumerRebalanceListeners(),
-                CountKafkaCdiEvents.noCdiEvents);
+                CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = Collections.synchronizedList(new ArrayList<>());
         source.getStream().subscribe().with(messages::add);
@@ -182,7 +182,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         assertThat(messages.stream().map(m -> ((KafkaRecord<String, Integer>) m).getPayload())
                 .collect(Collectors.toList())).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-        admin = KafkaAdminHelper.createAdminClient(vertx, config).getDelegate();
+        admin = KafkaAdminHelper.createAdminClient(vertx, config, topic).getDelegate();
         await().atMost(2, TimeUnit.MINUTES)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
@@ -230,7 +230,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         source = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit-without-acking", ic,
                 getConsumerRebalanceListeners(),
-                CountKafkaCdiEvents.noCdiEvents);
+                CountKafkaCdiEvents.noCdiEvents, -1);
 
         List<Message<?>> messages = Collections.synchronizedList(new ArrayList<>());
         source.getStream().subscribe().with(messages::add);


### PR DESCRIPTION
That makes consuming the metrics much simpler.