### PR TITLE
Fix missing getAck /  getNack implementation in Message implementations

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
@@ -2,9 +2,14 @@ package io.smallrye.reactive.messaging.amqp;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.qpid.proton.amqp.Binary;
-import org.apache.qpid.proton.amqp.messaging.*;
+import org.apache.qpid.proton.amqp.messaging.AmqpSequence;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Section;
 import org.apache.qpid.proton.message.Message;
 import org.apache.qpid.proton.message.MessageError;
 import org.eclipse.microprofile.reactive.messaging.Metadata;
@@ -175,5 +180,15 @@ public class AmqpMessage<T> implements org.eclipse.microprofile.reactive.messagi
 
     public io.vertx.mutiny.amqp.AmqpMessage getAmqpMessage() {
         return new io.vertx.mutiny.amqp.AmqpMessage(message);
+    }
+
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
+    }
+
+    @Override
+    public Function<Throwable, CompletionStage<Void>> getNack() {
+        return this::nack;
     }
 }

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/OutgoingAmqpMessage.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/OutgoingAmqpMessage.java
@@ -2,6 +2,8 @@ package io.smallrye.reactive.messaging.amqp;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.reactive.messaging.Metadata;
 
@@ -82,6 +84,16 @@ public class OutgoingAmqpMessage<T> extends AmqpMessage<T>
     @Override
     public CompletionStage<Void> nack(Throwable reason) {
         return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
+    }
+
+    @Override
+    public Function<Throwable, CompletionStage<Void>> getNack() {
+        return this::nack;
     }
 
     @Override

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpBrokerTestBase.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpBrokerTestBase.java
@@ -1,7 +1,8 @@
 package io.smallrye.reactive.messaging.amqp;
 
+import javax.enterprise.inject.se.SeContainer;
+
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,7 +58,7 @@ public class AmqpBrokerTestBase {
         MapBasedConfig.cleanup();
     }
 
