### PR TITLE
Implementation of a new wiring algorithm

### DIFF
--- a/api/src/main/java/io/smallrye/reactive/messaging/ChannelRegistry.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/ChannelRegistry.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.microprofile.reactive.messaging.Emitter;
@@ -10,7 +11,12 @@ import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 
 public interface ChannelRegistry {
 
-    PublisherBuilder<? extends Message<?>> register(String name, PublisherBuilder<? extends Message<?>> stream);
+    default PublisherBuilder<? extends Message<?>> register(String name, PublisherBuilder<? extends Message<?>> stream) {
+        return register(name, stream, false);
+    }
+
+    PublisherBuilder<? extends Message<?>> register(String name, PublisherBuilder<? extends Message<?>> stream,
+            boolean broadcast);
 
     SubscriberBuilder<? extends Message<?>, Void> register(String name,
             SubscriberBuilder<? extends Message<?>, Void> subscriber);
@@ -32,4 +38,6 @@ public interface ChannelRegistry {
     Set<String> getOutgoingNames();
 
     Set<String> getEmitterNames();
+
+    Map<String, Boolean> getIncomingChannels();
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpFailureHandlerTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpFailureHandlerTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
-import io.smallrye.reactive.messaging.extension.MediatorManager;
 
 public class AmqpFailureHandlerTest extends AmqpBrokerTestBase {
 
@@ -41,7 +40,6 @@ public class AmqpFailureHandlerTest extends AmqpBrokerTestBase {
         weld.addBeanClass(MyReceiverBean.class);
 
         container = weld.initialize();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
         return container.getBeanManager().createInstance().select(MyReceiverBean.class).get();
     }
 
@@ -50,7 +48,6 @@ public class AmqpFailureHandlerTest extends AmqpBrokerTestBase {
         weld.addBeanClass(MyReceiverBeanRecovering.class);
 
         container = weld.initialize();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
         return container.getBeanManager().createInstance().select(MyReceiverBeanRecovering.class).get();
     }
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
@@ -30,7 +30,6 @@ import org.reactivestreams.Subscription;
 import io.smallrye.common.constraint.NotNull;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
-import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.amqp.AmqpMessage;
@@ -235,7 +234,6 @@ public class AmqpSourceTest extends AmqpBrokerTestBase {
         weld.addBeanClass(ConsumptionBean.class);
 
         container = weld.initialize();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
         return container.getBeanManager().createInstance().select(ConsumptionBean.class).get();
     }
 
@@ -439,7 +437,6 @@ public class AmqpSourceTest extends AmqpBrokerTestBase {
                 .write();
 
         container = weld.initialize();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
         List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
         assertThat(list).isEmpty();
 
@@ -468,7 +465,6 @@ public class AmqpSourceTest extends AmqpBrokerTestBase {
                 .write();
 
         container = weld.initialize();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
         List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
         assertThat(list).isEmpty();
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/RabbitMQTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
-import io.smallrye.reactive.messaging.extension.MediatorManager;
 
 public class RabbitMQTest extends RabbitMQBrokerTestBase {
 
@@ -75,7 +74,6 @@ public class RabbitMQTest extends RabbitMQBrokerTestBase {
         weld.addBeanClass(ConsumptionBean.class);
 
         container = weld.initialize();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
         await().until(() -> isAmqpConnectorReady(container));
         await().until(() -> isAmqpConnectorAlive(container));
         ConsumptionBean bean = container.getBeanManager().createInstance().select(ConsumptionBean.class).get();

--- a/smallrye-reactive-messaging-aws-sns/src/test/java/io/smallrye/reactive/messaging/aws/sns/AwsSnsTestBase.java
+++ b/smallrye-reactive-messaging-aws-sns/src/test/java/io/smallrye/reactive/messaging/aws/sns/AwsSnsTestBase.java
@@ -21,6 +21,7 @@ import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
+import io.smallrye.reactive.messaging.wiring.Wiring;
 import io.vertx.mutiny.core.Vertx;
 
 public class AwsSnsTestBase {
@@ -70,6 +71,7 @@ public class AwsSnsTestBase {
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
         weld.addBeanClass(HealthCenter.class);
+        weld.addBeanClass(Wiring.class);
         weld.addExtension(new ReactiveMessagingExtension());
 
         weld.addBeanClass(SnsConnector.class);

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/source/FailureHandlerTest.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/source/FailureHandlerTest.java
@@ -23,7 +23,6 @@ import io.smallrye.reactive.messaging.camel.CamelConnector;
 import io.smallrye.reactive.messaging.camel.CamelMessage;
 import io.smallrye.reactive.messaging.camel.CamelTestBase;
 import io.smallrye.reactive.messaging.camel.MapBasedConfig;
-import io.smallrye.reactive.messaging.extension.MediatorManager;
 
 public class FailureHandlerTest extends CamelTestBase {
 
@@ -41,7 +40,6 @@ public class FailureHandlerTest extends CamelTestBase {
         weld.addBeanClass(MyReceiverBean.class);
 
         container = weld.initialize();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
         return container.getBeanManager().createInstance().select(MyReceiverBean.class).get();
     }
 
@@ -108,7 +106,7 @@ public class FailureHandlerTest extends CamelTestBase {
 
     @ApplicationScoped
     public static class MyReceiverBean {
-        private List<String> received = new CopyOnWriteArrayList<>();
+        private final List<String> received = new CopyOnWriteArrayList<>();
 
         private static final List<String> SKIPPED = Arrays.asList("3", "6", "9");
 

--- a/smallrye-reactive-messaging-gcp-pubsub/src/test/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubTestBase.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/test/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubTestBase.java
@@ -27,6 +27,7 @@ import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
+import io.smallrye.reactive.messaging.wiring.Wiring;
 
 public class PubSubTestBase {
 
@@ -97,6 +98,7 @@ public class PubSubTestBase {
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
         weld.addBeanClass(HealthCenter.class);
+        weld.addBeanClass(Wiring.class);
         weld.addExtension(new ReactiveMessagingExtension());
 
         weld.addBeanClass(PubSubManager.class);

--- a/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/WeldTestBase.java
+++ b/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/WeldTestBase.java
@@ -24,6 +24,7 @@ import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
 import io.smallrye.reactive.messaging.impl.LegacyConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.metrics.MetricDecorator;
+import io.smallrye.reactive.messaging.wiring.Wiring;
 
 public class WeldTestBase {
 
@@ -72,6 +73,7 @@ public class WeldTestBase {
                 LegacyConfiguredChannelFactory.class,
                 MetricDecorator.class,
                 HealthCenter.class,
+                Wiring.class,
 
                 // In memory connector
                 InMemoryConnector.class,

--- a/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/jms/support/JmsTestBase.java
+++ b/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/jms/support/JmsTestBase.java
@@ -18,6 +18,7 @@ import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
 import io.smallrye.reactive.messaging.jms.JmsConnector;
+import io.smallrye.reactive.messaging.wiring.Wiring;
 
 public class JmsTestBase {
 
@@ -79,6 +80,7 @@ public class JmsTestBase {
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
         weld.addBeanClass(HealthCenter.class);
+        weld.addBeanClass(Wiring.class);
         weld.addExtension(new ReactiveMessagingExtension());
         weld.addBeanClass(JmsConnector.class);
         weld.disableDiscovery();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
@@ -25,6 +25,7 @@ import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
 import io.smallrye.reactive.messaging.kafka.KafkaCDIEvents;
 import io.smallrye.reactive.messaging.kafka.KafkaConnector;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaThrottledLatestProcessedCommit;
+import io.smallrye.reactive.messaging.wiring.Wiring;
 
 public class WeldTestBase {
 
@@ -47,6 +48,7 @@ public class WeldTestBase {
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
         weld.addBeanClass(HealthCenter.class);
+        weld.addBeanClass(Wiring.class);
         weld.addExtension(new ReactiveMessagingExtension());
 
         weld.addBeanClass(KafkaCDIEvents.class);

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ConnectionSharingTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ConnectionSharingTest.java
@@ -23,7 +23,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import io.smallrye.mutiny.Multi;
-import io.smallrye.reactive.messaging.extension.MediatorManager;
 
 public class ConnectionSharingTest extends MqttTestBase {
 
@@ -45,8 +44,6 @@ public class ConnectionSharingTest extends MqttTestBase {
         container = weld.initialize();
 
         App bean = container.getBeanManager().createInstance().select(App.class).get();
-
-        await().until(() -> this.container.select(MediatorManager.class).get().isInitialized());
 
         await()
                 .until(() -> this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/FailureHandlerTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/FailureHandlerTest.java
@@ -21,7 +21,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
-import io.smallrye.reactive.messaging.extension.MediatorManager;
 
 public class FailureHandlerTest extends MqttTestBase {
 
@@ -41,7 +40,6 @@ public class FailureHandlerTest extends MqttTestBase {
         weld.addBeanClass(MyReceiverBean.class);
 
         container = weld.initialize();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
         return container.getBeanManager().createInstance().select(MyReceiverBean.class).get();
     }
 
@@ -104,7 +102,7 @@ public class FailureHandlerTest extends MqttTestBase {
 
     @ApplicationScoped
     public static class MyReceiverBean {
-        private List<String> received = new CopyOnWriteArrayList<>();
+        private final List<String> received = new CopyOnWriteArrayList<>();
 
         private static final List<String> SKIPPED = Arrays.asList("3", "6", "9");
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
@@ -16,8 +16,6 @@ import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.After;
 import org.junit.Test;
 
-import io.smallrye.reactive.messaging.extension.MediatorManager;
-
 public class MqttSourceTest extends MqttTestBase {
 
     private WeldContainer container;
@@ -171,7 +169,6 @@ public class MqttSourceTest extends MqttTestBase {
     @Test
     public void testABeanConsumingTheMQTTMessages() {
         ConsumptionBean bean = deploy();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
 
         await()
                 .until(() -> container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttTestBase.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttTestBase.java
@@ -20,6 +20,7 @@ import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
+import io.smallrye.reactive.messaging.wiring.Wiring;
 import io.vertx.mutiny.core.Vertx;
 import repeat.RepeatRule;
 
@@ -75,6 +76,7 @@ public class MqttTestBase {
         weld.addBeanClass(ConfiguredChannelFactory.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
         weld.addBeanClass(ExecutionHolder.class);
+        weld.addBeanClass(Wiring.class);
         weld.addPackages(EmitterImpl.class.getPackage());
         weld.addExtension(new ReactiveMessagingExtension());
         weld.addBeanClass(MqttConnector.class);

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MultipleTopicsConsumptionTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MultipleTopicsConsumptionTest.java
@@ -19,8 +19,6 @@ import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.After;
 import org.junit.Test;
 
-import io.smallrye.reactive.messaging.extension.MediatorManager;
-
 public class MultipleTopicsConsumptionTest extends MqttTestBase {
 
     private WeldContainer container;
@@ -41,8 +39,6 @@ public class MultipleTopicsConsumptionTest extends MqttTestBase {
         container = weld.initialize();
 
         Consumers bean = container.getBeanManager().createInstance().select(Consumers.class).get();
-
-        await().until(() -> this.container.select(MediatorManager.class).get().isInitialized());
 
         await()
                 .until(() -> this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());
@@ -69,8 +65,6 @@ public class MultipleTopicsConsumptionTest extends MqttTestBase {
         container = weld.initialize();
 
         Consumers bean = container.getBeanManager().createInstance().select(Consumers.class).get();
-
-        await().until(() -> this.container.select(MediatorManager.class).get().isInitialized());
 
         await()
                 .until(() -> this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
@@ -16,8 +16,6 @@ import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.After;
 import org.junit.Test;
 
-import io.smallrye.reactive.messaging.extension.MediatorManager;
-
 public class SecureMqttSourceTest extends SecureMqttTestBase {
 
     private WeldContainer container;
@@ -62,7 +60,6 @@ public class SecureMqttSourceTest extends SecureMqttTestBase {
     @Test
     public void testABeanConsumingTheMQTTMessagesWithAuthentication() {
         ConsumptionBean bean = deploy();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
 
         List<Integer> list = bean.getResults();
         assertThat(list).isEmpty();

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ChannelConfiguration.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ChannelConfiguration.java
@@ -2,7 +2,11 @@ package io.smallrye.reactive.messaging.extension;
 
 public class ChannelConfiguration {
 
-    public final String channelName;
+    public String channelName;
+
+    public ChannelConfiguration() {
+        // Used for proxies.
+    }
 
     public ChannelConfiguration(String channelName) {
         this.channelName = channelName;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ChannelConfiguration.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ChannelConfiguration.java
@@ -1,0 +1,10 @@
+package io.smallrye.reactive.messaging.extension;
+
+public class ChannelConfiguration {
+
+    public final String channelName;
+
+    public ChannelConfiguration(String channelName) {
+        this.channelName = channelName;
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/EmitterConfiguration.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/EmitterConfiguration.java
@@ -37,7 +37,6 @@ public class EmitterConfiguration {
             this.broadcast = Boolean.TRUE;
             this.numberOfSubscriberBeforeConnecting = broadcast.value();
         } else {
-            this.broadcast = Boolean.FALSE;
             this.numberOfSubscriberBeforeConnecting = -1;
         }
     }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
@@ -1,44 +1,21 @@
 package io.smallrye.reactive.messaging.extension;
 
-import static io.smallrye.reactive.messaging.i18n.ProviderExceptions.ex;
 import static io.smallrye.reactive.messaging.i18n.ProviderLogging.log;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
+import java.util.*;
 
-import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.spi.AnnotatedMethod;
-import javax.enterprise.inject.spi.AnnotatedType;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.DeploymentException;
+import javax.enterprise.inject.spi.*;
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscription;
 
-import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.*;
 import io.smallrye.reactive.messaging.annotations.Incomings;
-import io.smallrye.reactive.messaging.annotations.Merge;
 import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
 
 /**
@@ -47,36 +24,12 @@ import io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry;
 @ApplicationScoped
 public class MediatorManager {
 
-    private static final int DEFAULT_BUFFER_SIZE = 128;
-
     public static final String STRICT_MODE_PROPERTY = "smallrye-messaging-strict-binding";
-    private final boolean strictMode = Boolean.parseBoolean(System.getProperty(STRICT_MODE_PROPERTY, "false"));
 
     private final CollectedMediatorMetadata collected = new CollectedMediatorMetadata();
 
-    // TODO Populate this list
-    private final List<Subscription> subscriptions = new CopyOnWriteArrayList<>();
-
-    private final List<AbstractMediator> mediators = new ArrayList<>();
-
-    @Inject
-    @ConfigProperty(name = "mp.messaging.emitter.default-buffer-size", defaultValue = "128")
-    int defaultBufferSize;
-
-    @Inject
-    @ConfigProperty(name = "smallrye.messaging.emitter.default-buffer-size", defaultValue = "128")
-    @Deprecated // Use mp.messaging.emitter.default-buffer-size instead
-    int defaultBufferSizeLegacy;
-
-    @Inject
-    @Any
-    Instance<ChannelRegistar> streamRegistars;
-
     @Inject
     MediatorFactory mediatorFactory;
-
-    @Inject
-    ChannelRegistry channelRegistry;
 
     @Inject
     BeanManager beanManager;
@@ -93,16 +46,15 @@ public class MediatorManager {
     @Inject
     HealthCenter health;
 
-    private volatile boolean initialized;
-
     public MediatorManager() {
+        boolean strictMode = Boolean.parseBoolean(System.getProperty(STRICT_MODE_PROPERTY, "false"));
         if (strictMode) {
             log.strictModeEnabled();
         }
     }
 
-    public boolean isInitialized() {
-        return initialized;
+    public List<MediatorConfiguration> getConfigurations() {
+        return collected.mediators();
     }
 
     public <T> void analyze(AnnotatedType<T> annotatedType, Bean<T> bean) {
@@ -140,273 +92,39 @@ public class MediatorManager {
         collected.addAll(mediators);
     }
 
-    @PreDestroy
-    void shutdown() {
-        log.cancelSubscriptions();
-        subscriptions.forEach(Subscription::cancel);
-        subscriptions.clear();
-    }
-
-    public void initializeAndRun() {
-        if (initialized) {
-            throw ex.illegalStateForMediatorManagerAlreadyInitialized();
-        }
-        log.deploymentDoneStartProcessing();
-
-        streamRegistars.stream().forEach(ChannelRegistar::initialize);
-        Set<String> unmanagedSubscribers = channelRegistry.getOutgoingNames();
-        log.initializingMediators();
-        collected.mediators()
-                .forEach(configuration -> {
-                    AbstractMediator mediator = createMediator(configuration);
-
-                    log.initializingMethod(mediator.getMethodAsString());
-
-                    mediator.setDecorators(decorators);
-                    mediator.setConverters(converters);
-                    mediator.setHealth(health);
-                    mediator.setWorkerPoolRegistry(workerPoolRegistry);
-
-                    try {
-                        Object beanInstance = beanManager.getReference(configuration.getBean(), Object.class,
-                                beanManager.createCreationalContext(configuration.getBean()));
-
-                        if (configuration.getInvokerClass() != null) {
-                            try {
-                                Constructor<? extends Invoker> constructorUsingBeanInstance = configuration.getInvokerClass()
-                                        .getConstructor(Object.class);
-                                if (constructorUsingBeanInstance != null) {
-                                    mediator.setInvoker(constructorUsingBeanInstance.newInstance(beanInstance));
-                                } else {
-                                    mediator.setInvoker(configuration.getInvokerClass().getDeclaredConstructor()
-                                            .newInstance());
-                                }
-
-                            } catch (InstantiationException | IllegalAccessException e) {
-                                log.unableToCreateInvoker(configuration.getInvokerClass(), e);
-                                return;
-                            }
-                        }
-
-                        mediator.initialize(beanInstance);
-                    } catch (Throwable e) {
-                        log.unableToInitializeMediator(mediator.getMethodAsString(), e);
-                        return;
-                    }
-
-                    if (mediator.getConfiguration().shape() == Shape.PUBLISHER) {
-                        log.registeringAsPublisher(mediator.getConfiguration().methodAsString(),
-                                mediator.getConfiguration().getOutgoing());
-                        channelRegistry.register(mediator.getConfiguration().getOutgoing(), mediator.getStream());
-                    }
-                    if (mediator.getConfiguration().shape() == Shape.SUBSCRIBER) {
-                        List<String> list = mediator.getConfiguration().getIncoming();
-                        log.registeringAsSubscriber(mediator.getConfiguration().methodAsString(), list);
-                        for (String l : list) {
-                            channelRegistry.register(l, mediator.getComputedSubscriber());
-                        }
-                    }
-                });
+    public AbstractMediator createMediator(MediatorConfiguration configuration) {
+        AbstractMediator mediator = mediatorFactory.create(configuration);
+        mediator.setDecorators(decorators);
+        mediator.setConverters(converters);
+        mediator.setHealth(health);
+        mediator.setWorkerPoolRegistry(workerPoolRegistry);
 
         try {
-            weaving(unmanagedSubscribers);
-        } catch (WeavingException e) {
-            throw new DeploymentException(e);
-        }
-    }
+            Object beanInstance = beanManager.getReference(configuration.getBean(), Object.class,
+                    beanManager.createCreationalContext(configuration.getBean()));
 
-    @SuppressWarnings("unchecked")
-    private void weaving(Set<String> unmanagedSubscribers) {
-        // At that point all the publishers have been registered in the registry
-        log.connectingMediators();
-        List<AbstractMediator> unsatisfied = getAllNonSatisfiedMediators();
-        // This list contains the names of the streams that have bean connected and
-        List<LazySource> lazy = new ArrayList<>();
-        while (!unsatisfied.isEmpty()) {
-            int numberOfUnsatisfiedBeforeLoop = unsatisfied.size();
-
-            unsatisfied.forEach(mediator -> {
-                log.attemptToResolve(mediator.getMethodAsString());
-                List<String> list = mediator.configuration().getIncoming();
-                if (list.size() == 1) {
-                    // Single source.
-                    List<PublisherBuilder<? extends Message<?>>> sources = channelRegistry.getPublishers(list.get(0));
-                    Optional<PublisherBuilder<? extends Message<?>>> maybeSource = getAggregatedSource(sources, list.get(0),
-                            mediator, lazy);
-                    maybeSource.ifPresent(publisher -> {
-                        mediator.connectToUpstream(publisher);
-                        log.connectingTo(mediator.getMethodAsString(), list, publisher);
-                        if (mediator.configuration().getOutgoing() != null) {
-                            channelRegistry.register(mediator.getConfiguration().getOutgoing(), mediator.getStream());
-                        }
-                    });
-                } else {
-                    List<PublisherBuilder<? extends Message<?>>> upstreams = new ArrayList<>();
-                    for (String sn : list) {
-                        List<PublisherBuilder<? extends Message<?>>> sources = channelRegistry.getPublishers(sn);
-                        Optional<PublisherBuilder<? extends Message<?>>> maybeSource = getAggregatedSource(sources, sn,
-                                mediator,
-                                lazy);
-                        maybeSource.ifPresent(upstreams::add);
+            if (configuration.getInvokerClass() != null) {
+                try {
+                    Constructor<? extends Invoker> constructorUsingBeanInstance = configuration.getInvokerClass()
+                            .getConstructor(Object.class);
+                    if (constructorUsingBeanInstance != null) {
+                        mediator.setInvoker(constructorUsingBeanInstance.newInstance(beanInstance));
+                    } else {
+                        mediator.setInvoker(configuration.getInvokerClass().getDeclaredConstructor()
+                                .newInstance());
                     }
 
-                    if (upstreams.size() == list.size()) {
-                        // We have all our upstreams
-                        Multi<? extends Message<?>> merged = Multi.createBy().merging()
-                                .streams(upstreams.stream().map(PublisherBuilder::buildRs).collect(Collectors.toList()));
-                        mediator.connectToUpstream(ReactiveStreams.fromPublisher(merged));
-                        log.connectingTo(mediator.getMethodAsString(), list);
-                        if (mediator.configuration().getOutgoing() != null) {
-                            channelRegistry.register(mediator.getConfiguration().getOutgoing(), mediator.getStream());
-                        }
-                    }
-                }
-            });
-
-            unsatisfied = getAllNonSatisfiedMediators();
-            int numberOfUnsatisfiedAfterLoop = unsatisfied.size();
-
-            if (numberOfUnsatisfiedAfterLoop == numberOfUnsatisfiedBeforeLoop) {
-                // Stale!
-                if (strictMode) {
-                    throw ex.weavingImposibleToBind(unsatisfied.stream()
-                            .map(m -> m.configuration().methodAsString())
-                            .collect(Collectors.toList()),
-                            channelRegistry.getIncomingNames(),
-                            channelRegistry.getEmitterNames());
-                } else {
-                    log.impossibleToBindMediators(
-                            unsatisfied.stream().map(m -> m.configuration().methodAsString()).collect(Collectors.toList()),
-                            channelRegistry.getIncomingNames(),
-                            channelRegistry.getEmitterNames());
-                }
-                break;
-            }
-        }
-
-        // Inject lazy sources
-        lazy.forEach(l -> l.configure(channelRegistry));
-
-        // Run
-        mediators.stream()
-                .filter(m -> m.configuration()
-                        .shape() == Shape.SUBSCRIBER)
-                .filter(AbstractMediator::isConnected)
-                .forEach(AbstractMediator::run);
-
-        // We also need to connect mediator and emitter to un-managed subscribers
-        for (String name : unmanagedSubscribers) {
-            List<AbstractMediator> list = lookupForMediatorsWithMatchingDownstream(name);
-            List<SubscriberBuilder<? extends Message<?>, Void>> subscribers = channelRegistry.getSubscribers(name);
-            for (AbstractMediator mediator : list) {
-                if (subscribers.size() == 1) {
-                    log.connectingMethodToSink(mediator.getMethodAsString(), name);
-                    mediator.getStream().to((SubscriberBuilder<Message<?>, Void>) subscribers.get(0)).run();
-                } else if (subscribers.size() > 2) {
-                    log.numberOfSubscribersConsumingStream(subscribers.size(), name);
-                    subscribers.forEach(s -> {
-                        log.connectingMethodToSink(mediator.getMethodAsString(), name);
-                        mediator.getStream().to((SubscriberBuilder<Message<?>, Void>) s).run();
-                    });
+                } catch (InstantiationException | IllegalAccessException e) {
+                    log.unableToCreateInvoker(configuration.getInvokerClass(), e);
+                    throw e;
                 }
             }
 
-            if (list.isEmpty()) {
-                AbstractEmitter emitter = (AbstractEmitter) channelRegistry.getEmitter(name);
-                if (emitter == null) {
-                    emitter = (AbstractEmitter) channelRegistry.getMutinyEmitter(name);
-                }
-                if (emitter != null) {
-                    if (subscribers.size() == 1) {
-                        log.connectingEmitterToSink(name);
-                        ReactiveStreams.fromPublisher(emitter.getPublisher()).to(subscribers.get(0)).run();
-                    } else if (subscribers.size() > 2) {
-                        log.numberOfSubscribersConsumingStream(subscribers.size(), name);
-                        for (SubscriberBuilder<? extends Message<?>, Void> subscriber : subscribers) {
-                            log.connectingEmitterToSink(name);
-                            ReactiveStreams.fromPublisher(emitter.getPublisher()).to(subscriber).run();
-                        }
-                    }
-                }
-            }
+            mediator.initialize(beanInstance);
+        } catch (Throwable e) {
+            log.unableToInitializeMediator(mediator.getMethodAsString(), e);
+            throw new DefinitionException(e);
         }
-
-        initialized = true;
-    }
-
-    private List<AbstractMediator> lookupForMediatorsWithMatchingDownstream(String name) {
-        return mediators.stream()
-                .filter(m -> m.configuration()
-                        .getOutgoing() != null)
-                .filter(m -> m.configuration()
-                        .getOutgoing()
-                        .equalsIgnoreCase(name))
-                .collect(Collectors.toList());
-    }
-
-    private List<AbstractMediator> getAllNonSatisfiedMediators() {
-        return mediators.stream()
-                .filter(mediator -> !mediator.isConnected())
-                .collect(Collectors.toList());
-    }
-
-    private AbstractMediator createMediator(MediatorConfiguration configuration) {
-        AbstractMediator mediator = mediatorFactory.create(configuration);
-        log.mediatorCreated(configuration.methodAsString());
-        mediators.add(mediator);
         return mediator;
-    }
-
-    private Optional<PublisherBuilder<? extends Message<?>>> getAggregatedSource(
-            List<PublisherBuilder<? extends Message<?>>> sources,
-            String sourceName,
-            AbstractMediator mediator,
-            List<LazySource> lazy) {
-        if (sources.isEmpty()) {
-            return Optional.empty();
-        }
-
-        Merge.Mode merge = mediator.getConfiguration()
-                .getMerge();
-        if (merge != null) {
-            LazySource lazySource = new LazySource(sourceName, merge);
-            lazy.add(lazySource);
-            return Optional.of(ReactiveStreams.fromPublisher(lazySource));
-        }
-
-        if (sources.size() > 1) {
-            throw new WeavingException(sourceName, mediator.getMethodAsString(), sources.size());
-        }
-        return Optional.of(sources.get(0));
-
-    }
-
-    public void initializeEmitters(List<EmitterConfiguration> emitters) {
-        for (EmitterConfiguration config : emitters) {
-            int bufferSize = getDefaultBufferSize();
-            initializeEmitter(config, bufferSize);
-        }
-    }
-
-    private int getDefaultBufferSize() {
-        if (defaultBufferSize == DEFAULT_BUFFER_SIZE && defaultBufferSizeLegacy != DEFAULT_BUFFER_SIZE) {
-            return defaultBufferSizeLegacy;
-        } else {
-            return defaultBufferSize;
-        }
-    }
-
-    public void initializeEmitter(EmitterConfiguration emitterConfiguration, long defaultBufferSize) {
-        Publisher<? extends Message<?>> publisher;
-        if (emitterConfiguration.isMutinyEmitter) {
-            MutinyEmitterImpl<?> mutinyEmitter = new MutinyEmitterImpl<>(emitterConfiguration, defaultBufferSize);
-            publisher = mutinyEmitter.getPublisher();
-            channelRegistry.register(emitterConfiguration.name, mutinyEmitter);
-        } else {
-            EmitterImpl<?> emitter = new EmitterImpl<>(emitterConfiguration, defaultBufferSize);
-            publisher = emitter.getPublisher();
-            channelRegistry.register(emitterConfiguration.name, emitter);
-        }
-        channelRegistry.register(emitterConfiguration.name, ReactiveStreams.fromPublisher(publisher));
     }
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
@@ -63,7 +63,23 @@ public class MediatorManager {
 
         methods.stream()
                 .filter(this::hasMediatorAnnotations)
-                .forEach(method -> collected.add(method.getJavaMember(), bean));
+                .forEach(method -> {
+                    if (shouldCollectMethod(method, collected)) {
+                        collected.add(method.getJavaMember(), bean);
+                    }
+                });
+    }
+
+    /**
+     * Checks if the given method is not an overloaded version of another method already included.
+     */
+    private <T> boolean shouldCollectMethod(AnnotatedMethod<? super T> method, CollectedMediatorMetadata collected) {
+        // TODO Not very happy with this - it eliminates methods based on name and not full signature.
+        Optional<MediatorConfiguration> existing = collected.mediators().stream()
+                .filter(mc -> mc.getMethod().getDeclaringClass() == method.getJavaMember().getDeclaringClass()
+                        && mc.getMethod().getName().equals(method.getJavaMember().getName()))
+                .findAny();
+        return !existing.isPresent();
     }
 
     private <T> boolean hasMediatorAnnotations(AnnotatedMethod<? super T> method) {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ThrowingEmitter.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/ThrowingEmitter.java
@@ -20,7 +20,7 @@ import io.smallrye.mutiny.subscription.MultiEmitter;
 class ThrowingEmitter<T> implements MultiEmitter<T> {
 
     private MultiEmitter<? super T> delegate;
-    private AtomicLong requested;
+    private final AtomicLong requested;
 
     public static <T> Multi<T> create(Consumer<MultiEmitter<? super T>> deferred, long bufferSize) {
         // ThrowingEmitter works by wrapping around a delegate emitter and tracking the requests from downstream so that it can throw an exception from emit() if there aren't sufficient requests

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
@@ -52,7 +52,7 @@ public interface ProviderLogging extends BasicLogger {
     @Message(id = 207, value = "Cancel subscriptions")
     void cancelSubscriptions();
 
-    @LogMessage(level = Logger.Level.INFO)
+    @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 208, value = "Deployment done... start processing")
     void deploymentDoneStartProcessing();
 
@@ -124,11 +124,11 @@ public interface ProviderLogging extends BasicLogger {
     @Message(id = 225, value = "No subscriber for channel %s attached to the emitter %s.%s")
     void noSubscriberForChannelAttachedToEmitter(String name, String beanClassName, String memberName);
 
-    @LogMessage(level = Logger.Level.INFO)
+    @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 226, value = "Found incoming connectors: %s")
     void foundIncomingConnectors(List<String> connectors);
 
-    @LogMessage(level = Logger.Level.INFO)
+    @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 227, value = "Found outgoing connectors: %s")
     void foundOutgoingConnectors(List<String> connectors);
 
@@ -136,7 +136,7 @@ public interface ProviderLogging extends BasicLogger {
     @Message(id = 228, value = "No MicroProfile Config found, skipping")
     void skippingMPConfig();
 
-    @LogMessage(level = Logger.Level.INFO)
+    @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 229, value = "Channel manager initializing...")
     void channelManagerInitializing();
 
@@ -144,11 +144,11 @@ public interface ProviderLogging extends BasicLogger {
     @Message(id = 230, value = "Unable to create the publisher or subscriber during initialization")
     void unableToCreatePublisherOrSubscriber(@Cause Throwable t);
 
-    @LogMessage(level = Logger.Level.WARN)
+    @LogMessage(level = Logger.Level.INFO)
     @Message(id = 231, value = "Incoming channel `%s` disabled by configuration")
     void incomingChannelDisabled(String channel);
 
-    @LogMessage(level = Logger.Level.WARN)
+    @LogMessage(level = Logger.Level.INFO)
     @Message(id = 232, value = "Outgoing channel `%s` disabled by configuration")
     void outgoingChannelDisabled(String channel);
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
@@ -1,17 +1,17 @@
 package io.smallrye.reactive.messaging.i18n;
 
 import java.util.List;
-import java.util.Set;
 
 import javax.enterprise.inject.spi.Bean;
 
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+
+import io.smallrye.reactive.messaging.wiring.Wiring;
 
 @MessageLogger(projectCode = "SRMSG", length = 5)
 public interface ProviderLogging extends BasicLogger {
@@ -44,85 +44,37 @@ public interface ProviderLogging extends BasicLogger {
     @Message(id = 205, value = "Strict mode enabled")
     void strictModeEnabled();
 
-    @LogMessage(level = Logger.Level.INFO)
+    @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 206, value = "Scanning Type: %s")
-    void scanningType(Class javaClass);
+    void scanningType(Class<?> javaClass);
 
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 207, value = "Cancel subscriptions")
-    void cancelSubscriptions();
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 207, value = "%s")
+    void reportWiringFailures(String message);
 
-    @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 208, value = "Deployment done... start processing")
-    void deploymentDoneStartProcessing();
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 209, value = "Initializing mediators")
-    void initializingMediators();
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 208, value = "The connector '%s' has no downstreams")
+    void connectorWithoutDownstream(Wiring.Component component);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 210, value = "Initializing %s")
-    void initializingMethod(String methodAsString);
+    @Message(id = 209, value = "Beginning graph resolution, number of components detected: %d")
+    void startGraphResolution(int size);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 210, value = "Graph resolution completed in %d ns")
+    void completedGraphResolution(long duration);
 
     @LogMessage(level = Logger.Level.ERROR)
     @Message(id = 211, value = "Unable to create invoker instance of %s")
-    void unableToCreateInvoker(Class invokerClass, @Cause Throwable t);
+    void unableToCreateInvoker(Class<?> invokerClass, @Cause Throwable t);
 
     @LogMessage(level = Logger.Level.ERROR)
     @Message(id = 212, value = "Unable to initialize mediator: %s")
     void unableToInitializeMediator(String methodAsString, @Cause Throwable t);
 
-    @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 213, value = "Registering %s as publisher %s")
-    void registeringAsPublisher(String methodAsString, String outgoing);
-
-    @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 214, value = "Registering %s as subscriber %s")
-    void registeringAsSubscriber(String methodAsString, List<String> list);
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 215, value = "Connecting mediators")
-    void connectingMediators();
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 216, value = "Attempt to resolve %s")
-    void attemptToResolve(String methodAsString);
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 217, value = "Connecting %s to `%s` (%s)")
-    void connectingTo(String methodAsString, List<String> list, PublisherBuilder publisher);
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 218, value = "Connecting %s to `%s`")
-    void connectingTo(String methodAsString, List<String> list);
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 219, value = "Impossible to bind mediators, some mediators are not connected: %s \n Available publishers: %s \n Available emitters: %s")
-    void impossibleToBindMediators(List<String> list, Set<String> incomingNames, Set<String> emitterNames);
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 220, value = "Connecting method %s to sink %s")
-    void connectingMethodToSink(String methodAsString, String name);
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 221, value = "%d subscribers consuming the stream %s")
-    void numberOfSubscribersConsumingStream(int size, String name);
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 222, value = "Connecting emitter to sink %s")
-    void connectingEmitterToSink(String name);
-
-    @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 223, value = "Mediator created for %s")
-    void mediatorCreated(String methodAsString);
-
     @LogMessage(level = Logger.Level.INFO)
     @Message(id = 224, value = "Analyzing mediator bean: %s")
     void analyzingMediatorBean(Bean<?> bean);
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 225, value = "No subscriber for channel %s attached to the emitter %s.%s")
-    void noSubscriberForChannelAttachedToEmitter(String name, String beanClassName, String memberName);
 
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 226, value = "Found incoming connectors: %s")
@@ -159,5 +111,13 @@ public interface ProviderLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 234, value = "Failed to emit a Message to the channel")
     void failureEmittingMessage(@Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 235, value = "Beginning materialization")
+    void startMaterialization();
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 236, value = "Materialization completed in %d ns")
+    void materializationCompleted(long duration);
 
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
@@ -150,7 +150,8 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
                 String channel = entry.getKey();
                 ConnectorConfig config = entry.getValue();
                 if (config.getOptionalValue(ConnectorConfig.CHANNEL_ENABLED_PROPERTY, Boolean.TYPE).orElse(true)) {
-                    registry.register(channel, createPublisherBuilder(channel, config));
+                    registry.register(channel, createPublisherBuilder(channel, config),
+                            config.getOptionalValue(ConnectorConfig.BROADCAST_PROPERTY, Boolean.class).orElse(false));
                 } else {
                     log.incomingChannelDisabled(channel);
                 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConnectorConfig.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConnectorConfig.java
@@ -20,6 +20,11 @@ public class ConnectorConfig implements Config {
      */
     public static final String CHANNEL_ENABLED_PROPERTY = "enabled";
 
+    /**
+     * Name of the attribute configuring the broadcast on a connector.
+     */
+    public static final String BROADCAST_PROPERTY = "broadcast";
+
     private final String prefix;
     private final Config overall;
 
@@ -97,7 +102,7 @@ public class ConnectorConfig implements Config {
      * Gets the lists of config keys for the given connector.
      * Note that the list contains property names from the config and env variables.
      * It includes keys from the connector config and channel config.
-     * 
+     *
      * @return the list of keys
      */
     @Override

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/InternalChannelRegistry.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/InternalChannelRegistry.java
@@ -18,16 +18,18 @@ import io.smallrye.reactive.messaging.MutinyEmitter;
 public class InternalChannelRegistry implements ChannelRegistry {
 
     private final Map<String, List<PublisherBuilder<? extends Message<?>>>> publishers = new HashMap<>();
+    private final Map<String, Boolean> outgoing = new HashMap<>();
     private final Map<String, List<SubscriberBuilder<? extends Message<?>, Void>>> subscribers = new HashMap<>();
     private final Map<String, Emitter<?>> emitters = new HashMap<>();
     private final Map<String, MutinyEmitter<?>> mutinyEmitters = new HashMap<>();
 
     @Override
-    public synchronized PublisherBuilder<? extends Message<?>> register(String name,
-            PublisherBuilder<? extends Message<?>> stream) {
+    public PublisherBuilder<? extends Message<?>> register(String name,
+            PublisherBuilder<? extends Message<?>> stream, boolean broadcast) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         Objects.requireNonNull(stream, msg.streamMustBeSet());
         register(publishers, name, stream);
+        outgoing.put(name, broadcast);
         return stream;
     }
 
@@ -99,6 +101,11 @@ public class InternalChannelRegistry implements ChannelRegistry {
         set.addAll(emitters.keySet());
         set.addAll(mutinyEmitters.keySet());
         return set;
+    }
+
+    @Override
+    public Map<String, Boolean> getIncomingChannels() {
+        return outgoing;
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/CycleException.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/CycleException.java
@@ -1,0 +1,16 @@
+package io.smallrye.reactive.messaging.wiring;
+
+public class CycleException extends WiringException {
+    private final Wiring.Component component;
+    private final Wiring.Component downstream;
+
+    public CycleException(Wiring.Component component, Wiring.Component downstream) {
+        this.component = component;
+        this.downstream = downstream;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Cycle detected between " + component + " and a downstream component " + downstream;
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/Graph.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/Graph.java
@@ -1,0 +1,171 @@
+package io.smallrye.reactive.messaging.wiring;
+
+import static io.smallrye.reactive.messaging.extension.MediatorManager.STRICT_MODE_PROPERTY;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import io.smallrye.reactive.messaging.ChannelRegistry;
+
+public class Graph {
+
+    private static final Logger LOGGER = Logger.getLogger("Reactive Messaging Graph");
+
+    private final Set<Wiring.Component> resolved;
+    private final Set<Wiring.ConsumingComponent> unresolved;
+    private final boolean isClosed;
+    private final Set<Wiring.PublishingComponent> inbound;
+    private final Set<Wiring.ConsumingComponent> outbound;
+    private final List<Exception> errors = new ArrayList<>();
+
+    public Graph(Set<Wiring.Component> resolved, Set<Wiring.ConsumingComponent> unresolved) {
+        this.resolved = resolved;
+        this.unresolved = unresolved;
+        this.isClosed = computeClosure();
+
+        boolean strict = Boolean.parseBoolean(System.getProperty(STRICT_MODE_PROPERTY, "false"));
+        if (strict && !isClosed) {
+            errors.add(new NotClosedGraph(this.resolved, unresolved));
+        }
+        if (!strict && !isClosed) {
+            StringBuffer message = new StringBuffer(
+                    "Some components are not connected to either downstream consumers or upstream producers:\n");
+            this.resolved.stream().filter(component -> !component.isDownstreamResolved())
+                    .forEach(c -> message.append("\t- ").append(c).append(" has no downstream\n"));
+            this.unresolved.stream().filter(component -> !component.isDownstreamResolved())
+                    .forEach(c -> message.append("\t- ").append(c).append(" has no downstream\n"));
+            this.unresolved.stream()
+                    .filter(c -> !c.isUpstreamResolved())
+                    .forEach(c -> {
+                        if (c.upstreams().isEmpty()) {
+                            message.append("\t- ").append(c).append(" has no upstream\n");
+                        } else {
+                            message.append("\t- ").append(c).append(" does not have all its requested upstreams: ")
+                                    .append(c.upstreams()).append("\n");
+                        }
+                    });
+            LOGGER.warn(message);
+        }
+
+        this.inbound = this.resolved.stream()
+                .filter(c -> c.isUpstreamResolved() && c.upstreams().isEmpty() && isDownstreamFullyResolved(c))
+                .map(c -> (Wiring.PublishingComponent) c)
+                .collect(Collectors.toSet());
+        // Verify that the full chain is ok
+        this.outbound = this.resolved.stream()
+                .filter(c -> c.isDownstreamResolved() && c.downstreams().isEmpty() && isUpstreamFullyResolved(c))
+                .map(c -> (Wiring.ConsumingComponent) c)
+                .collect(Collectors.toSet());
+
+        // Validate
+        this.resolved.forEach(c -> {
+            try {
+                c.validate();
+            } catch (WiringException e) {
+                errors.add(e);
+            }
+        });
+    }
+
+    public List<Exception> getWiringErrors() {
+        return errors;
+    }
+
+    public void materialize(ChannelRegistry registry) {
+        Set<Wiring.Component> materialized = new HashSet<>();
+        List<Wiring.Component> current = new ArrayList<>(inbound);
+        while (!current.isEmpty()) {
+            List<Wiring.Component> downstreams = new ArrayList<>();
+            for (Wiring.Component cmp : current) {
+                if (!materialized.contains(cmp) && allUpstreamsMaterialized(cmp, materialized)) {
+                    cmp.materialize(registry);
+                    downstreams.addAll(cmp.downstreams());
+                    materialized.add(cmp);
+                }
+            }
+            current.removeAll(materialized);
+            current.addAll(downstreams);
+        }
+    }
+
+    private boolean allUpstreamsMaterialized(Wiring.Component cmp, Set<Wiring.Component> materialized) {
+        for (Wiring.Component upstream : cmp.upstreams()) {
+            if (!materialized.contains(upstream)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Set<Wiring.Component> getResolvedComponents() {
+        return resolved;
+    }
+
+    public boolean isClosed() {
+        return isClosed;
+    }
+
+    public Set<Wiring.PublishingComponent> getInbound() {
+        return inbound;
+    }
+
+    public Set<Wiring.ConsumingComponent> getOutbound() {
+        return outbound;
+    }
+
+    private boolean isUpstreamFullyResolved(Wiring.Component component) {
+        if (!component.isUpstreamResolved()) {
+            return false;
+        }
+        for (Wiring.Component upstream : component.upstreams()) {
+            if (!isUpstreamFullyResolved(upstream)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isDownstreamFullyResolved(Wiring.Component component) {
+        if (!component.isDownstreamResolved()) {
+            return false;
+        }
+        for (Wiring.Component downstream : component.downstreams()) {
+            if (!isDownstreamFullyResolved(downstream)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Set<Wiring.ConsumingComponent> getUnresolvedComponents() {
+        return unresolved;
+    }
+
+    public boolean hasWiringErrors() {
+        return !errors.isEmpty();
+    }
+
+    private boolean computeClosure() {
+        if (!unresolved.isEmpty()) {
+            return false;
+        }
+
+        for (Wiring.Component component : resolved) {
+            if (!component.isUpstreamResolved()) {
+                return false;
+            }
+            // One test from the TCK deploys an unused connector.
+            if (!(component instanceof Wiring.InboundConnectorComponent) && !component.isDownstreamResolved()) {
+                return false;
+            } else if (component instanceof Wiring.InboundConnectorComponent && !component.isDownstreamResolved()) {
+                LOGGER.warn("The connector " + component + " has no downstreams");
+            }
+        }
+        return true;
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/NotClosedGraph.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/NotClosedGraph.java
@@ -1,0 +1,29 @@
+package io.smallrye.reactive.messaging.wiring;
+
+import java.util.Set;
+
+public class NotClosedGraph extends Exception {
+    private final Set<Wiring.Component> resolved;
+    private final Set<Wiring.ConsumingComponent> unresolved;
+
+    public NotClosedGraph(Set<Wiring.Component> components,
+            Set<Wiring.ConsumingComponent> unresolved) {
+        this.resolved = components;
+        this.unresolved = unresolved;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuffer message = new StringBuffer(
+                "Some components are not connected to either downstream consumers or upstream producers:\n");
+        this.resolved.stream().filter(component -> !component.isDownstreamResolved())
+                .forEach(c -> message.append("\t- ").append(c).append(" has no downstream\n"));
+        this.unresolved.stream().filter(component -> !component.isDownstreamResolved())
+                .forEach(c -> message.append("\t- ").append(c).append(" has no downstream\n"));
+        this.unresolved.stream()
+                .filter(c -> c.upstreams().isEmpty())
+                .forEach(c -> message.append("\t- ").append(c).append(" has no upstream\n"));
+
+        return message.toString();
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/OpenGraphException.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/OpenGraphException.java
@@ -2,11 +2,11 @@ package io.smallrye.reactive.messaging.wiring;
 
 import java.util.Set;
 
-public class NotClosedGraph extends Exception {
+public class OpenGraphException extends WiringException {
     private final Set<Wiring.Component> resolved;
     private final Set<Wiring.ConsumingComponent> unresolved;
 
-    public NotClosedGraph(Set<Wiring.Component> components,
+    public OpenGraphException(Set<Wiring.Component> components,
             Set<Wiring.ConsumingComponent> unresolved) {
         this.resolved = components;
         this.unresolved = unresolved;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyDownstreamCandidatesException.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyDownstreamCandidatesException.java
@@ -1,9 +1,9 @@
 package io.smallrye.reactive.messaging.wiring;
 
-public class TooManyDownstreams extends WiringException {
+public class TooManyDownstreamCandidatesException extends WiringException {
     private final Wiring.PublishingComponent component;
 
-    public TooManyDownstreams(Wiring.PublishingComponent pc) {
+    public TooManyDownstreamCandidatesException(Wiring.PublishingComponent pc) {
         this.component = pc;
     }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyDownstreams.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyDownstreams.java
@@ -1,0 +1,28 @@
+package io.smallrye.reactive.messaging.wiring;
+
+public class TooManyDownstreams extends WiringException {
+    private final Wiring.PublishingComponent component;
+
+    public TooManyDownstreams(Wiring.PublishingComponent pc) {
+        this.component = pc;
+    }
+
+    public String getMessage() {
+        return String.format(
+                "'%s' supports a single downstream consumer, but found %d: %s. You may want to enable broadcast using %s",
+                component, component.downstreams().size(), component.downstreams(), getHint());
+    }
+
+    private String getHint() {
+        if (component instanceof Wiring.InboundConnectorComponent) {
+            return "'mp.messaging.incoming." + component.getOutgoingChannel()
+                    + ".broadcast=true' + to allow multiple downstreams.";
+        } else if (component instanceof Wiring.EmitterComponent) {
+            return "'@Broadcast' on the injected emitter field.";
+        } else if (component instanceof Wiring.PublisherMediatorComponent
+                || component instanceof Wiring.ProcessorMediatorComponent) {
+            return "'@Broadcast' on the method " + component + ".";
+        }
+        throw new IllegalStateException("Unable to provide the broadcast hint " + component);
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyUpstreamCandidatesException.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyUpstreamCandidatesException.java
@@ -2,16 +2,16 @@ package io.smallrye.reactive.messaging.wiring;
 
 import java.util.List;
 
-public class TooManyUpstreams extends WiringException {
+public class TooManyUpstreamCandidatesException extends WiringException {
     private final Wiring.ConsumingComponent component;
     private final String incoming;
     private final List<Wiring.Component> upstreams;
 
-    public TooManyUpstreams(Wiring.ConsumingComponent cc) {
+    public TooManyUpstreamCandidatesException(Wiring.ConsumingComponent cc) {
         this(cc, null, null);
     }
 
-    public TooManyUpstreams(Wiring.ConsumingComponent cc, String incoming, List<Wiring.Component> upstreams) {
+    public TooManyUpstreamCandidatesException(Wiring.ConsumingComponent cc, String incoming, List<Wiring.Component> upstreams) {
         this.component = cc;
         this.incoming = incoming;
         this.upstreams = upstreams;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyUpstreams.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyUpstreams.java
@@ -1,0 +1,38 @@
+package io.smallrye.reactive.messaging.wiring;
+
+import java.util.List;
+
+public class TooManyUpstreams extends WiringException {
+    private final Wiring.ConsumingComponent component;
+    private final String incoming;
+    private final List<Wiring.Component> upstreams;
+
+    public TooManyUpstreams(Wiring.ConsumingComponent cc) {
+        this(cc, null, null);
+    }
+
+    public TooManyUpstreams(Wiring.ConsumingComponent cc, String incoming, List<Wiring.Component> upstreams) {
+        this.component = cc;
+        this.incoming = incoming;
+        this.upstreams = upstreams;
+    }
+
+    public String getMessage() {
+        if (incoming != null && upstreams != null) {
+            return String.format(
+                    "'%s' supports a single upstream producer for channel '%s', but found %d: %s. You may want to add the '@Merge' annotation on the method.",
+                    component, incoming, upstreams.size(), upstreams);
+        } else {
+            if (component instanceof Wiring.ProcessorMediatorComponent
+                    || component instanceof Wiring.SubscriberMediatorComponent) {
+                return String.format(
+                        "'%s' supports a single upstream producer, but found %d: %s. You may want to add the '@Merge' annotation on the method.",
+                        component, component.upstreams().size(), component.upstreams());
+            } else {
+                return String.format(
+                        "'%s' supports a single upstream producer, but found %d: %s.",
+                        component, component.upstreams().size(), component.upstreams());
+            }
+        }
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/UnsatisfiedBroadcast.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/UnsatisfiedBroadcast.java
@@ -1,0 +1,15 @@
+package io.smallrye.reactive.messaging.wiring;
+
+public class UnsatisfiedBroadcast extends WiringException {
+    private final Wiring.PublishingComponent component;
+
+    public UnsatisfiedBroadcast(Wiring.PublishingComponent pc) {
+        this.component = pc;
+    }
+
+    public String getMessage() {
+        return String.format(
+                "'%s' requires %d downstream consumers, but found %d: %s",
+                component, component.getRequiredNumberOfSubscribers(), component.downstreams().size(), component.downstreams());
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/UnsatisfiedBroadcastException.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/UnsatisfiedBroadcastException.java
@@ -1,9 +1,9 @@
 package io.smallrye.reactive.messaging.wiring;
 
-public class UnsatisfiedBroadcast extends WiringException {
+public class UnsatisfiedBroadcastException extends WiringException {
     private final Wiring.PublishingComponent component;
 
-    public UnsatisfiedBroadcast(Wiring.PublishingComponent pc) {
+    public UnsatisfiedBroadcastException(Wiring.PublishingComponent pc) {
         this.component = pc;
     }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/Wiring.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/Wiring.java
@@ -1,0 +1,812 @@
+package io.smallrye.reactive.messaging.wiring;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.AbstractMediator;
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.MediatorConfiguration;
+import io.smallrye.reactive.messaging.annotations.Merge;
+import io.smallrye.reactive.messaging.extension.*;
+
+@ApplicationScoped
+public class Wiring {
+
+    public static final int DEFAULT_BUFFER_SIZE = 128;
+
+    @Inject
+    @ConfigProperty(name = "mp.messaging.emitter.default-buffer-size", defaultValue = "128")
+    int defaultBufferSize;
+
+    @Inject
+    @ConfigProperty(name = "smallrye.messaging.emitter.default-buffer-size", defaultValue = "128")
+    @Deprecated // Use mp.messaging.emitter.default-buffer-size instead
+    int defaultBufferSizeLegacy;
+
+    @Inject
+    MediatorManager manager;
+
+    private final List<Component> components;
+
+    public Wiring() {
+        components = new ArrayList<>();
+    }
+
+    public void prepare(ChannelRegistry registry, List<EmitterConfiguration> emitters, List<ChannelConfiguration> channels,
+            List<MediatorConfiguration> mediators) {
+
+        for (MediatorConfiguration mediator : mediators) {
+            if (mediator.getOutgoing() != null && !mediator.getIncoming().isEmpty()) {
+                components.add(new ProcessorMediatorComponent(manager, mediator));
+            } else if (mediator.getOutgoing() != null) {
+                components.add(new PublisherMediatorComponent(manager, mediator));
+            } else {
+                components.add(new SubscriberMediatorComponent(manager, mediator));
+            }
+        }
+
+        for (ChannelConfiguration channel : channels) {
+            components.add(new InjectedChannelComponent(channel));
+        }
+
+        for (EmitterConfiguration emitter : emitters) {
+            components.add(new EmitterComponent(emitter, defaultBufferSize, defaultBufferSizeLegacy));
+        }
+
+        // At that point, the registry only contains connectors or managed channels
+        for (Map.Entry<String, Boolean> entry : registry.getIncomingChannels().entrySet()) {
+            components.add(new InboundConnectorComponent(entry.getKey(), entry.getValue()));
+        }
+
+        for (String outgoingName : registry.getOutgoingNames()) {
+            components.add(new OutgoingConnectorComponent(outgoingName));
+        }
+
+    }
+
+    public Graph resolve() {
+        Set<Component> resolved = new LinkedHashSet<>();
+        Set<ConsumingComponent> unresolved = new LinkedHashSet<>();
+
+        // Initialize lists
+        for (Component component : components) {
+            if (component.isUpstreamResolved()) {
+                resolved.add(component);
+            } else {
+                unresolved.add((ConsumingComponent) component);
+            }
+        }
+
+        boolean doneOrStale = false;
+        // Until everything is resolved or we got staled
+        while (!doneOrStale) {
+            List<ConsumingComponent> resolvedDuringThisTurn = new ArrayList<>();
+            for (ConsumingComponent component : unresolved) {
+                List<String> incomings = component.incomings();
+                for (String incoming : incomings) {
+                    List<Component> matches = getMatchesFor(incoming, resolved);
+                    if (!matches.isEmpty()) {
+                        matches.forEach(m -> bind(component, m));
+                        if (component.isUpstreamResolved()) {
+                            resolvedDuringThisTurn.add(component);
+                        }
+                    }
+                }
+            }
+
+            resolved.addAll(resolvedDuringThisTurn);
+            unresolved.removeAll(resolvedDuringThisTurn);
+
+            doneOrStale = resolvedDuringThisTurn.isEmpty() || unresolved.isEmpty();
+
+            // Update components consuming multiple incomings.
+            for (Component component : resolved) {
+                if (component instanceof ConsumingComponent) {
+                    ConsumingComponent cc = (ConsumingComponent) component;
+                    List<String> incomings = cc.incomings();
+                    for (String incoming : incomings) {
+                        List<Component> matches = getMatchesFor(incoming, resolved);
+                        for (Component match : matches) {
+                            bind(cc, match);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Attempt to resolve from the unresolved set.
+        List<ConsumingComponent> newlyResolved = new ArrayList<>();
+        for (ConsumingComponent c : unresolved) {
+            for (String incoming : c.incomings()) {
+                // searched in unresolved
+                List<Component> matches = getMatchesFor(incoming, unresolved);
+                if (!matches.isEmpty()) {
+                    newlyResolved.add(c);
+                    matches.forEach(m -> bind(c, m));
+                }
+            }
+        }
+        if (!newlyResolved.isEmpty()) {
+            unresolved.removeAll(newlyResolved);
+            resolved.addAll(newlyResolved);
+        }
+
+        return new Graph(resolved, unresolved);
+
+    }
+
+    private void bind(ConsumingComponent consumer, Component provider) {
+        consumer.connectUpstream(provider);
+        provider.connectDownstream(consumer);
+    }
+
+    private List<Component> getMatchesFor(String incoming, Set<? extends Component> candidates) {
+        List<Component> matches = new ArrayList<>();
+        for (Component component : candidates) {
+            Optional<String> outgoing = component.outgoing();
+            if (outgoing.isPresent() && outgoing.get().equalsIgnoreCase(incoming)) {
+                matches.add(component);
+            }
+        }
+        return matches;
+    }
+
+    interface Component {
+
+        void validate() throws WiringException;
+
+        boolean isUpstreamResolved();
+
+        boolean isDownstreamResolved();
+
+        default Optional<String> outgoing() {
+            return Optional.empty();
+        }
+
+        default List<String> incomings() {
+            return Collections.emptyList();
+        }
+
+        default Set<Component> downstreams() {
+            return Collections.emptySet();
+        }
+
+        default Set<Component> upstreams() {
+            return Collections.emptySet();
+        }
+
+        default void connectDownstream(Component downstream) {
+            throw new UnsupportedOperationException("Downstream connection not expected for " + this);
+        }
+
+        default void connectUpstream(Component upstream) {
+            throw new UnsupportedOperationException("Upstream connection not expected for " + this);
+        }
+
+        void materialize(ChannelRegistry registry);
+    }
+
+    interface PublishingComponent extends Component {
+        boolean broadcast();
+
+        int getRequiredNumberOfSubscribers();
+
+        default String getOutgoingChannel() {
+            return outgoing().orElseThrow(() -> new IllegalStateException("Outgoing not configured for " + this));
+        }
+
+        @Override
+        default boolean isDownstreamResolved() {
+            return !downstreams().isEmpty();
+        }
+    }
+
+    interface ConsumingComponent extends Component {
+
+        @Override
+        default boolean isUpstreamResolved() {
+            return !upstreams().isEmpty();
+        }
+
+        boolean merge();
+
+    }
+
+    static class InboundConnectorComponent implements PublishingComponent {
+
+        private final String name;
+        private final boolean broadcast;
+        private final Set<Component> downstreams = new LinkedHashSet<>();
+
+        public InboundConnectorComponent(String name, boolean broadcast) {
+            this.name = name;
+            this.broadcast = broadcast;
+        }
+
+        @Override
+        public Optional<String> outgoing() {
+            return Optional.of(name);
+        }
+
+        @Override
+        public boolean isUpstreamResolved() {
+            return true;
+        }
+
+        @Override
+        public Set<Component> downstreams() {
+            return downstreams;
+        }
+
+        @Override
+        public void connectDownstream(Component component) {
+            downstreams.add(component);
+        }
+
+        @Override
+        public void materialize(ChannelRegistry registry) {
+            // We are already registered and created.
+        }
+
+        @Override
+        public Set<Component> upstreams() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public boolean broadcast() {
+            return broadcast;
+        }
+
+        @Override
+        public int getRequiredNumberOfSubscribers() {
+            return 0;
+        }
+
+        @Override
+        public String toString() {
+            return "IncomingConnector{channel:'" + name + "', attribute:'mp.messaging.incoming." + name + "'}";
+        }
+
+        @Override
+        public void validate() throws WiringException {
+            if (!broadcast && downstreams().size() > 1) {
+                throw new TooManyDownstreams(this);
+            }
+        }
+    }
+
+    static class OutgoingConnectorComponent implements ConsumingComponent {
+
+        private final String name;
+        private final Set<Component> upstreams = new LinkedHashSet<>();
+
+        public OutgoingConnectorComponent(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean isDownstreamResolved() {
+            // No downstream
+            return true;
+        }
+
+        @Override
+        public List<String> incomings() {
+            return Collections.singletonList(name);
+        }
+
+        @Override
+        public boolean merge() {
+            return false; // TODO is that true?
+        }
+
+        @Override
+        public void connectUpstream(Component upstream) {
+            upstream.connectDownstream(this);
+            upstreams.add(upstream);
+        }
+
+        @Override
+        public Set<Component> upstreams() {
+            return upstreams;
+        }
+
+        @Override
+        public String toString() {
+            return "OutgoingConnector{channel:'" + name + "', attribute:'mp.messaging.outgoing." + name + "'}";
+        }
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        @Override
+        public void materialize(ChannelRegistry registry) {
+            List<PublisherBuilder<? extends Message<?>>> publishers = registry.getPublishers(name);
+            Multi<? extends Message<?>> merged = Multi.createBy().merging()
+                    .streams(publishers.stream().map(PublisherBuilder::buildRs).collect(Collectors.toList()));
+            // TODO Improve this.
+            SubscriberBuilder<? extends Message<?>, Void> connector = registry.getSubscribers(name).get(0);
+            Subscriber subscriber = connector.build();
+            merged.subscribe().withSubscriber(subscriber);
+        }
+
+        @Override
+        public void validate() throws WiringException {
+            if (upstreams().size() > 1) {
+                throw new TooManyUpstreams(this);
+            }
+        }
+    }
+
+    static class InjectedChannelComponent implements ConsumingComponent {
+
+        private final String name;
+        private final Set<Component> upstreams = new LinkedHashSet<>();
+
+        public InjectedChannelComponent(ChannelConfiguration configuration) {
+            this.name = configuration.channelName;
+        }
+
+        @Override
+        public boolean isDownstreamResolved() {
+            // No downstream.
+            return true;
+        }
+
+        @Override
+        public List<String> incomings() {
+            return Collections.singletonList(name);
+        }
+
+        @Override
+        public boolean merge() {
+            return false; // TODO We may want to add this feature.
+        }
+
+        @Override
+        public void connectUpstream(Component upstream) {
+            upstreams.add(upstream);
+        }
+
+        @Override
+        public Set<Component> upstreams() {
+            return upstreams;
+        }
+
+        @Override
+        public String toString() {
+            return "@Channel{channel:'" + name + "'}";
+        }
+
+        @Override
+        public void materialize(ChannelRegistry registry) {
+            // Nothing to be done for channel - look up happen during the subscription.
+        }
+
+        @Override
+        public void validate() throws WiringException {
+            if (upstreams().size() > 1) {
+                throw new TooManyUpstreams(this);
+            }
+        }
+    }
+
+    static class EmitterComponent implements PublishingComponent {
+
+        private final EmitterConfiguration configuration;
+        private final Set<Component> downstreams = new LinkedHashSet<>();
+        private final int defaultBufferSize;
+        private final int defaultBufferSizeLegacy;
+
+        public EmitterComponent(EmitterConfiguration configuration, int defaultBufferSize, int defaultBufferSizeLegacy) {
+            this.configuration = configuration;
+            this.defaultBufferSize = defaultBufferSize;
+            this.defaultBufferSizeLegacy = defaultBufferSizeLegacy;
+        }
+
+        @Override
+        public Optional<String> outgoing() {
+            return Optional.of(configuration.name);
+        }
+
+        @Override
+        public Set<Component> downstreams() {
+            return downstreams;
+        }
+
+        @Override
+        public boolean isUpstreamResolved() {
+            return true;
+        }
+
+        @Override
+        public void connectDownstream(Component component) {
+            downstreams.add(component);
+        }
+
+        @Override
+        public boolean broadcast() {
+            return configuration.broadcast;
+        }
+
+        @Override
+        public int getRequiredNumberOfSubscribers() {
+            return configuration.numberOfSubscriberBeforeConnecting;
+        }
+
+        @Override
+        public Set<Component> upstreams() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public String toString() {
+            return "Emitter{channel:'" + getOutgoingChannel() + "'}";
+        }
+
+        @Override
+        public void materialize(ChannelRegistry registry) {
+            Publisher<? extends Message<?>> publisher;
+            int def = getDefaultBufferSize();
+            if (configuration.isMutinyEmitter) {
+                MutinyEmitterImpl<?> mutinyEmitter = new MutinyEmitterImpl<>(configuration, def);
+                publisher = mutinyEmitter.getPublisher();
+                registry.register(configuration.name, mutinyEmitter);
+            } else {
+                EmitterImpl<?> emitter = new EmitterImpl<>(configuration, def);
+                publisher = emitter.getPublisher();
+                registry.register(configuration.name, emitter);
+            }
+            registry.register(configuration.name, ReactiveStreams.fromPublisher(publisher));
+        }
+
+        private int getDefaultBufferSize() {
+            if (defaultBufferSize == DEFAULT_BUFFER_SIZE && defaultBufferSizeLegacy != DEFAULT_BUFFER_SIZE) {
+                return defaultBufferSizeLegacy;
+            } else {
+                return defaultBufferSize;
+            }
+        }
+
+        @Override
+        public void validate() throws WiringException {
+            if (!configuration.broadcast && downstreams().size() > 1) {
+                throw new TooManyDownstreams(this);
+            }
+
+            if (broadcast()
+                    && getRequiredNumberOfSubscribers() != 0 && getRequiredNumberOfSubscribers() != downstreams.size()) {
+                throw new UnsatisfiedBroadcast(this);
+            }
+        }
+    }
+
+    abstract static class MediatorComponent implements Component {
+        final MediatorConfiguration configuration;
+        final MediatorManager manager;
+
+        protected MediatorComponent(MediatorManager manager, MediatorConfiguration configuration) {
+            this.configuration = configuration;
+            this.manager = manager;
+        }
+    }
+
+    static class PublisherMediatorComponent extends MediatorComponent implements PublishingComponent {
+
+        private final Set<Component> downstreams = new LinkedHashSet<>();
+
+        protected PublisherMediatorComponent(MediatorManager manager, MediatorConfiguration configuration) {
+            super(manager, configuration);
+        }
+
+        @Override
+        public Optional<String> outgoing() {
+            return Optional.of(configuration.getOutgoing());
+        }
+
+        @Override
+        public boolean isUpstreamResolved() {
+            return true;
+        }
+
+        @Override
+        public Set<Component> downstreams() {
+            return downstreams;
+        }
+
+        @Override
+        public void connectDownstream(Component component) {
+            downstreams.add(component);
+        }
+
+        @Override
+        public void materialize(ChannelRegistry registry) {
+            AbstractMediator mediator = manager.createMediator(configuration);
+            registry.register(configuration.getOutgoing(), mediator.getStream());
+        }
+
+        @Override
+        public boolean broadcast() {
+            return configuration.getBroadcast();
+        }
+
+        @Override
+        public int getRequiredNumberOfSubscribers() {
+            return configuration.getNumberOfSubscriberBeforeConnecting();
+        }
+
+        @Override
+        public Set<Component> upstreams() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public String toString() {
+            return "PublisherMethod{" +
+                    "method:'" + configuration.methodAsString() + "', outgoing:'" + getOutgoingChannel() + "'}";
+        }
+
+        @Override
+        public void validate() throws WiringException {
+            if (!broadcast() && downstreams().size() > 1) {
+                throw new TooManyDownstreams(this);
+            }
+            if (broadcast()
+                    && getRequiredNumberOfSubscribers() != 0 && getRequiredNumberOfSubscribers() != downstreams.size()) {
+                throw new UnsatisfiedBroadcast(this);
+            }
+        }
+    }
+
+    static class SubscriberMediatorComponent extends MediatorComponent implements ConsumingComponent {
+
+        private final Set<Component> upstreams = new LinkedHashSet<>();
+
+        protected SubscriberMediatorComponent(MediatorManager manager, MediatorConfiguration configuration) {
+            super(manager, configuration);
+        }
+
+        @Override
+        public Set<Component> upstreams() {
+            return upstreams;
+        }
+
+        @Override
+        public boolean isDownstreamResolved() {
+            // No downstream
+            return true;
+        }
+
+        @Override
+        public List<String> incomings() {
+            return configuration.getIncoming();
+        }
+
+        @Override
+        public boolean merge() {
+            return configuration.getMerge() != null;
+        }
+
+        @Override
+        public void connectUpstream(Component upstream) {
+            upstreams.add(upstream);
+        }
+
+        @Override
+        public void materialize(ChannelRegistry registry) {
+            AbstractMediator mediator = manager.createMediator(configuration);
+
+            boolean concat = configuration.getMerge() == Merge.Mode.CONCAT;
+            boolean one = configuration.getMerge() == Merge.Mode.ONE;
+
+            Multi<? extends Message<?>> aggregates;
+            List<PublisherBuilder<? extends Message<?>>> publishers = new ArrayList<>();
+            for (String channel : configuration.getIncoming()) {
+                publishers.addAll(registry.getPublishers(channel));
+            }
+            if (concat) {
+                aggregates = Multi.createBy().concatenating()
+                        .streams(publishers.stream().map(PublisherBuilder::buildRs).collect(Collectors.toList()));
+            } else if (one) {
+                aggregates = Multi.createFrom().publisher(publishers.get(0).buildRs());
+            } else {
+                aggregates = Multi.createBy().merging()
+                        .streams(publishers.stream().map(PublisherBuilder::buildRs).collect(Collectors.toList()));
+            }
+
+            mediator.connectToUpstream(ReactiveStreams.fromPublisher(aggregates));
+
+            SubscriberBuilder<Message<?>, Void> subscriber = mediator.getComputedSubscriber();
+            incomings().forEach(s -> registry.register(s, subscriber));
+
+            mediator.run();
+        }
+
+        @Override
+        public String toString() {
+            return "SubscriberMethod{" +
+                    "method:'" + configuration.methodAsString() + "', incoming:'" + String
+                            .join(",", configuration.getIncoming())
+                    + "'}";
+        }
+
+        private boolean hasAllUpstreams() {
+            // A subscriber can have multiple incomings - all of them must be bound.
+            for (String incoming : incomings()) {
+                // For each incoming, check that we have a match
+                if (upstreams().stream().noneMatch(c -> incoming.equals(c.outgoing().orElse(null)))) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        @Override
+        public boolean isUpstreamResolved() {
+            return hasAllUpstreams();
+        }
+
+        @Override
+        public void validate() throws WiringException {
+            // Check that for each incoming we have a single upstream or a merge strategy
+            for (String incoming : incomings()) {
+                List<Component> components = downstreams().stream()
+                        .filter(c -> incoming.equals(c.outgoing().orElse(null)))
+                        .collect(Collectors.toList());
+                if (components.size() > 1 && !merge()) {
+                    throw new TooManyUpstreams(this, incoming, components);
+                }
+            }
+
+            if (!merge() && upstreams.size() != incomings().size()) {
+                throw new TooManyUpstreams(this);
+            }
+        }
+    }
+
+    static class ProcessorMediatorComponent extends MediatorComponent
+            implements ConsumingComponent, PublishingComponent {
+
+        private final Set<Component> upstreams = new LinkedHashSet<>();
+        private final Set<Component> downstreams = new LinkedHashSet<>();
+
+        protected ProcessorMediatorComponent(MediatorManager manager, MediatorConfiguration configuration) {
+            super(manager, configuration);
+        }
+
+        @Override
+        public Set<Component> upstreams() {
+            return upstreams;
+        }
+
+        @Override
+        public List<String> incomings() {
+            return configuration.getIncoming();
+        }
+
+        @Override
+        public boolean merge() {
+            return configuration.getMerge() != null;
+        }
+
+        @Override
+        public void connectUpstream(Component upstream) {
+            upstreams.add(upstream);
+        }
+
+        @Override
+        public Optional<String> outgoing() {
+            return Optional.of(configuration.getOutgoing());
+        }
+
+        @Override
+        public Set<Component> downstreams() {
+            return downstreams;
+        }
+
+        @Override
+        public void connectDownstream(Component component) {
+            downstreams.add(component);
+        }
+
+        @Override
+        public boolean broadcast() {
+            return configuration.getBroadcast();
+        }
+
+        @Override
+        public int getRequiredNumberOfSubscribers() {
+            return configuration.getNumberOfSubscriberBeforeConnecting();
+        }
+
+        private boolean hasAllUpstreams() {
+            // A subscriber can have multiple incomings - all of them must be bound.
+            for (String incoming : incomings()) {
+                // For each incoming, check that we have a match
+                if (upstreams().stream().noneMatch(c -> incoming.equals(c.outgoing().orElse(null)))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public boolean isUpstreamResolved() {
+            return hasAllUpstreams();
+        }
+
+        @Override
+        public String toString() {
+            return "ProcessingMethod{" +
+                    "method:'" + configuration.methodAsString()
+                    + "', incoming:'" + String.join(",", configuration.getIncoming())
+                    + "', outgoing:'" + getOutgoingChannel() + "'}";
+        }
+
+        @Override
+        public void materialize(ChannelRegistry registry) {
+            AbstractMediator mediator = manager.createMediator(configuration);
+
+            boolean concat = configuration.getMerge() == Merge.Mode.CONCAT;
+            boolean one = configuration.getMerge() == Merge.Mode.ONE;
+
+            Multi<? extends Message<?>> aggregates;
+            List<PublisherBuilder<? extends Message<?>>> publishers = new ArrayList<>();
+            for (String channel : configuration.getIncoming()) {
+                publishers.addAll(registry.getPublishers(channel));
+            }
+            if (concat) {
+                aggregates = Multi.createBy().concatenating()
+                        .streams(publishers.stream().map(PublisherBuilder::buildRs).collect(Collectors.toList()));
+            } else if (one) {
+                aggregates = Multi.createFrom().publisher(publishers.get(0).buildRs());
+            } else {
+                aggregates = Multi.createBy().merging()
+                        .streams(publishers.stream().map(PublisherBuilder::buildRs).collect(Collectors.toList()));
+            }
+
+            mediator.connectToUpstream(ReactiveStreams.fromPublisher(aggregates));
+
+            registry.register(getOutgoingChannel(), mediator.getStream());
+        }
+
+        @Override
+        public void validate() throws WiringException {
+            // Check that for each incoming we have a single upstream or a merge strategy
+            for (String incoming : incomings()) {
+                List<Component> components = downstreams().stream()
+                        .filter(c -> incoming.equals(c.outgoing().orElse(null)))
+                        .collect(Collectors.toList());
+                if (components.size() > 1 && !merge()) {
+                    throw new TooManyUpstreams(this, incoming, components);
+                }
+            }
+
+            if (!merge() && upstreams.size() != incomings().size()) {
+                throw new TooManyUpstreams(this);
+            }
+
+            if (!broadcast() && downstreams().size() > 1) {
+                throw new TooManyDownstreams(this);
+            }
+
+            if (broadcast()
+                    && getRequiredNumberOfSubscribers() != 0 && getRequiredNumberOfSubscribers() != downstreams.size()) {
+                throw new UnsatisfiedBroadcast(this);
+            }
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/WiringException.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/WiringException.java
@@ -1,0 +1,4 @@
+package io.smallrye.reactive.messaging.wiring;
+
+public class WiringException extends Exception {
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/WiringException.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/WiringException.java
@@ -1,4 +1,6 @@
 package io.smallrye.reactive.messaging.wiring;
 
-public class WiringException extends Exception {
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+
+public class WiringException extends UnsatisfiedResolutionException {
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/InheritanceTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/InheritanceTest.java
@@ -1,0 +1,73 @@
+package io.smallrye.reactive.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.annotations.Merge;
+
+public class InheritanceTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void test() {
+        addBeanClass(Foo.class);
+        initialize();
+
+        Foo foo = get(Foo.class);
+        foo.emit();
+
+        assertThat(foo.list())
+                .hasSize(1)
+                .allSatisfy(m -> assertThat(m.content).isEqualTo("hello"));
+    }
+
+    interface MyMessageTypeListener extends SimpleListener<MyMessageType> {
+
+    }
+
+    @FunctionalInterface
+    interface SimpleListener<T> {
+        void onMessage(T message);
+    }
+
+    @ApplicationScoped
+    static class Foo implements MyMessageTypeListener {
+        private final List<MyMessageType> list = new ArrayList<>();
+        @Inject
+        @Channel("in")
+        Emitter<MyMessageType> emitter;
+
+        @Override
+        @Incoming("in")
+        @Merge
+        public void onMessage(MyMessageType message) {
+            list.add(message);
+        }
+
+        public void emit() {
+            emitter.send(new MyMessageType("hello"));
+        }
+
+        public List<MyMessageType> list() {
+            return list;
+        }
+    }
+
+    private static class MyMessageType {
+
+        String content;
+
+        public MyMessageType(String content) {
+            this.content = content;
+        }
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
@@ -4,14 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.se.SeContainer;
 import javax.enterprise.inject.spi.DeploymentException;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.junit.Test;
 
@@ -43,9 +44,18 @@ public class SubscriberShapeTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testThatWeCanProduceSubscriberOfMessage() {
+        initializer.addBeanClasses(DumbGenerator.class);
         initializer.addBeanClasses(BeanReturningASubscriberOfMessagesButDiscarding.class);
         initialize();
         assertThatSubscriberWasPublished(container);
+    }
+
+    @ApplicationScoped
+    public static class DumbGenerator {
+        @Outgoing("subscriber")
+        Multi<String> generate() {
+            return Multi.createFrom().items("a", "b", "c", "d");
+        }
     }
 
     @Test
@@ -144,11 +154,6 @@ public class SubscriberShapeTest extends WeldTestBaseWithoutTails {
         assertThat(registry(container).getOutgoingNames()).contains("subscriber");
         List<SubscriberBuilder<? extends Message<?>, Void>> subscriber = registry(container).getSubscribers("subscriber");
         assertThat(subscriber).isNotEmpty();
-        List<String> list = new ArrayList<>();
-        Multi.createFrom().items("a", "b", "c").map(Message::of)
-                .onItem().invoke(m -> list.add(m.getPayload()))
-                .subscribe(((SubscriberBuilder<Message<?>, Void>) subscriber.get(0)).build());
-        assertThat(list).containsExactly("a", "b", "c");
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
@@ -32,6 +32,7 @@ import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
 import io.smallrye.reactive.messaging.impl.LegacyConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.metrics.MetricDecorator;
+import io.smallrye.reactive.messaging.wiring.Wiring;
 
 public class WeldTestBaseWithoutTails {
 
@@ -103,6 +104,7 @@ public class WeldTestBaseWithoutTails {
         initializer = SeContainerInitializer.newInstance();
 
         initializer.addBeanClasses(MediatorFactory.class,
+                Wiring.class,
                 ExecutionHolder.class,
                 MediatorManager.class,
                 WorkerPoolRegistry.class,

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsManipulatingPayloads.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsManipulatingPayloads.java
@@ -144,7 +144,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
                 }));
     }
 
-    @Incoming(NO_ACKNOWLEDGMENT_CS)
+    @Incoming(NO_ACKNOWLEDGMENT_UNI)
     @Acknowledgment(Acknowledgment.Strategy.NONE)
     @Outgoing("sink-" + NO_ACKNOWLEDGMENT_UNI)
     public Uni<String> processorWithNoAckUni(String input) {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/BlockingPublisherTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/BlockingPublisherTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.blocking;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -9,6 +10,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.junit.Test;
 
+import io.smallrye.reactive.messaging.PublisherShapeTest;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.blocking.beans.BeanReturningMessages;
 import io.smallrye.reactive.messaging.blocking.beans.BeanReturningPayloads;
@@ -18,15 +20,14 @@ public class BlockingPublisherTest extends WeldTestBaseWithoutTails {
     @Test
     public void testBlockingWhenProducingPayload() {
         addBeanClass(BeanReturningPayloads.class);
+        addBeanClass(PublisherShapeTest.InfiniteSubscriber.class);
         initialize();
 
         List<PublisherBuilder<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
         assertThat(producer).isNotEmpty();
-        List<Integer> list = producer.get(0).map(Message::getPayload)
-                .limit(5)
-                .map(i -> (Integer) i)
-                .toList().run().toCompletableFuture().join();
-        assertThat(list).containsExactly(1, 2, 3, 4, 5);
+        PublisherShapeTest.InfiniteSubscriber subscriber = get(PublisherShapeTest.InfiniteSubscriber.class);
+        await().until(() -> subscriber.list().size() == 4);
+        assertThat(subscriber.list()).containsExactly(1, 2, 3, 4);
 
         BeanReturningPayloads bean = container.getBeanManager().createInstance().select(BeanReturningPayloads.class).get();
 
@@ -40,15 +41,14 @@ public class BlockingPublisherTest extends WeldTestBaseWithoutTails {
     @Test
     public void testBlockingWhenProducingMessages() {
         addBeanClass(BeanReturningMessages.class);
+        addBeanClass(PublisherShapeTest.InfiniteSubscriber.class);
         initialize();
 
         List<PublisherBuilder<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
         assertThat(producer).isNotEmpty();
-        List<Integer> list = producer.get(0).map(Message::getPayload)
-                .limit(5)
-                .map(i -> (Integer) i)
-                .toList().run().toCompletableFuture().join();
-        assertThat(list).containsExactly(1, 2, 3, 4, 5);
+        PublisherShapeTest.InfiniteSubscriber subscriber = get(PublisherShapeTest.InfiniteSubscriber.class);
+        await().until(() -> subscriber.list().size() == 4);
+        assertThat(subscriber.list()).containsExactly(1, 2, 3, 4);
 
         BeanReturningMessages bean = container.getBeanManager().createInstance().select(BeanReturningMessages.class).get();
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/incomings/IncomingsTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/incomings/IncomingsTest.java
@@ -77,7 +77,6 @@ public class IncomingsTest extends WeldTestBaseWithoutTails {
 
     @Test
     public void testIncomingsWithMissingSource() {
-        // Strict mode disable, won't fail, but won't work.
         addBeanClass(ProducerOnB.class);
         addBeanClass(MyBeanUsingMultipleIncomings.class);
         initialize();
@@ -190,7 +189,7 @@ public class IncomingsTest extends WeldTestBaseWithoutTails {
     @ApplicationScoped
     public static class MyBeanUsingMultipleIncomings {
 
-        private List<String> list = new CopyOnWriteArrayList<>();
+        private final List<String> list = new CopyOnWriteArrayList<>();
 
         @Incoming("a")
         @Incoming("b")
@@ -207,7 +206,7 @@ public class IncomingsTest extends WeldTestBaseWithoutTails {
     @ApplicationScoped
     public static class MyBeanUsingIncomings {
 
-        private List<String> list = new CopyOnWriteArrayList<>();
+        private final List<String> list = new CopyOnWriteArrayList<>();
 
         @Incomings({
                 @Incoming("a"),
@@ -226,7 +225,7 @@ public class IncomingsTest extends WeldTestBaseWithoutTails {
     @ApplicationScoped
     public static class MyBeanUsingMultipleIncomingsAndMerge {
 
-        private List<String> list = new CopyOnWriteArrayList<>();
+        private final List<String> list = new CopyOnWriteArrayList<>();
 
         @Incoming("a")
         @Incoming("b")
@@ -244,7 +243,7 @@ public class IncomingsTest extends WeldTestBaseWithoutTails {
     @ApplicationScoped
     public static class ProcessorUsingMultipleIncomings {
 
-        private List<String> list = new CopyOnWriteArrayList<>();
+        private final List<String> list = new CopyOnWriteArrayList<>();
 
         @Incoming("a")
         @Incoming("b")
@@ -262,7 +261,7 @@ public class IncomingsTest extends WeldTestBaseWithoutTails {
     @ApplicationScoped
     public static class ProcessorUsingMultipleIncomingsAndMerge {
 
-        private List<String> list = new CopyOnWriteArrayList<>();
+        private final List<String> list = new CopyOnWriteArrayList<>();
 
         @Incoming("a")
         @Incoming("b")
@@ -280,7 +279,7 @@ public class IncomingsTest extends WeldTestBaseWithoutTails {
 
     @ApplicationScoped
     public static class MySink {
-        private List<String> list = new CopyOnWriteArrayList<>();
+        private final List<String> list = new CopyOnWriteArrayList<>();
 
         @Incoming("out")
         public void consume(String s) {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedNonExistentChannel.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedNonExistentChannel.java
@@ -15,4 +15,8 @@ public class BeanInjectedNonExistentChannel {
     @Channel("idonotexist")
     private Multi<Message<String>> field;
 
+    public Multi<Message<String>> getChannel() {
+        return field;
+    }
+
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelInjectionTest.java
@@ -88,10 +88,11 @@ public class ChannelInjectionTest extends WeldTestBaseWithoutTails {
     @Test
     public void testNonExistentChannel() {
         addBeanClass(SourceBean.class);
+        BeanInjectedNonExistentChannel bean = installInitializeAndGet(BeanInjectedNonExistentChannel.class);
         try {
-            installInitializeAndGet(BeanInjectedNonExistentChannel.class);
-            fail();
-        } catch (DeploymentException expected) {
+            bean.getChannel().collectItems().first().await().indefinitely();
+        } catch (IllegalStateException e) {
+            assertThat(e).hasMessageContaining("SRMSG00018");
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterAndForgetInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterAndForgetInjectionTest.java
@@ -91,16 +91,11 @@ public class MutinyEmitterAndForgetInjectionTest extends WeldTestBaseWithoutTail
 
     @Test
     public void testWithMissingChannel() {
-        // The error is only thrown when a message is emitted as the subscription can be delayed.
-        installInitializeAndGet(BeanWithMissingChannel.class).emitter().sendAndForget(Message.of("foo"));
-        assertThat(logCapture.records()).isNotNull()
-                .filteredOn(r -> r.getMessage().contains("SRMSG00234"))
-                .hasSize(1)
-                .hasOnlyOneElementSatisfying(r -> {
-                    assertThat(r.getMessage()).contains("Failed to emit a Message to the channel");
-                    assertThat(r.getThrown()).isExactlyInstanceOf(IllegalStateException.class);
-                    assertThat(r.getThrown().getMessage()).contains("SRMSG00027: No subscriber found for the channel missing");
-                });
+        try {
+            installInitializeAndGet(BeanWithMissingChannel.class).emitter().sendAndForget(Message.of("foo"));
+        } catch (IllegalStateException e) {
+            assertThat(e).hasMessageContaining("SRMSG00019");
+        }
     }
 
     @Test
@@ -239,7 +234,7 @@ public class MutinyEmitterAndForgetInjectionTest extends WeldTestBaseWithoutTail
             emitter.sendAndForget("a");
             emitter.sendAndForget("b");
             try {
-                emitter.sendAndForget((String) null);
+                emitter.sendAndForget(null);
             } catch (IllegalArgumentException e) {
                 caughtNullPayload = true;
             }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/SourceBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/SourceBean.java
@@ -8,11 +8,13 @@ import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
 
 @ApplicationScoped
 public class SourceBean {
 
     @Outgoing("hello")
+    @Broadcast
     public Publisher<String> hello() {
         return Flowable.fromArray("h", "e", "l", "l", "o");
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/DefaultOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/DefaultOverflowStrategyTest.java
@@ -57,7 +57,7 @@ public class DefaultOverflowStrategyTest extends WeldTestBaseWithoutTails {
 
         await().until(() -> bean.exception() != null);
         assertThat(bean.output()).doesNotContain("999");
-        assertThat(bean.output()).hasSizeBetween(0, 256);
+        assertThat(bean.output()).hasSizeBetween(0, 998);
         assertThat(bean.failure()).isNotNull().isInstanceOf(BackPressureFailure.class);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/DropOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/DropOverflowStrategyTest.java
@@ -56,7 +56,7 @@ public class DropOverflowStrategyTest extends WeldTestBaseWithoutTails {
         bean.emitALotOfItems();
 
         await().until(bean::isAllDone);
-        assertThat(bean.output()).contains("1", "2", "3", "4", "5").doesNotContain("999");
+        assertThat(bean.output()).contains("1", "2", "3", "4", "5").hasSizeLessThan(999);
         assertThat(bean.failure()).isNull();
         assertThat(bean.exception()).isNull();
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/FailOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/FailOverflowStrategyTest.java
@@ -58,7 +58,7 @@ public class FailOverflowStrategyTest extends WeldTestBaseWithoutTails {
 
         await().until(() -> bean.exception() != null);
         assertThat(bean.output()).doesNotContain("999");
-        assertThat(bean.output()).hasSizeBetween(0, 256);
+        assertThat(bean.output()).hasSizeBetween(0, 998);
         assertThat(bean.failure()).isNotNull().isInstanceOf(BackPressureFailure.class);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyDefaultOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyDefaultOverflowStrategyTest.java
@@ -57,7 +57,7 @@ public class LegacyDefaultOverflowStrategyTest extends WeldTestBaseWithoutTails 
 
         await().until(() -> bean.exception() != null);
         assertThat(bean.output()).doesNotContain("999");
-        assertThat(bean.output()).hasSizeBetween(0, 256);
+        assertThat(bean.output()).hasSizeLessThan(999);
         assertThat(bean.failure()).isNotNull().isInstanceOf(BackPressureFailure.class);
     }
 
@@ -69,7 +69,7 @@ public class LegacyDefaultOverflowStrategyTest extends WeldTestBaseWithoutTails 
         @Channel("hello")
         Emitter<String> emitter;
 
-        private List<String> output = new CopyOnWriteArrayList<>();
+        private final List<String> output = new CopyOnWriteArrayList<>();
 
         private volatile Throwable downstreamFailure;
         private Exception callerException;

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyDropOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyDropOverflowStrategyTest.java
@@ -56,7 +56,7 @@ public class LegacyDropOverflowStrategyTest extends WeldTestBaseWithoutTails {
         bean.emitALotOfItems();
 
         await().until(bean::isDone);
-        assertThat(bean.output()).contains("1", "2", "3", "4", "5").doesNotContain("999");
+        assertThat(bean.output()).contains("1", "2", "3", "4", "5").hasSizeLessThan(999);
         assertThat(bean.failure()).isNull();
         assertThat(bean.exception()).isNull();
     }
@@ -70,7 +70,7 @@ public class LegacyDropOverflowStrategyTest extends WeldTestBaseWithoutTails {
         @OnOverflow(value = OnOverflow.Strategy.DROP)
         Emitter<String> emitter;
 
-        private List<String> output = new CopyOnWriteArrayList<>();
+        private final List<String> output = new CopyOnWriteArrayList<>();
 
         private volatile Throwable downstreamFailure;
         private volatile boolean done;

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyEmitterBufferOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyEmitterBufferOverflowStrategyTest.java
@@ -70,7 +70,7 @@ public class LegacyEmitterBufferOverflowStrategyTest extends WeldTestBaseWithout
         @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 300)
         Emitter<String> emitter;
 
-        private List<String> output = new CopyOnWriteArrayList<>();
+        private final List<String> output = new CopyOnWriteArrayList<>();
 
         private volatile Throwable downstreamFailure;
         private Exception callerException;

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyFailOverflowStrategyTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/overflow/LegacyFailOverflowStrategyTest.java
@@ -58,7 +58,7 @@ public class LegacyFailOverflowStrategyTest extends WeldTestBaseWithoutTails {
 
         await().until(() -> bean.exception() != null);
         assertThat(bean.output()).doesNotContain("999");
-        assertThat(bean.output()).hasSizeBetween(0, 256);
+        assertThat(bean.output()).hasSizeBetween(0, 998);
         assertThat(bean.failure()).isNotNull().isInstanceOf(BackPressureFailure.class);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/BeanUsingMerge.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/BeanUsingMerge.java
@@ -15,7 +15,7 @@ import io.smallrye.reactive.messaging.annotations.Merge;
 @ApplicationScoped
 public class BeanUsingMerge {
 
-    private List<String> list = new ArrayList<>();
+    private final List<String> list = new ArrayList<>();
 
     @Outgoing("X")
     public Flowable<String> x() {
@@ -29,8 +29,8 @@ public class BeanUsingMerge {
         return Flowable.fromArray("d", "e", "f");
     }
 
-    @Outgoing("X")
     @Incoming("Z2")
+    @Outgoing("X")
     public Flowable<String> y(Flowable<String> z) {
         return z.map(String::toUpperCase);
     }
@@ -41,8 +41,8 @@ public class BeanUsingMerge {
         list.add(payload);
     }
 
-    @Outgoing("Z2")
     @Incoming("Z1")
+    @Outgoing("Z2")
     public Flowable<String> z2(Flowable<String> z) {
         return z
                 .zipWith(Flowable.interval(5, TimeUnit.MILLISECONDS), (a, b) -> a)

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/InvalidBindingTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/InvalidBindingTest.java
@@ -20,7 +20,7 @@ import io.reactivex.processors.UnicastProcessor;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
 import io.smallrye.reactive.messaging.annotations.Merge;
-import io.smallrye.reactive.messaging.wiring.TooManyUpstreams;
+import io.smallrye.reactive.messaging.wiring.TooManyUpstreamCandidatesException;
 
 /**
  * Checks that the deployment fails when a subscriber has 2 many potential publishers and does not use the
@@ -39,7 +39,7 @@ public class InvalidBindingTest extends WeldTestBaseWithoutTails {
             fail("Invalid weaving not detected");
         } catch (DeploymentException e) {
             assertThat(e.getCause())
-                    .hasStackTraceContaining(TooManyUpstreams.class.getName())
+                    .hasStackTraceContaining(TooManyUpstreamCandidatesException.class.getName())
                     .hasStackTraceContaining("'source'")
                     .hasStackTraceContaining("#sink")
                     .hasStackTraceContaining("found 2");
@@ -71,7 +71,7 @@ public class InvalidBindingTest extends WeldTestBaseWithoutTails {
             e.getCause().printStackTrace();
             assertThat(e.getCause())
                     .isInstanceOf(DeploymentException.class)
-                    .hasStackTraceContaining("TooManyDownstreams");
+                    .hasStackTraceContaining("TooManyDownstream");
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/InvalidBindingTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/InvalidBindingTest.java
@@ -17,10 +17,10 @@ import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
 import io.reactivex.processors.UnicastProcessor;
-import io.smallrye.reactive.messaging.WeavingException;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
 import io.smallrye.reactive.messaging.annotations.Merge;
+import io.smallrye.reactive.messaging.wiring.TooManyUpstreams;
 
 /**
  * Checks that the deployment fails when a subscriber has 2 many potential publishers and does not use the
@@ -39,10 +39,10 @@ public class InvalidBindingTest extends WeldTestBaseWithoutTails {
             fail("Invalid weaving not detected");
         } catch (DeploymentException e) {
             assertThat(e.getCause())
-                    .hasCauseInstanceOf(WeavingException.class)
-                    .hasMessageContaining("`source`")
-                    .hasMessageContaining("#sink")
-                    .hasMessageContaining("(2)");
+                    .hasStackTraceContaining(TooManyUpstreams.class.getName())
+                    .hasStackTraceContaining("'source'")
+                    .hasStackTraceContaining("#sink")
+                    .hasStackTraceContaining("found 2");
         }
     }
 
@@ -71,9 +71,7 @@ public class InvalidBindingTest extends WeldTestBaseWithoutTails {
             e.getCause().printStackTrace();
             assertThat(e.getCause())
                     .isInstanceOf(DeploymentException.class)
-                    .hasCauseInstanceOf(WeavingException.class)
-                    .hasMessageContaining("source")
-                    .hasMessageContaining("Synchronous");
+                    .hasStackTraceContaining("TooManyDownstreams");
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/MergeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/MergeTest.java
@@ -21,7 +21,10 @@ public class MergeTest extends WeldTestBaseWithoutTails {
     public void testRegularMerge() {
         initialize();
         BeanUsingMerge merge = container.getBeanManager().createInstance().select(BeanUsingMerge.class).get();
-        await().until(() -> merge.list().size() == 7);
+        await().until(() -> {
+            System.out.println(merge.list());
+            return merge.list().size() == 7;
+        });
         assertThat(merge.list()).contains("a", "b", "c", "D", "E", "F", "G");
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/BroadcastLiteral.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/BroadcastLiteral.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.reactive.messaging.wiring;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+
+/**
+ * Supports inline instantiation of the {@link Broadcast} qualifier.
+ */
+public final class BroadcastLiteral extends AnnotationLiteral<Broadcast> implements Broadcast {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int numberOfSubscribers;
+
+    public static Broadcast of(int value) {
+        return new BroadcastLiteral(value);
+    }
+
+    private BroadcastLiteral(int value) {
+        this.numberOfSubscribers = value;
+    }
+
+    @Override
+    public int value() {
+        return numberOfSubscribers;
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/IncomingLiteral.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/IncomingLiteral.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.reactive.messaging.wiring;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+/**
+ * Supports inline instantiation of the {@link Incoming} qualifier.
+ */
+public final class IncomingLiteral extends AnnotationLiteral<Incoming> implements Incoming {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String value;
+
+    public static Incoming of(String value) {
+        return new IncomingLiteral(value);
+    }
+
+    private IncomingLiteral(String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return the incoming name.
+     */
+    public String value() {
+        return value;
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/OutgoingLiteral.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/OutgoingLiteral.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * <p>
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.reactive.messaging.wiring;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+/**
+ * Supports inline instantiation of the {@link Outgoing} qualifier.
+ */
+public final class OutgoingLiteral extends AnnotationLiteral<Outgoing> implements Outgoing {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String value;
+
+    public static Outgoing of(String value) {
+        return new OutgoingLiteral(value);
+    }
+
+    private OutgoingLiteral(String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return the outgoing name.
+     */
+    public String value() {
+        return value;
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringBroadcastTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringBroadcastTest.java
@@ -1,0 +1,625 @@
+package io.smallrye.reactive.messaging.wiring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.NoSuchElementException;
+
+import javax.enterprise.inject.spi.Bean;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.DefaultMediatorConfiguration;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+import io.smallrye.reactive.messaging.extension.ChannelConfiguration;
+import io.smallrye.reactive.messaging.extension.EmitterConfiguration;
+
+@SuppressWarnings("rawtypes")
+public class WiringBroadcastTest {
+
+    /**
+     * Emitter emitting on the channel "a" with broadcast and two downstream subscribers (1 channel and one processor)
+     * The @Broadcast does not specify the number of subscribers.
+     * <p>
+     * emitter - {a} -> processor - {b} -> channel
+     * emitter - {a} -> channel
+     */
+    @Test
+    public void testEmitterWithImmediateBroadcast() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        EmitterConfiguration ec = new EmitterConfiguration("a", false, null, BroadcastLiteral.of(0));
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(ec), Arrays.asList(cc1, cc2),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(2);
+    }
+
+    /**
+     * Emitter emitting on the channel "a" with broadcast and two downstream subscribers (1 channel and one processor)
+     * The @Broadcast sets the number of subscribers to 2.
+     * <p>
+     * emitter - {a} -> processor - {b} -> channel
+     * -> channel
+     */
+    @Test
+    public void testEmitterWithBroadcastAndExactNumberOfSubscribers() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        EmitterConfiguration ec = new EmitterConfiguration("a", false, null, BroadcastLiteral.of(2));
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(ec), Arrays.asList(cc1, cc2),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(2);
+    }
+
+    /**
+     * Emitter emitting on the channel "a" with broadcast and two downstream subscribers (1 channel and one processor)
+     * The @Broadcast sets the number of subscribers to 1.
+     * <p>
+     * emitter - {a} -> processor - {b} -> channel
+     * -> channel
+     */
+    @Test
+    public void testEmitterWithBroadcastAndMoreSubscribersThanConfigured() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        EmitterConfiguration ec = new EmitterConfiguration("a", false, null, BroadcastLiteral.of(1));
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(ec), Arrays.asList(cc1, cc2),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e)
+                .isInstanceOf(UnsatisfiedBroadcast.class)
+                .hasMessageContaining("1", "2"));
+    }
+
+    /**
+     * Emitter emitting on the channel "a" with broadcast and two downstream subscribers (1 channel and one processor)
+     * The @Broadcast sets the number of subscribers to 3.
+     * <p>
+     * emitter - {a} -> processor - {b} -> channel
+     * -> channel
+     */
+    @Test
+    public void testEmitterWithUnsatisfiedBroadcast() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        EmitterConfiguration ec = new EmitterConfiguration("a", false, null, BroadcastLiteral.of(3));
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(ec), Arrays.asList(cc1, cc2),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+    }
+
+    @Test
+    public void testWithInvalidEmitterBroadcastAndHint() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        EmitterConfiguration ec = new EmitterConfiguration("a", false, null, null);
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(ec), Arrays.asList(cc1, cc2),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(t -> assertThat(t).isInstanceOf(TooManyDownstreams.class)
+                        .hasMessageContaining("channel:'a'")
+                        .hasMessageContaining("@Broadcast"));
+
+    }
+
+    /**
+     * Producer method emitting on the channel "a" with broadcast and two downstream subscribers (1 channel and one processor)
+     * The @Broadcast does not set the number of subscriber
+     * <p>
+     * produce - {a} -> processor - {b} -> channel
+     * -> channel
+     */
+    @Test
+    public void testWithPublisherMethodWithImmediateBroadcast() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producerWithBroadcast"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(2);
+    }
+
+    /**
+     * Producer method emitting on the channel "a" with broadcast and two downstream subscribers (1 channel and one processor)
+     * The @Broadcast sets the number of subscribers to 2.
+     * <p>
+     * produce - {a} -> processor - {b} -> channel
+     * -> channel
+     */
+    @Test
+    public void testWithPublisherMethodWithBroadcastAndExactNumberOfSubscribers() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producerWithBroadcast2"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(2);
+    }
+
+    /**
+     * Producer method emitting on the channel "a" with broadcast and three downstream subscribers (2 channels and one
+     * processor)
+     * The @Broadcast sets the number of subscribers to 2.
+     * <p>
+     * produce - {a} -> processor - {b} -> channel
+     * -> channel
+     * -> channel
+     */
+    @Test
+    public void testWithPublisherMethodWithBroadcastAnMoreSubscribersThanConfigured() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producerWithBroadcast2"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+        ChannelConfiguration cc3 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2, cc3),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(5);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+    }
+
+    /**
+     * Producer method emitting on the channel "a" with broadcast and two downstream subscribers (1 channel and one processor)
+     * The @Broadcast sets the number of subscribers to 3.
+     * <p>
+     * produce - {a} -> processor - {b} -> channel
+     * -> channel
+     */
+    @Test
+    public void testWithPublisherMethodWithUnsatisfiedBroadcast() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producerWithBroadcast3"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+    }
+
+    /**
+     * Test missing broadcast on publisher method
+     */
+    @Test
+    public void testWithPublishingMethodAndMissingBroadcastAndHint() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(TooManyDownstreams.class).hasMessageContaining("@Broadcast"));
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(2);
+    }
+
+    /**
+     * Producer method emitting on the channel "a" and a process method with broadcast and two downstream subscribers (2
+     * channels)
+     * The @Broadcast does not set the number of subscriber
+     * <p>
+     * produce - {a} -> processor - {b} -> channel
+     * -> channel
+     */
+    @Test
+    public void testWithProcessorMethodWithImmediateBroadcast() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("processWithBroadcast"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("b");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(2);
+    }
+
+    /**
+     * Producer method emitting on the channel "a" and a process method with broadcast and two downstream subscribers (2
+     * channels)
+     * The @Broadcast sets the number of subscribers to 2.
+     * <p>
+     * produce - {a} -> processor - {b} -> channel
+     * -> channel
+     */
+    @Test
+    public void testWithProcessorMethodWithBroadcastAndExactNumberOfSubscribers() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("processWithBroadcast2"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("b");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(2);
+    }
+
+    /**
+     * Producer method emitting on the channel "a" and a process method with broadcast and three downstream subscribers (3
+     * channels)
+     * The @Broadcast sets the number of subscribers to 2.
+     * <p>
+     * produce - {a} -> processor - {b} -> channel
+     * -> channel
+     * -> channel
+     */
+    @Test
+    public void testWithProcessorMethodWithBroadcastAnMoreSubscribersThanConfigured() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("processWithBroadcast2"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("b");
+        ChannelConfiguration cc3 = new ChannelConfiguration("b");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2, cc3),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(5);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+    }
+
+    /**
+     * Producer method emitting on the channel "a" and a process method with broadcast and two downstream subscribers (2
+     * channels)
+     * The @Broadcast sets the number of subscribers to 3.
+     * <p>
+     * produce - {a} -> processor - {b} -> channel
+     * -> channel
+     */
+    @Test
+    public void testWithProcessorMethodWithUnsatisfiedBroadcast() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("processWithBroadcast3"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("b");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+    }
+
+    /**
+     * Test missing broadcast on producer method
+     */
+    @Test
+    public void testWithProducerMethodAndMissingBroadcastAndHint() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("b");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getResolvedComponents()).hasSize(4);
+        assertThat(graph.isClosed()).isTrue();
+
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(TooManyDownstreams.class).hasMessageContaining("@Broadcast"));
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(2);
+    }
+
+    /**
+     * connector - {a} -> process -> channel
+     * -> channel
+     */
+    @Test
+    public void testWithConnectorWithBroadcast() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", true));
+
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+
+        assertThat(graph.hasWiringErrors()).isFalse();
+        assertThat(graph.getWiringErrors()).hasSize(0);
+        assertThat(graph.isClosed());
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(2);
+    }
+
+    /**
+     * connector - {a} -> process -> channel
+     * -> channel
+     * <p>
+     * the connector does not have broadcast enabled.
+     */
+    @Test
+    public void testWithMissingConnectorBroadcastAndHint() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", false));
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+        ChannelConfiguration cc2 = new ChannelConfiguration("a");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Arrays.asList(cc1, cc2),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(t -> assertThat(t).isInstanceOf(TooManyDownstreams.class)
+                        .hasMessageContaining("channel:'a'")
+                        .hasMessageContaining("mp.messaging.incoming.a.broadcast=true"));
+
+    }
+
+    private Method getMethod(String name) {
+        for (Method method : this.getClass().getMethods()) {
+            if (method.getName().equals(name)) {
+                return method;
+            }
+        }
+        throw new NoSuchElementException("No method " + name);
+    }
+
+    public void consume(String ignored) {
+        // ...
+    }
+
+    public String producer() {
+        // ...
+        return "hello";
+    }
+
+    public String process(String s) {
+        return s;
+    }
+
+    @Broadcast
+    public String producerWithBroadcast() {
+        // ...
+        return "hello";
+    }
+
+    @Broadcast(2)
+    public String producerWithBroadcast2() {
+        // ...
+        return "hello";
+    }
+
+    @Broadcast(3)
+    public String producerWithBroadcast3() {
+        // ...
+        return "hello";
+    }
+
+    @Broadcast
+    public String processWithBroadcast(String s) {
+        return s;
+    }
+
+    @Broadcast(2)
+    public String processWithBroadcast2(String s) {
+        return s;
+    }
+
+    @Broadcast(3)
+    public String processWithBroadcast3(String s) {
+        return s;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringBroadcastTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringBroadcastTest.java
@@ -115,7 +115,7 @@ public class WiringBroadcastTest {
         assertThat(graph.isClosed()).isTrue();
         assertThat(graph.hasWiringErrors()).isTrue();
         assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e)
-                .isInstanceOf(UnsatisfiedBroadcast.class)
+                .isInstanceOf(UnsatisfiedBroadcastException.class)
                 .hasMessageContaining("1", "2"));
     }
 
@@ -146,7 +146,8 @@ public class WiringBroadcastTest {
         assertThat(graph.getResolvedComponents()).hasSize(4);
         assertThat(graph.isClosed()).isTrue();
         assertThat(graph.hasWiringErrors()).isTrue();
-        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcastException.class));
     }
 
     @Test
@@ -169,7 +170,7 @@ public class WiringBroadcastTest {
 
         assertThat(graph.hasWiringErrors()).isTrue();
         assertThat(graph.getWiringErrors()).hasSize(1)
-                .allSatisfy(t -> assertThat(t).isInstanceOf(TooManyDownstreams.class)
+                .allSatisfy(t -> assertThat(t).isInstanceOf(TooManyDownstreamCandidatesException.class)
                         .hasMessageContaining("channel:'a'")
                         .hasMessageContaining("@Broadcast"));
 
@@ -272,7 +273,8 @@ public class WiringBroadcastTest {
         assertThat(graph.getResolvedComponents()).hasSize(5);
         assertThat(graph.isClosed()).isTrue();
         assertThat(graph.hasWiringErrors()).isTrue();
-        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcastException.class));
     }
 
     /**
@@ -303,7 +305,8 @@ public class WiringBroadcastTest {
         assertThat(graph.getResolvedComponents()).hasSize(4);
         assertThat(graph.isClosed()).isTrue();
         assertThat(graph.hasWiringErrors()).isTrue();
-        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcastException.class));
     }
 
     /**
@@ -332,7 +335,8 @@ public class WiringBroadcastTest {
         assertThat(graph.isClosed()).isTrue();
 
         assertThat(graph.getWiringErrors()).hasSize(1)
-                .allSatisfy(e -> assertThat(e).isInstanceOf(TooManyDownstreams.class).hasMessageContaining("@Broadcast"));
+                .allSatisfy(e -> assertThat(e).isInstanceOf(TooManyDownstreamCandidatesException.class)
+                        .hasMessageContaining("@Broadcast"));
 
         assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
         assertThat(graph.getOutbound()).hasSize(2);
@@ -437,7 +441,8 @@ public class WiringBroadcastTest {
         assertThat(graph.getResolvedComponents()).hasSize(5);
         assertThat(graph.isClosed()).isTrue();
         assertThat(graph.hasWiringErrors()).isTrue();
-        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcastException.class));
     }
 
     /**
@@ -469,7 +474,8 @@ public class WiringBroadcastTest {
         assertThat(graph.getResolvedComponents()).hasSize(4);
         assertThat(graph.isClosed()).isTrue();
         assertThat(graph.hasWiringErrors()).isTrue();
-        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcast.class));
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(UnsatisfiedBroadcastException.class));
     }
 
     /**
@@ -498,7 +504,8 @@ public class WiringBroadcastTest {
         assertThat(graph.isClosed()).isTrue();
 
         assertThat(graph.getWiringErrors()).hasSize(1)
-                .allSatisfy(e -> assertThat(e).isInstanceOf(TooManyDownstreams.class).hasMessageContaining("@Broadcast"));
+                .allSatisfy(e -> assertThat(e).isInstanceOf(TooManyDownstreamCandidatesException.class)
+                        .hasMessageContaining("@Broadcast"));
 
         assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
         assertThat(graph.getOutbound()).hasSize(2);
@@ -561,7 +568,7 @@ public class WiringBroadcastTest {
 
         assertThat(graph.hasWiringErrors()).isTrue();
         assertThat(graph.getWiringErrors()).hasSize(1)
-                .allSatisfy(t -> assertThat(t).isInstanceOf(TooManyDownstreams.class)
+                .allSatisfy(t -> assertThat(t).isInstanceOf(TooManyDownstreamCandidatesException.class)
                         .hasMessageContaining("channel:'a'")
                         .hasMessageContaining("mp.messaging.incoming.a.broadcast=true"));
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringMergeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringMergeTest.java
@@ -62,7 +62,8 @@ public class WiringMergeTest {
                 Collections.singletonList(processor));
         Graph graph = wiring.resolve();
         assertThat(graph.hasWiringErrors()).isTrue();
-        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(TooManyUpstreams.class));
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(TooManyUpstreamCandidatesException.class));
     }
 
     @Test
@@ -82,7 +83,8 @@ public class WiringMergeTest {
                 Collections.singletonList(subscriber));
         Graph graph = wiring.resolve();
         assertThat(graph.hasWiringErrors()).isTrue();
-        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(TooManyUpstreams.class));
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(TooManyUpstreamCandidatesException.class));
     }
 
     @Test
@@ -100,7 +102,8 @@ public class WiringMergeTest {
                 Collections.emptyList());
         Graph graph = wiring.resolve();
         assertThat(graph.hasWiringErrors()).isTrue();
-        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(TooManyUpstreams.class));
+        assertThat(graph.getWiringErrors()).hasSize(1)
+                .allSatisfy(e -> assertThat(e).isInstanceOf(TooManyUpstreamCandidatesException.class));
     }
 
     private Method getMethod(String name) {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringMergeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringMergeTest.java
@@ -1,0 +1,133 @@
+package io.smallrye.reactive.messaging.wiring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.NoSuchElementException;
+
+import javax.enterprise.inject.spi.Bean;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.DefaultMediatorConfiguration;
+import io.smallrye.reactive.messaging.annotations.Merge;
+import io.smallrye.reactive.messaging.extension.ChannelConfiguration;
+import io.smallrye.reactive.messaging.extension.EmitterConfiguration;
+
+@SuppressWarnings("rawtypes")
+public class WiringMergeTest {
+
+    @Test
+    public void testMerge() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", true));
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("processWithMerge"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        EmitterConfiguration ec = new EmitterConfiguration("a", false, null, null);
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(ec), Collections.singletonList(cc1),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getOutbound()).hasSize(1)
+                .allSatisfy(o -> assertThat(o.upstreams()).hasSize(1).allSatisfy(u -> assertThat(u.upstreams()).hasSize(2)));
+    }
+
+    @Test
+    public void testInvalidMergeWithProcessor() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", true));
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        EmitterConfiguration ec = new EmitterConfiguration("a", false, null, null);
+        ChannelConfiguration cc1 = new ChannelConfiguration("b");
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(ec), Collections.singletonList(cc1),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(TooManyUpstreams.class));
+    }
+
+    @Test
+    public void testInvalidMergeWithSubscriber() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", true));
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("a")), null, null);
+
+        EmitterConfiguration ec = new EmitterConfiguration("a", false, null, null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(ec), Collections.emptyList(),
+                Collections.singletonList(subscriber));
+        Graph graph = wiring.resolve();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(TooManyUpstreams.class));
+    }
+
+    @Test
+    public void testInvalidMergeWithOutgoingConnector() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", true));
+        when(registry.getOutgoingNames()).thenReturn(Collections.singleton("a"));
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        EmitterConfiguration ec = new EmitterConfiguration("a", false, null, null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(ec), Collections.emptyList(),
+                Collections.emptyList());
+        Graph graph = wiring.resolve();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> assertThat(e).isInstanceOf(TooManyUpstreams.class));
+    }
+
+    private Method getMethod(String name) {
+        for (Method method : this.getClass().getMethods()) {
+            if (method.getName().equals(name)) {
+                return method;
+            }
+        }
+        throw new NoSuchElementException("No method " + name);
+    }
+
+    public void consume(String ignored) {
+        // ...
+    }
+
+    public String producer() {
+        // ...
+        return "hello";
+    }
+
+    public String process(String s) {
+        return s;
+    }
+
+    @Merge
+    public String processWithMerge(String s) {
+        return s;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringTest.java
@@ -1,0 +1,481 @@
+package io.smallrye.reactive.messaging.wiring;
+
+import static io.smallrye.reactive.messaging.extension.MediatorManager.STRICT_MODE_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.NoSuchElementException;
+
+import javax.enterprise.inject.spi.Bean;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.DefaultMediatorConfiguration;
+import io.smallrye.reactive.messaging.extension.ChannelConfiguration;
+import io.smallrye.reactive.messaging.extension.EmitterConfiguration;
+
+@SuppressWarnings("rawtypes")
+class WiringTest {
+
+    @AfterEach
+    public void cleanup() {
+        System.setProperty(STRICT_MODE_PROPERTY, "false");
+    }
+
+    @Test
+    public void testEmptyGraph() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).isEmpty();
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+        assertThat(graph.getInbound()).isEmpty();
+        assertThat(graph.getOutbound()).isEmpty();
+    }
+
+    /**
+     * Only use methods (producer, process, consumer)
+     * a -> b -> c
+     */
+    @Test
+    public void testProducerProcessorSubscriberChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList(subscriber, processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(3);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.incomings()).containsExactly("b"));
+    }
+
+    /**
+     * Only use methods (producer, process, consumer)
+     * a -> b -> c
+     *
+     * Enable the strict mode.
+     */
+    @Test
+    public void testProducerProcessorSubscriberChainStrict() {
+        System.setProperty(STRICT_MODE_PROPERTY, "true");
+
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList(subscriber, processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(3);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.incomings()).containsExactly("b"));
+
+    }
+
+    /**
+     * Only use methods (process, consumer)
+     * X -> b -> c
+     */
+    @Test
+    public void testNoProducerProcessorSubscriberChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList(subscriber, processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(1);
+        assertThat(graph.getUnresolvedComponents()).hasSize(1);
+        assertThat(graph.isClosed()).isFalse();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).isEmpty();
+        assertThat(graph.getOutbound()).isEmpty();
+    }
+
+    /**
+     * Only use methods (producer, consumer)
+     * a -> X -> c
+     */
+    @Test
+    public void testProducerNoProcessorSubscriberChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList(subscriber, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(1); // Only one resolved component (producer)
+        assertThat(graph.getUnresolvedComponents()).hasSize(1);
+        assertThat(graph.isClosed()).isFalse();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).isEmpty();
+        assertThat(graph.getOutbound()).isEmpty();
+    }
+
+    /**
+     * Only use methods (producer, process)
+     * a -> b -> X
+     */
+    @Test
+    public void testProducerProcessorNoSubscriberChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(2);
+        assertThat(graph.getUnresolvedComponents()).hasSize(0);
+        assertThat(graph.isClosed()).isFalse();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).isEmpty();
+        assertThat(graph.getOutbound()).isEmpty();
+    }
+
+    /**
+     * Only use methods (producer, process)
+     * a -> b -> X
+     *
+     * Strict mode enabled
+     */
+    @Test
+    public void testProducerProcessorNoSubscriberChainStrict() {
+        System.setProperty(STRICT_MODE_PROPERTY, "true");
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
+        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(),
+                Arrays.asList(processor, producer));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(2);
+        assertThat(graph.getUnresolvedComponents()).hasSize(0);
+        assertThat(graph.isClosed()).isFalse();
+        assertThat(graph.hasWiringErrors()).isTrue();
+        assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> {
+            assertThat(e).isInstanceOf(NotClosedGraph.class);
+            assertThat(e).hasMessageContaining("b");
+        });
+
+        assertThat(graph.getInbound()).isEmpty();
+        assertThat(graph.getOutbound()).isEmpty();
+    }
+
+    /**
+     * Two connectors (inbound, outbound) and a method processing in between.
+     * connector -> process -> connector.
+     */
+    @Test
+    public void testConnectorProcessorConnectorChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", false));
+        when(registry.getOutgoingNames()).thenReturn(Collections.singleton("b"));
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(3);
+        assertThat(graph.getUnresolvedComponents()).hasSize(0);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.incomings()).containsExactly("b"));
+    }
+
+    /**
+     * Two connectors (inbound, outbound) not connected with a processor.
+     * connector -> X -> connector.
+     */
+    @Test
+    public void testConnectorNoProcessorConnectorChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", false));
+        when(registry.getOutgoingNames()).thenReturn(Collections.singleton("b"));
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(1);
+        assertThat(graph.getUnresolvedComponents()).hasSize(1);
+        assertThat(graph.isClosed()).isFalse();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(0);
+        assertThat(graph.getOutbound()).hasSize(0);
+    }
+
+    /**
+     * Two connectors (inbound, outbound) connected directly.
+     * connector -> connector.
+     */
+    @Test
+    public void testConnectorToConnectorChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", false));
+        when(registry.getOutgoingNames()).thenReturn(Collections.singleton("a"));
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(2);
+        assertThat(graph.getUnresolvedComponents()).hasSize(0);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.incomings()).containsExactly("a"));
+    }
+
+    /**
+     * Use an emitter, and two methods to process and subscribe
+     * emitter -> b -> c
+     */
+    @Test
+    public void testEmitterProcessorSubscriberChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry, Collections.singletonList(new EmitterConfiguration("a", false, null, null)),
+                Collections.emptyList(),
+                Arrays.asList(subscriber, processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(3);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.incomings()).containsExactly("b"));
+    }
+
+    /**
+     * Use an emitter, and the process method.
+     * emitter -> b -> X
+     */
+    @Test
+    public void testEmitterProcessorNoSubscriberChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry,
+                Collections.singletonList(new EmitterConfiguration("a", false, null, null)),
+                Collections.emptyList(),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(2);
+        assertThat(graph.isClosed()).isFalse();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).isEmpty();
+        assertThat(graph.getOutbound()).isEmpty();
+    }
+
+    /**
+     * Use an emitter, and a subscriber method, but no processor
+     * emitter -> X -> c
+     */
+    @Test
+    public void testEmitterNoProcessorSubscriberChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry,
+                Collections.singletonList(new EmitterConfiguration("a", false, null, null)),
+                Collections.emptyList(),
+                Collections.singletonList(subscriber));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(1);
+        assertThat(graph.isClosed()).isFalse();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).isEmpty();
+        assertThat(graph.getOutbound()).isEmpty();
+    }
+
+    /**
+     * Use an emitter, and one method to process and an injected channel
+     * emitter -> b -> channel
+     */
+    @Test
+    public void testEmitterProcessorChannelChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry,
+                Collections.singletonList(new EmitterConfiguration("a", false, null, null)),
+                Collections.singletonList(new ChannelConfiguration("b")),
+                Collections.singletonList(processor));
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(3);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.incomings()).containsExactly("b"));
+    }
+
+    /**
+     * Use an emitter, and an injected channel - no processor
+     * emitter -> X -> channel
+     */
+    @Test
+    public void testEmitterNoProcessorChannelChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry,
+                Collections.singletonList(new EmitterConfiguration("a", false, null, null)),
+                Collections.singletonList(new ChannelConfiguration("b")),
+                Collections.emptyList());
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(1);
+        assertThat(graph.isClosed()).isFalse();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).isEmpty();
+        assertThat(graph.getOutbound()).isEmpty();
+    }
+
+    /**
+     * Use an emitter, directly connected to an injected channel.
+     * emitter -> b -> channel
+     */
+    @Test
+    public void testEmitterToChannelChain() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(registry,
+                Collections.singletonList(new EmitterConfiguration("a", false, null, null)),
+                Collections.singletonList(new ChannelConfiguration("a")),
+                Collections.emptyList());
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(2);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.incomings()).containsExactly("a"));
+    }
+
+    private Method getMethod(String name) {
+        for (Method method : this.getClass().getMethods()) {
+            if (method.getName().equals(name)) {
+                return method;
+            }
+        }
+        throw new NoSuchElementException("No method " + name);
+    }
+
+    public void consume(String ignored) {
+        // ...
+    }
+
+    public String producer() {
+        // ...
+        return "hello";
+    }
+
+    public String process(String s) {
+        return s;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringTest.java
@@ -215,7 +215,7 @@ class WiringTest {
         assertThat(graph.isClosed()).isFalse();
         assertThat(graph.hasWiringErrors()).isTrue();
         assertThat(graph.getWiringErrors()).hasSize(1).allSatisfy(e -> {
-            assertThat(e).isInstanceOf(NotClosedGraph.class);
+            assertThat(e).isInstanceOf(OpenGraphException.class);
             assertThat(e).hasMessageContaining("b");
         });
 

--- a/smallrye-reactive-messaging-vertx-eventbus/src/test/java/io/smallrye/reactive/messaging/eventbus/EventBusSourceTest.java
+++ b/smallrye-reactive-messaging-vertx-eventbus/src/test/java/io/smallrye/reactive/messaging/eventbus/EventBusSourceTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.vertx.core.eventbus.DeliveryOptions;
 
 public class EventBusSourceTest extends EventbusTestBase {
@@ -146,7 +145,6 @@ public class EventBusSourceTest extends EventbusTestBase {
     @Test
     public void testABeanConsumingTheEventBusMessages() {
         ConsumptionBean bean = deploy();
-        await().until(() -> container.select(MediatorManager.class).get().isInitialized());
 
         List<Integer> list = bean.getResults();
         assertThat(list).isEmpty();

--- a/smallrye-reactive-messaging-vertx-eventbus/src/test/java/io/smallrye/reactive/messaging/eventbus/EventbusTestBase.java
+++ b/smallrye-reactive-messaging-vertx-eventbus/src/test/java/io/smallrye/reactive/messaging/eventbus/EventbusTestBase.java
@@ -16,6 +16,7 @@ import io.smallrye.reactive.messaging.extension.MediatorManager;
 import io.smallrye.reactive.messaging.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.impl.InternalChannelRegistry;
+import io.smallrye.reactive.messaging.wiring.Wiring;
 import io.vertx.mutiny.core.Vertx;
 
 public class EventbusTestBase {
@@ -32,6 +33,7 @@ public class EventbusTestBase {
         weld.addBeanClass(ExecutionHolder.class);
         weld.addBeanClass(WorkerPoolRegistry.class);
         weld.addBeanClass(HealthCenter.class);
+        weld.addBeanClass(Wiring.class);
         weld.addExtension(new ReactiveMessagingExtension());
         weld.addBeanClass(VertxEventBusConnector.class);
 


### PR DESCRIPTION
The previous algorithm led to chicken-and-egg issues as the traversal of the graph and the instantiation of the component was made in a single step. 

This new algorithm distinguishes the two phases.
First, the resolution phase looks at the metadata and components (emitter, channels, connectors, and mediators) and assembles the graph. Once built, the graph is validated to detect wiring issues (missing broadcast, missing upstream/downstream...). These issues are reported to the user before starting anything.  

After the validation, the materialization happens. It actually creates the managed objects and connects everything. 

In comparison to the first algorithm, this new one:

* improves error reporting - error messages have been clarified
* supports some topologies not handled before (having a channel, a processor, and an emitter in the same class)
* detect more issues before the application is even started. 

It fixes #414, #879, and https://github.com/quarkusio/quarkus/issues/12820