### PR TITLE
Avoid adding empty section to the outgoing AMQP message

### DIFF
--- a/documentation/src/main/doc/modules/ROOT/nav.adoc
+++ b/documentation/src/main/doc/modules/ROOT/nav.adoc
@@ -31,12 +31,16 @@
 *** xref:kafka:kafka.adoc#kafka-installation[Using the connector]
 *** xref:kafka:kafka.adoc#kafka-inbound[Receiving Kafka Records]
 *** xref:kafka:kafka.adoc#kafka-outbound[Writing Kafka Records]
+*** xref:kafka:kafka.adoc#kafka-health[Health Check]
+*** xref:kafka:kafka.adoc#kafka-avro-configuration[Using Avro]
 
 ** xref:amqp:amqp.adoc[AMQP]
 *** xref:amqp:amqp.adoc#amqp-installation[Using the connector]
 *** xref:amqp:amqp.adoc#amqp-inbound[Receiving AMQP Messages]
 *** xref:amqp:amqp.adoc#amqp-outbound[Sending AMQP Messages]
 *** xref:amqp:amqp.adoc#amqp-customization[Configuring the client]
+*** xref:amqp:amqp.adoc#amqp-health[Health Check]
+*** xref:amqp:amqp.adoc#amqp-rabbitmq[Connecting with RabbitMQ]
 
 ** xref:camel:camel.adoc[Apache Camel]
 *** xref:camel:camel.adoc#camel-installation[Using the connector]

--- a/documentation/src/main/doc/modules/amqp/pages/amqp.adoc
+++ b/documentation/src/main/doc/modules/amqp/pages/amqp.adoc
@@ -16,6 +16,7 @@ include::inbound.adoc[]
 include::outbound.adoc[]
 include::client-customization.adoc[]
 include::health.adoc[]
+include::rabbitmq.adoc[]
 
 
 

--- a/documentation/src/main/doc/modules/amqp/pages/installation.adoc
+++ b/documentation/src/main/doc/modules/amqp/pages/installation.adoc
@@ -28,6 +28,5 @@ mp.messaging.outgoing.[channel-name].connector=smallrye-amqp
 [IMPORTANT]
 .RabbitMQ
 ====
-This connector is for AMQP 1.0. RabbitMQ implements AMQP 0.9.1.
-To use this connector with RabbitMQ, you need to enable and configure the https://github.com/rabbitmq/rabbitmq-amqp1.0/blob/v3.7.x/README.md[AMQP 1.0 plugin].
+To use RabbitMQ, refer to <<amqp-rabbitmq>>.
 ====