-    public boolean isAmqpConnectorReady(WeldContainer container) {
+    public boolean isAmqpConnectorReady(SeContainer container) {
         HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
         return health.getReadiness().isOk();
     }
@@ -66,7 +67,7 @@ public class AmqpBrokerTestBase {
         return connector.getReadiness().isOk();
     }
 
-    public boolean isAmqpConnectorAlive(WeldContainer container) {
+    public boolean isAmqpConnectorAlive(SeContainer container) {
         HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
         return health.getLiveness().isOk();
     }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpWithConverterTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpWithConverterTest.java
@@ -1,0 +1,89 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import static org.awaitility.Awaitility.await;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.jboss.weld.environment.se.Weld;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.MessageConverter;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class AmqpWithConverterTest extends AmqpBrokerTestBase {
+
+    private SeContainer container;
+
+    @AfterEach
+    public void cleanup() {
+        container.close();
+    }
+
+    @Test
+    public void testAckWithConverter() {
+        String address = UUID.randomUUID().toString();
+        SeContainerInitializer weld = Weld.newInstance();
+        new MapBasedConfig()
+                .with("mp.messaging.incoming.in.connector", AmqpConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.in.host", host)
+                .with("mp.messaging.incoming.in.port", port)
+                .with("mp.messaging.incoming.in.username", username)
+                .with("mp.messaging.incoming.in.password", password)
+                .with("mp.messaging.incoming.in.address", address)
+                .write();
+        weld.addBeanClasses(DummyConverter.class, MyApp.class);
+        container = weld.initialize();
+
+        await().until(() -> isAmqpConnectorAlive(container));
+        await().until(() -> isAmqpConnectorReady(container));
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers(address, counter::incrementAndGet);
+
+        MyApp app = container.getBeanManager().createInstance().select(MyApp.class).get();
+        await().until(() -> app.list().size() == 10);
+    }
+
+    @ApplicationScoped
+    public static class DummyConverter implements MessageConverter {
+
+        @Override
+        public boolean canConvert(Message<?> in, Type target) {
+            return true;
+        }
+
+        @Override
+        public Message<?> convert(Message<?> in, Type target) {
+            return in.withPayload(new DummyData());
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyApp {
+        List<DummyData> list = new ArrayList<>();
+
+        @Incoming("in")
+        public void consume(DummyData data) {
+            list.add(data);
+        }
+
+        public List<DummyData> list() {
+            return list;
+        }
+    }
+
+    public static class DummyData {
+
+    }
+}

--- a/smallrye-reactive-messaging-aws-sns/src/main/java/io/smallrye/reactive/messaging/aws/sns/SnsMessage.java
+++ b/smallrye-reactive-messaging-aws-sns/src/main/java/io/smallrye/reactive/messaging/aws/sns/SnsMessage.java
@@ -5,6 +5,7 @@ import static io.smallrye.reactive.messaging.aws.sns.i18n.SnsMessages.msg;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 
@@ -51,6 +52,11 @@ public class SnsMessage implements Message<String> {
     public CompletionStage<Void> ack() {
         //Acknowledgment is handled automatically by AWS SDK.
         return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
     }
 
     @Override

--- a/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/CamelMessage.java
+++ b/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/CamelMessage.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.camel;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import org.apache.camel.Exchange;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -39,5 +40,10 @@ public class CamelMessage<T> implements Message<T> {
     @Override
     public CompletionStage<Void> nack(Throwable reason) {
         return onNack.handle(this, reason);
+    }
+
+    @Override
+    public Function<Throwable, CompletionStage<Void>> getNack() {
+        return this::nack;
     }
 }

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/source/FailureHandlerTest.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/source/FailureHandlerTest.java
@@ -90,17 +90,17 @@ public class FailureHandlerTest extends CamelTestBase {
 
     private void getFailConfig() {
         new MapBasedConfig()
-                .put("mp.messaging.incoming.camel.endpoint-uri", "seda:fail")
-                .put("mp.messaging.incoming.camel.connector", CamelConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.camel.endpoint-uri", "seda:fail")
+                .with("mp.messaging.incoming.camel.connector", CamelConnector.CONNECTOR_NAME)
                 // fail is the default.
                 .write();
     }
 
     private void getIgnoreConfig() {
         new MapBasedConfig()
-                .put("mp.messaging.incoming.camel.endpoint-uri", "seda:ignore")
-                .put("mp.messaging.incoming.camel.connector", CamelConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.camel.failure-strategy", "ignore")
+                .with("mp.messaging.incoming.camel.endpoint-uri", "seda:ignore")
+                .with("mp.messaging.incoming.camel.connector", CamelConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.camel.failure-strategy", "ignore")
                 .write();
     }
 

--- a/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubMessage.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubMessage.java
@@ -5,6 +5,7 @@ import static io.smallrye.reactive.messaging.gcp.pubsub.i18n.PubSubMessages.msg;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 
@@ -42,6 +43,11 @@ public class PubSubMessage implements Message<String> {
             ackReplyConsumer.ack();
         }
         return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
     }
 
     @Override

--- a/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/HttpMessage.java
+++ b/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/HttpMessage.java
@@ -50,6 +50,11 @@ public class HttpMessage<T> implements Message<T> {
         this.ack = ack;
     }
 
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return ack;
+    }
+
     public static <T> HttpMessageBuilder<T> builder() {
         return new HttpMessageBuilder<>();
     }

--- a/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/IncomingJmsMessage.java
+++ b/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/IncomingJmsMessage.java
@@ -5,6 +5,7 @@ import static io.smallrye.reactive.messaging.jms.i18n.JmsExceptions.ex;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -99,6 +100,11 @@ public class IncomingJmsMessage<T> implements org.eclipse.microprofile.reactive.
 
         return json.fromJson(value, clazz);
 
+    }
+
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
     }
 
     @Override

--- a/smallrye-reactive-messaging-mqtt-server/src/main/java/io/smallrye/reactive/messaging/mqtt/server/MqttMessage.java
+++ b/smallrye-reactive-messaging-mqtt-server/src/main/java/io/smallrye/reactive/messaging/mqtt/server/MqttMessage.java
@@ -31,6 +31,11 @@ public class MqttMessage implements Message<byte[]> {
         return ack.get();
     }
 
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
+    }
+
     public int getMessageId() {
         return message.messageId();
     }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/ReceivingMqttMessage.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/ReceivingMqttMessage.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.mqtt;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.mutiny.mqtt.messages.MqttPublishMessage;
@@ -42,5 +43,10 @@ public class ReceivingMqttMessage implements MqttMessage<byte[]> {
     @Override
     public CompletionStage<Void> nack(Throwable reason) {
         return this.onNack.handle(reason);
+    }
+
+    @Override
+    public Function<Throwable, CompletionStage<Void>> getNack() {
+        return this::nack;
     }
 }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessage.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessage.java
@@ -34,6 +34,11 @@ public final class SendingMqttMessage<T> implements MqttMessage<T> {
         return CompletableFuture.completedFuture(null);
     }
 
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
+    }
+
     public T getPayload() {
         return payload;
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/ProcessorWithConverterTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/converters/ProcessorWithConverterTest.java
@@ -23,8 +23,6 @@ import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 
 public class ProcessorWithConverterTest extends WeldTestBaseWithoutTails {
 
-    // TODO Converter throwin exception during accept / during conversion
-
     @Test
     public void testConversionWhenReceivingPayload() {
         addBeanClass(Source.class, Sink.class, StringToPersonConverter.class, PayloadProcessor.class);
@@ -49,7 +47,10 @@ public class ProcessorWithConverterTest extends WeldTestBaseWithoutTails {
         addBeanClass(Source.class, Sink.class, StringToPersonConverter.class, MessageProcessor.class);
         initialize();
         Sink sink = get(Sink.class);
+        Source source = get(Source.class);
         assertThat(sink.list()).hasSize(5);
+        assertThat(source.acks()).isEqualTo(5);
+        assertThat(source.nacks()).isEqualTo(0);
     }
 
     @Test

--- a/smallrye-reactive-messaging-vertx-eventbus/src/main/java/io/smallrye/reactive/messaging/eventbus/EventBusMessage.java
+++ b/smallrye-reactive-messaging-vertx-eventbus/src/main/java/io/smallrye/reactive/messaging/eventbus/EventBusMessage.java
@@ -67,4 +67,9 @@ public class EventBusMessage<T> implements Message<T> {
         return wrapped;
     }
 
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
+    }
+
 }


### PR DESCRIPTION
Some implementations of Message didn't override the getAck and getNack method, breaking the acknowledgement chain.

- Fix #903
- Fix missing getAck / getNack override in Message implementations
