### PR TITLE
Extend Kafka DLQ headers

### DIFF
--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -119,7 +119,7 @@ The Kafka connector supports 3 strategies:
 The offset of the record that has not been processed correctly is not committed.
 * `ignore` - the failure is logged, but the processing continue.
 The offset of the record that has not been processed correctly is committed.
-* `dead-letter-queue` - the offset of the record that has not been processed correctly is committed, but the record is written to a (Kafka) _dead letter topic_.
+* `dead-letter-queue` - the offset of the record that has not been processed correctly is committed, but the record is written to a (Kafka) _dead letter queue_ topic.
 
 The strategy is selected using the `failure-strategy` attribute.
 
@@ -129,8 +129,13 @@ In the case of `dead-letter-queue`, you can configure the following attributes:
 * `dead-letter-queue.key.serializer`: the serializer used to write the record key on the dead letter queue. By default, it deduces the serializer from the key deserializer.
 * `dead-letter-queue.value.serializer`: the serializer used to write the record value on the dead letter queue. By default, it deduces the serializer from the value deserializer.
 
-The record written on the dead letter queue contains the `dead-letter-reason` header with the nack reason (message from the exception passed to the `nack` method).
-It may also contain the `dead-letter-cause` with the message from the cause, if any.
+The record written on the dead letter queue contains a set of additional headers about the original record:
+
+* `dead-letter-reason` - the reason of the failure
+* `dead-letter-cause` - the cause of the failure if any
+* `dead-letter-topic` - the original topic of the record
+* `dead-letter-partition` - the original partition of the record (integer mapped to String)
+* `dead-letter-offset` - the original offset of the record (long mapped to String)
 
 === Receiving Cloud Events
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterQueue.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterQueue.java
@@ -20,6 +20,12 @@ import io.vertx.mutiny.kafka.client.producer.KafkaProducerRecord;
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class KafkaDeadLetterQueue implements KafkaFailureHandler {
 
+    public static final String DEAD_LETTER_REASON = "dead-letter-reason";
+    public static final String DEAD_LETTER_CAUSE = "dead-letter-cause";
+    public static final String DEAD_LETTER_TOPIC = "dead-letter-topic";
+    public static final String DEAD_LETTER_OFFSET = "dead-letter-offset";
+    public static final String DEAD_LETTER_PARTITION = "dead-letter-partition";
+
     private final String channel;
     private final KafkaProducer producer;
     private final String topic;
@@ -71,10 +77,13 @@ public class KafkaDeadLetterQueue implements KafkaFailureHandler {
     public <K, V> CompletionStage<Void> handle(
             IncomingKafkaRecord<K, V> record, Throwable reason) {
         KafkaProducerRecord<K, V> dead = KafkaProducerRecord.create(topic, record.getKey(), record.getPayload());
-        dead.addHeader("dead-letter-reason", reason.getMessage());
+        dead.addHeader(DEAD_LETTER_REASON, reason.getMessage());
         if (reason.getCause() != null) {
-            dead.addHeader("dead-letter-cause", reason.getCause().getMessage());
+            dead.addHeader(DEAD_LETTER_CAUSE, reason.getCause().getMessage());
         }
+        dead.addHeader(DEAD_LETTER_TOPIC, record.getTopic());
+        dead.addHeader(DEAD_LETTER_PARTITION, Integer.toString(record.getPartition()));
+        dead.addHeader(DEAD_LETTER_OFFSET, Long.toString(record.getOffset()));
         log.messageNackedDeadLetter(channel, topic);
         return producer.send(dead)
                 .onFailure().invoke(t -> source.reportFailure((Throwable) t))

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/fault/KafkaFailureHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/fault/KafkaFailureHandlerTest.java
@@ -1,5 +1,6 @@
 package io.smallrye.reactive.messaging.kafka.fault;
 
+import static io.smallrye.reactive.messaging.kafka.fault.KafkaDeadLetterQueue.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -136,8 +137,11 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
         assertThat(records).allSatisfy(r -> {
             assertThat(r.topic()).isEqualTo("dead-letter-topic-kafka");
             assertThat(r.value()).isIn(3, 6, 9);
-            assertThat(new String(r.headers().lastHeader("dead-letter-reason").value())).startsWith("nack 3 -");
-            assertThat(r.headers().lastHeader("dead-letter-cause")).isNull();
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_REASON).value())).startsWith("nack 3 -");
+            assertThat(r.headers().lastHeader(DEAD_LETTER_CAUSE)).isNull();
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_PARTITION).value())).isEqualTo("0");
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_TOPIC).value())).isEqualTo("dead-letter-default");
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_OFFSET).value())).isNotNull().isIn("3", "6", "9");
         });
 
         assertThat(isAlive()).isTrue();
@@ -171,8 +175,11 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
         assertThat(records).allSatisfy(r -> {
             assertThat(r.topic()).isEqualTo("dead-letter-topic-kafka-payload");
             assertThat(r.value()).isIn(3, 6, 9);
-            assertThat(new String(r.headers().lastHeader("dead-letter-reason").value())).startsWith("nack 3 -");
-            assertThat(r.headers().lastHeader("dead-letter-cause")).isNull();
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_REASON).value())).startsWith("nack 3 -");
+            assertThat(r.headers().lastHeader(DEAD_LETTER_CAUSE)).isNull();
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_PARTITION).value())).isEqualTo("0");
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_TOPIC).value())).isEqualTo("dq-payload");
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_OFFSET).value())).isNotNull().isIn("3", "6", "9");
         });
 
         assertThat(isAlive()).isTrue();
@@ -205,8 +212,11 @@ public class KafkaFailureHandlerTest extends KafkaTestBase {
         assertThat(records).allSatisfy(r -> {
             assertThat(r.topic()).isEqualTo("missed");
             assertThat(r.value()).isIn(3, 6, 9);
-            assertThat(new String(r.headers().lastHeader("dead-letter-reason").value())).startsWith("nack 3 -");
-            assertThat(r.headers().lastHeader("dead-letter-cause")).isNull();
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_REASON).value())).startsWith("nack 3 -");
+            assertThat(r.headers().lastHeader(DEAD_LETTER_CAUSE)).isNull();
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_PARTITION).value())).isEqualTo("0");
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_TOPIC).value())).isEqualTo("dead-letter-custom");
+            assertThat(new String(r.headers().lastHeader(DEAD_LETTER_OFFSET).value())).isNotNull().isIn("3", "6", "9");
         });
 
         assertThat(isAlive()).isTrue();


### PR DESCRIPTION
Extend the set of headers written with a record sent to the DLQ.
It is now possible to compute the original position of the record.﻿