--- a/documentation/src/main/doc/modules/amqp/pages/rabbitmq.adoc
+++ b/documentation/src/main/doc/modules/amqp/pages/rabbitmq.adoc
@@ -1,0 +1,34 @@
+[#amqp-rabbitmq]
+== Using RabbitMQ
+
+This connector is for AMQP 1.0.
+RabbitMQ implements AMQP 0.9.1.
+RabbitMQ does not provide AMQP 1.0 by default, but there is a plugin for it.
+To use RabbitMQ with this connector, enable and configure the https://github.com/rabbitmq/rabbitmq-amqp1.0/blob/v3.8.x/README.md[AMQP 1.0 plugin].
+
+Despite the plugin, a few features won't work with RabbitMQ.
+Thus, we recommend the following configurations.
+
+To receive messages from RabbitMQ:
+
+* Set `durable` to `false`
+
+[source, properties]
+----
+mp.messaging.incoming.prices.connector=smallrye-amqp
+mp.messaging.incoming.prices.durable=false
+----
+
+To send messages to RabbitMQ:
+
+* set the destination `address` (anonymous sender are not supported)
+* set `use-anonymous-sender` to `false`
+
+[source, properties]
+----
+mp.messaging.outgoing.generated-price.connector=smallrye-amqp
+mp.messaging.outgoing.generated-price.address=prices
+mp.messaging.outgoing.generated-price.use-anonymous-sender=false
+----
+
+As a consequence, it's not possible to change the destination dynamically (using message metadata) when using RabbitMQ.

--- a/documentation/src/main/doc/modules/kafka/pages/kafka.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/kafka.adoc
@@ -25,6 +25,8 @@ include::outbound.adoc[]
 include::default-configuration.adoc[]
 include::avro-configuration.adoc[]
 include::health.adoc[]
+include::consumer-rebalance-listener.adoc[]
+
 
 
 

--- a/smallrye-reactive-messaging-amqp/pom.xml
+++ b/smallrye-reactive-messaging-amqp/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -56,6 +57,17 @@
       <artifactId>smallrye-connector-attribute-processor</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessageConverter.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessageConverter.java
@@ -11,6 +11,9 @@ import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.DeliveryAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Footer;
+import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 import io.vertx.amqp.impl.AmqpMessageImpl;
@@ -51,8 +54,14 @@ public class AmqpMessageConverter {
         }
 
         // Annotations
-        output.setDeliveryAnnotations(metadata.getDeliveryAnnotations());
-        output.setMessageAnnotations(metadata.getMessageAnnotations());
+        DeliveryAnnotations deliveryAnnotations = metadata.getDeliveryAnnotations();
+        MessageAnnotations messageAnnotations = metadata.getMessageAnnotations();
+        if (!deliveryAnnotations.getValue().isEmpty()) {
+            output.setDeliveryAnnotations(deliveryAnnotations);
+        }
+        if (!messageAnnotations.getValue().isEmpty()) {
+            output.setMessageAnnotations(messageAnnotations);
+        }
 
         // Properties
         output.setMessageId(metadata.getMessageId());
@@ -69,7 +78,9 @@ public class AmqpMessageConverter {
         output.setGroupSequence(metadata.getGroupSequence());
         output.setReplyToGroupId(metadata.getReplyToGroupId());
 
-        output.setApplicationProperties(new ApplicationProperties(metadata.getProperties().getMap()));
+        if (!metadata.getProperties().isEmpty()) {
+            output.setApplicationProperties(new ApplicationProperties(metadata.getProperties().getMap()));
+        }
 
         // Application data section:
         if (payload instanceof String || isPrimitive(payload.getClass()) || payload instanceof UUID) {
@@ -116,7 +127,10 @@ public class AmqpMessageConverter {
         }
 
         // Footer
-        output.setFooter(metadata.getFooter());
+        Footer footer = metadata.getFooter();
+        if (!footer.getValue().isEmpty()) {
+            output.setFooter(footer);
+        }
 
         return new AmqpMessage(new AmqpMessageImpl(output));
     }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpUsage.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpUsage.java
@@ -69,7 +69,7 @@ public class AmqpUsage {
                             msg = new AmqpMessage(new AmqpMessageImpl(m));
                         } else {
                             AmqpMessageBuilder builder = io.vertx.mutiny.amqp.AmqpMessage.create()
-                                    .durable(true)
+                                    .durable(false)
                                     .ttl(10000);
                             if (payload instanceof Integer) {
                                 builder.withIntegerAsBody((Integer) payload);

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/RabbitMQBrokerTestBase.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/RabbitMQBrokerTestBase.java
@@ -1,0 +1,86 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.extension.HealthCenter;
+import io.vertx.mutiny.core.Vertx;
+
+public class RabbitMQBrokerTestBase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("RabbitMQ");
+
+    private static final GenericContainer<?> RABBIT = new GenericContainer<>(DockerImageName.parse("rabbitmq:3-management"))
+            .withExposedPorts(5672, 15672)
+            .withLogConsumer(of -> LOGGER.info(of.getUtf8String()))
+            .waitingFor(
+                Wait.forLogMessage(".*Server startup complete; 4 plugins started.*\\n", 1)
+            )
+            .withFileSystemBind("src/test/resources/rabbitmq/enabled_plugins", "/etc/rabbitmq/enabled_plugins",
+                    BindMode.READ_ONLY);
+
+    protected static String host;
+    protected static int port;
+    final static String username = "guest";
+    final static String password = "guest";
+    AmqpUsage usage;
+    ExecutionHolder executionHolder;
+
+    @BeforeAll
+    public static void startBroker() {
+        RABBIT.start();
+
+        port = RABBIT.getMappedPort(5672);
+        host = RABBIT.getContainerIpAddress();
+
+        System.setProperty("amqp-host", host);
+        System.setProperty("amqp-port", Integer.toString(port));
+    }
+
+    @AfterAll
+    public static void stopBroker() {
+        RABBIT.stop();
+        System.clearProperty("amqp-host");
+        System.clearProperty("amqp-port");
+    }
+
+    @BeforeEach
+    public void setup() {
+        executionHolder = new ExecutionHolder(Vertx.vertx());
+
+        usage = new AmqpUsage(executionHolder.vertx(), host, port, username, password);
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+        MapBasedConfig.clear();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        usage.close();
+        executionHolder.terminate(null);
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+        MapBasedConfig.clear();
+    }
+
+    public boolean isAmqpConnectorReady(WeldContainer container) {
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        return health.getReadiness().isOk();
+    }
+
+    public boolean isAmqpConnectorAlive(WeldContainer container) {
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        return health.getLiveness().isOk();
+    }
+
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/RabbitMQTest.java
@@ -1,0 +1,95 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.extension.MediatorManager;
+
+public class RabbitMQTest extends RabbitMQBrokerTestBase {
+
+    private WeldContainer container;
+
+    Weld weld = new Weld();
+
+    @AfterEach
+    public void cleanup() {
+        if (container != null) {
+            container.shutdown();
+        }
+
+        MapBasedConfig.clear();
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+    }
+
+    @Test
+    public void testSendingMessagesToRabbitMQ() throws InterruptedException {
+
+        CountDownLatch latch = new CountDownLatch(10);
+        usage.consumeIntegers("sink",
+                v -> latch.countDown());
+
+        weld.addBeanClass(ProducingBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.outgoing.sink.address", "sink")
+                .put("mp.messaging.outgoing.sink.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.outgoing.sink.host", host)
+                .put("mp.messaging.outgoing.sink.port", port)
+                .put("mp.messaging.outgoing.sink.durable", false)
+                .put("mp.messaging.outgoing.sink.use-anonymous-sender", false)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isAmqpConnectorReady(container));
+        await().until(() -> isAmqpConnectorAlive(container));
+
+        assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+    }
+
+    @Test
+    public void testReceivingMessagesFromRabbitMQ() {
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.data.address", "data")
+                .put("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data.host", host)
+                .put("mp.messaging.incoming.data.port", port)
+                .put("mp.messaging.incoming.data.durable", false)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .write();
+
+        weld.addBeanClass(ConsumptionBean.class);
+
+        container = weld.initialize();
+        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
+        await().until(() -> isAmqpConnectorReady(container));
+        await().until(() -> isAmqpConnectorAlive(container));
+        ConsumptionBean bean = container.getBeanManager().createInstance().select(ConsumptionBean.class).get();
+
+        await().until(() -> isAmqpConnectorReady(container));
+        await().until(() -> isAmqpConnectorAlive(container));
+
+        List<Integer> list = bean.getResults();
+        assertThat(list).isEmpty();
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers("data", counter::getAndIncrement);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
+        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+}

--- a/smallrye-reactive-messaging-amqp/src/test/resources/rabbitmq/enabled_plugins
+++ b/smallrye-reactive-messaging-amqp/src/test/resources/rabbitmq/enabled_plugins
@@ -1,0 +1,2 @@
+[rabbitmq_management,rabbitmq_management_agent,rabbitmq_amqp1_0,rabbitmq_web_dispatch].
+


### PR DESCRIPTION
Do not add the section to the outgoing AMQP message if the section is empty.

Fix #806
Fix #807

