### PR TITLE
Improve health check reporting for application's failure

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -282,7 +282,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
                     .values()
                     .stream()
                     .filter(OffsetStore::hasTooManyMessagesWithoutAck)
-                    .forEach(o -> this.source.reportFailure(new TooManyMessagesWithoutAckException()));
+                    .forEach(o -> this.source.reportFailure(new TooManyMessagesWithoutAckException(), true));
         }
 
     }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterQueue.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterQueue.java
@@ -77,7 +77,7 @@ public class KafkaDeadLetterQueue implements KafkaFailureHandler {
         }
         log.messageNackedDeadLetter(channel, topic);
         return producer.send(dead)
-                .onFailure().invoke(t -> source.reportFailure((Throwable) t))
+                .onFailure().invoke(t -> source.reportFailure((Throwable) t, true))
                 .onItem().ignore().andContinueWithNull()
                 .subscribeAsCompletionStage()
                 .thenCompose(m -> record.ack());

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaFailStop.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaFailStop.java
@@ -26,7 +26,7 @@ public class KafkaFailStop implements KafkaFailureHandler {
         CompletableFuture<Void> future = new CompletableFuture<>();
         future.completeExceptionally(reason);
         // report failure to the connector for health check
-        source.reportFailure(reason);
+        source.reportFailure(reason, true);
         return future;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -132,7 +132,7 @@ public class KafkaSource<K, V> {
         Multi<KafkaConsumerRecord<K, V>> multi = consumer.toMulti()
                 .onFailure().invoke(t -> {
                     log.unableToReadRecord(topics, t);
-                    reportFailure(t);
+                    reportFailure(t, false);
                 });
 
         if (commitHandler instanceof ContextHolder) {
@@ -159,7 +159,7 @@ public class KafkaSource<K, V> {
 
         Multi<IncomingKafkaRecord<K, V>> incomingMulti = multi
                 .onSubscribe().call(s -> {
-                    this.consumer.exceptionHandler(this::reportFailure);
+                    this.consumer.exceptionHandler(t -> reportFailure(t, false));
                     if (this.pattern != null) {
                         BiConsumer<UniEmitter<?>, AsyncResult<Void>> completionHandler = (e, ar) -> {
                             if (ar.failed()) {
@@ -188,7 +188,7 @@ public class KafkaSource<K, V> {
         }
 
         this.stream = incomingMulti
-                .onFailure().invoke(this::reportFailure);
+                .onFailure().invoke(t -> reportFailure(t, false));
     }
 
     private Set<String> getTopics(KafkaConnectorIncomingConfiguration config) {
@@ -217,13 +217,17 @@ public class KafkaSource<K, V> {
         }
     }
 
-    public synchronized void reportFailure(Throwable failure) {
+    public synchronized void reportFailure(Throwable failure, boolean fatal) {
         log.failureReported(topics, failure);
         // Don't keep all the failures, there are only there for reporting.
         if (failures.size() == 10) {
             failures.remove(0);
         }
         failures.add(failure);
+
+        if (fatal) {
+            consumer.closeAndForget();
+        }
     }
 
     public void incomingTrace(IncomingKafkaRecord<K, V> kafkaRecord) {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/SubscriberMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/SubscriberMediator.java
@@ -135,7 +135,7 @@ public class SubscriberMediator extends AbstractMediator {
                             .onItem().transformToUni(msg -> invokeBlocking(msg.getPayload()))
                             .onItemOrFailure().transformToUni(handleInvocationResult(m))
                             .subscribeAsCompletionStage())
-                    .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
+                    .onError(failure -> health.reportApplicationFailure(configuration.methodAsString(), failure))
                     .ignore();
         } else {
             this.subscriber = ReactiveStreams.<Message<?>> builder()
@@ -143,7 +143,7 @@ public class SubscriberMediator extends AbstractMediator {
                             .onItem().transform(msg -> invoke(msg.getPayload()))
                             .onItemOrFailure().transformToUni(handleInvocationResult(m))
                             .subscribeAsCompletionStage())
-                    .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
+                    .onError(failure -> health.reportApplicationFailure(configuration.methodAsString(), failure))
                     .ignore();
         }
     }
@@ -184,7 +184,7 @@ public class SubscriberMediator extends AbstractMediator {
                         })
                         .onItemOrFailure().transformToUni(handleInvocationResult(message))
                         .subscribeAsCompletionStage())
-                .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
+                .onError(failure -> health.reportApplicationFailure(configuration.methodAsString(), failure))
                 .ignore();
     }
 
@@ -202,7 +202,7 @@ public class SubscriberMediator extends AbstractMediator {
                         })
                         .onItemOrFailure().transformToUni(handleInvocationResult(message))
                         .subscribeAsCompletionStage())
-                .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
+                .onError(failure -> health.reportApplicationFailure(configuration.methodAsString(), failure))
                 .ignore();
     }
 
@@ -242,7 +242,7 @@ public class SubscriberMediator extends AbstractMediator {
             this.subscriber = ReactiveStreams.<Message<?>> builder()
                     .flatMapCompletionStage(this::handlePreProcessingAck)
                     .via(wrapper)
-                    .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
+                    .onError(failure -> health.reportApplicationFailure(configuration.methodAsString(), failure))
                     .ignore();
         } else {
             Subscriber<Message<?>> sub;
@@ -255,7 +255,7 @@ public class SubscriberMediator extends AbstractMediator {
             this.subscriber = ReactiveStreams.<Message<?>> builder()
                     .flatMapCompletionStage(this::handlePreProcessingAck)
                     .via(new SubscriberWrapper<>(casted, Function.identity(), null))
-                    .onError(failure -> health.report(configuration.getIncoming().toString(), failure))
+                    .onError(failure -> health.reportApplicationFailure(configuration.methodAsString(), failure))
                     .ignore();
         }
     }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/HealthCenter.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/HealthCenter.java
@@ -41,6 +41,10 @@ public class HealthCenter {
         failures.add(new ReportedFailure(source, cause));
     }
 
+    public void reportApplicationFailure(String method, Throwable cause) {
+        failures.add(new ReportedFailure("application-" + method, cause));
+    }
+
     public static class ReportedFailure {
         final String source;
         final Throwable failure;


### PR DESCRIPTION
Improve the health check reporting for application failure. 
In addition, close the Kafka consumer if the failure is fatal.﻿
