### PR TITLE
Increase the log level of consumer failures

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -126,7 +126,7 @@ public interface KafkaLogging extends BasicLogger {
     @Message(id = 18227, value = "Re-enabling consumer for group '%s'. This consumer was paused because of a re-balance failure.")
     void reEnablingConsumerForGroup(String consumerGroup);
 
-    @LogMessage(level = Logger.Level.DEBUG)
+    @LogMessage(level = Logger.Level.WARN)
     @Message(id = 18228, value = "A failure has been reported for Kafka topics '%s'")
     void failureReported(Set<String> topics, @Cause Throwable t);
 


### PR DESCRIPTION
Consumer failures can arrives when a deserializer fails to deserialize the message.
At DEBUG level, such issue may be hard to find.
Increasing the level to WARNING as it's the level used by most nack messages.