### PR TITLE
Fix NPE from ACKed kafka record on revoked topic partition

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -169,4 +169,8 @@ public interface KafkaLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.INFO)
     @Message(id = 18238, value = "Setting client.id for Kafka consumer to %s")
     void setKafkaConsumerClientId(String name);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 18239, value = "Acked record %d on group %s was ignored because the topic partition %s was revoked for this instance. Record will likely be processed again.")
+    void messageAckedForRevokedTopicPartition(String groupId, String topicPartition, long offset);
 }


### PR DESCRIPTION
@cescoffier 

Found a bug. An NPE was raised on the throttled commit strategy for an ACKed record on a revoked topic partition. In my case I was playing around with MANUAL Acknowledgment and delaying the ACK. The NPE was caused because the offset store no longer exists after revocation.