### PR TITLE
Prevent JsonHelper from swallowing Booleans

### DIFF
--- a/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/JsonHelper.java
+++ b/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/JsonHelper.java
@@ -27,6 +27,14 @@ public class JsonHelper {
             }
 
             try {
+                boolean b = config.getValue(key, Boolean.class);
+                json.put(key, b);
+                continue;
+            } catch (ClassCastException | IllegalArgumentException e) {
+                // Ignore me
+            }
+
+            try {
                 String value = config.getValue(key, String.class);
                 if (value.trim().equalsIgnoreCase("false")) {
                     json.put(key, false);

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelper.java
@@ -39,6 +39,16 @@ public class JsonHelper {
             }
 
             try {
+                Optional<Boolean> b = config.getOptionalValue(originalKey, Boolean.class);
+                if (b.isPresent()) {
+                    json.put(key, b.get());
+                    continue;
+                }
+            } catch (ClassCastException | IllegalArgumentException e) {
+                // Ignore me
+            }
+
+            try {
                 String value = config.getOptionalValue(originalKey, String.class).orElse("").trim();
                 if (value.equalsIgnoreCase("false")) {
                     json.put(key, false);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelperTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelperTest.java
@@ -19,6 +19,7 @@ class JsonHelperTest {
                 .put("trueasstring", "true")
                 .put("falseasstring", "false")
                 .put("FOO_BAR", "value")
+                .put("someboolean", true)
                 .build();
 
         JsonObject object = JsonHelper.asJsonObject(config);
@@ -29,6 +30,7 @@ class JsonHelperTest {
         assertThat(object.getBoolean("falseasstring")).isFalse();
         assertThat(object.getString("foo.bar")).isEqualTo("value");
         assertThat(object.getString("bootstrap.servers")).isEqualTo("not-important");
+        assertThat(object.getBoolean("someboolean")).isTrue();
 
     }
 


### PR DESCRIPTION
I was trying to pass a `Boolean` value as Kafka configuration. Very unexpectedly it disappeared after `asJsonObject`. Since JSON has the usual notion of booleans, I think it is only natural for `asJsonObject` to support that.

If you decide that you do not want to accept this MR, I think you should instead have `asJsonObject` log the skipped properties.