### PR TITLE
Improve injected channel support

### DIFF
--- a/documentation/src/main/doc/modules/ROOT/pages/emitter/emitter.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/emitter/emitter.adoc
@@ -113,7 +113,11 @@ include::example$emitter/ChannelExamples.java[tag=channel]
 
 IMPORTANT: You must have a `@Outgoing("my-channel")` somewhere in your application (meaning a method generating messages transiting on the channel `my-channel`), or an inbound connector configured to manage the `prices` channel (`mp.messaging.incoming.prices...`)
 
-Be aware that when using a channel, the messages are not acknowledged automatically and, so, you must either handle the acknowledgment beforehand or manage it manually.
+
+Injected _channels_ merge all the matching _outgoing_ - so if you have multiple `@Outgoing("out")`, `@Inject @Channel("out")` gets all the messages.
+
+If your injected _channel_ receives _payloads_ (`Multi<T>`), it acknowledges the message automatically, and support multiple subscribers.
+If you injected _channel_ receives `Message` (`Multi<Message<T>>`), you will be responsible for the acknowledgement and broadcasting.
 
 [#emitter-broadcast]
 == Emitter and @Broadcast

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/Wiring.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/Wiring.java
@@ -378,7 +378,7 @@ public class Wiring {
 
         @Override
         public boolean merge() {
-            return false; // TODO We may want to add this feature.
+            return true;
         }
 
         @Override
@@ -398,9 +398,7 @@ public class Wiring {
 
         @Override
         public void validate() throws WiringException {
-            if (upstreams().size() > 1) {
-                throw new TooManyUpstreamCandidatesException(this);
-            }
+
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelAutoAckTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelAutoAckTest.java
@@ -1,0 +1,145 @@
+package io.smallrye.reactive.messaging.inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class ChannelAutoAckTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testWithMessageAndOneSource() {
+        addBeanClass(MessageConsumer.class, Producer1.class);
+        initialize();
+        MessageConsumer consumer = get(MessageConsumer.class);
+        List<Message<Integer>> messages = new ArrayList<>();
+        consumer.get()
+                .subscribe().with(messages::add);
+        assertThat(messages.stream().map(Message::getPayload).collect(Collectors.toList()))
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertThat(get(Producer1.class).acks()).isEqualTo(0);
+        messages.forEach(Message::ack);
+        assertThat(get(Producer1.class).acks()).isEqualTo(10);
+    }
+
+    @Test
+    public void testWithPayloadAndOneSource() {
+        addBeanClass(PayloadConsumer.class, Producer1.class);
+        initialize();
+        PayloadConsumer consumer = get(PayloadConsumer.class);
+        List<Integer> messages = new ArrayList<>();
+        consumer.get()
+                .subscribe().with(messages::add);
+        assertThat(messages)
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertThat(get(Producer1.class).acks()).isEqualTo(10);
+        assertThat(get(Producer1.class).acks()).isEqualTo(10);
+    }
+
+    @Test
+    public void testWithMessagesAndTwoSources() {
+        addBeanClass(MessageConsumer.class, Producer1.class, Producer2.class);
+        initialize();
+        MessageConsumer consumer = get(MessageConsumer.class);
+        List<Message<Integer>> messages = new ArrayList<>();
+        consumer.get()
+                .subscribe().with(messages::add);
+        assertThat(messages.stream().map(Message::getPayload).collect(Collectors.toList()))
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertThat(get(Producer1.class).acks()).isEqualTo(0);
+        assertThat(get(Producer2.class).acks()).isEqualTo(0);
+        messages.forEach(Message::ack);
+        assertThat(get(Producer1.class).acks()).isEqualTo(10);
+        assertThat(get(Producer2.class).acks()).isEqualTo(10);
+    }
+
+    @Test
+    public void testWithPayloadsAndTwoSources() {
+        addBeanClass(PayloadConsumer.class, Producer1.class, Producer2.class);
+        initialize();
+        PayloadConsumer consumer = get(PayloadConsumer.class);
+        List<Integer> messages = new ArrayList<>();
+        consumer.get()
+                .subscribe().with(messages::add);
+        assertThat(messages)
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertThat(get(Producer1.class).acks()).isEqualTo(10);
+        assertThat(get(Producer2.class).acks()).isEqualTo(10);
+    }
+
+    @ApplicationScoped
+    public static class Producer1 {
+
+        int acks = 0;
+
+        @Outgoing("foo")
+        public Multi<Message<Integer>> produce() {
+            return Multi.createFrom().range(0, 10)
+                    .onItem().transform(i -> Message.of(i, () -> {
+                        acks++;
+                        return CompletableFuture.completedFuture(null);
+                    }));
+        }
+
+        public int acks() {
+            return acks;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Producer2 {
+
+        int acks = 0;
+
+        @Outgoing("foo")
+        public Multi<Message<Integer>> produce() {
+            return Multi.createFrom().range(0, 10)
+                    .onItem().transform(i -> Message.of(i, () -> {
+                        acks++;
+                        return CompletableFuture.completedFuture(null);
+                    }));
+        }
+
+        public int acks() {
+            return acks;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MessageConsumer {
+
+        @Inject
+        @Channel("foo")
+        Multi<Message<Integer>> multiOfMessages;
+
+        public Multi<Message<Integer>> get() {
+            return multiOfMessages;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PayloadConsumer {
+
+        @Inject
+        @Channel("foo")
+        Multi<Integer> multiOfPayloads;
+
+        public Multi<Integer> get() {
+            return multiOfPayloads;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelAutoBroadcastTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelAutoBroadcastTest.java
@@ -1,0 +1,115 @@
+package io.smallrye.reactive.messaging.inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.mutiny.subscription.MultiEmitter;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class ChannelAutoBroadcastTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testPayloadBroadcasting() {
+        addBeanClass(PayloadConsumer.class, Producer.class);
+        initialize();
+        Producer producer = get(Producer.class);
+        PayloadConsumer consumer = get(PayloadConsumer.class);
+        List<Integer> messages1 = new ArrayList<>();
+        Cancellable cancellable = consumer.get()
+                .subscribe().with(messages1::add);
+
+        producer.emitter().emit(1);
+        assertThat(messages1).containsExactly(1);
+        assertThat(producer.acks()).isEqualTo(1);
+
+        List<Integer> messages2 = new ArrayList<>();
+        Cancellable cancellable2 = consumer.get()
+                .subscribe().with(messages2::add);
+
+        producer.emitter().emit(2);
+        assertThat(messages1).containsExactly(1, 2);
+        assertThat(messages2).containsExactly(2);
+        assertThat(producer.acks()).isEqualTo(2);
+
+        producer.emitter().emit(3).emit(4).emit(5);
+        assertThat(messages1).containsExactly(1, 2, 3, 4, 5);
+        assertThat(messages2).containsExactly(2, 3, 4, 5);
+        assertThat(producer.acks()).isEqualTo(5);
+
+        cancellable.cancel();
+
+        producer.emitter().emit(6).emit(7);
+        assertThat(messages1).containsExactly(1, 2, 3, 4, 5);
+        assertThat(messages2).containsExactly(2, 3, 4, 5, 6, 7);
+        assertThat(producer.acks()).isEqualTo(7);
+
+        cancellable2.cancel();
+
+        producer.emitter().emit(8);
+        assertThat(messages1).containsExactly(1, 2, 3, 4, 5);
+        assertThat(messages2).containsExactly(2, 3, 4, 5, 6, 7);
+        assertThat(producer.acks()).isEqualTo(8); // Acknowledging even without consumers
+    }
+
+    @ApplicationScoped
+    public static class Producer {
+
+        int acks = 0;
+        private MultiEmitter<? super Integer> emitter;
+
+        @Outgoing("foo")
+        public Multi<Message<Integer>> produce() {
+            return Multi.createFrom().<Integer> emitter(e -> emitter = e)
+                    .onItem().transform(i -> Message.of(i, () -> {
+                        acks++;
+                        return CompletableFuture.completedFuture(null);
+                    }));
+        }
+
+        public int acks() {
+            return acks;
+        }
+
+        public MultiEmitter<? super Integer> emitter() {
+            return emitter;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MessageConsumer {
+
+        @Inject
+        @Channel("foo")
+        Multi<Message<Integer>> multiOfMessages;
+
+        public Multi<Message<Integer>> get() {
+            return multiOfMessages;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PayloadConsumer {
+
+        @Inject
+        @Channel("foo")
+        Multi<Integer> multiOfPayloads;
+
+        public Multi<Integer> get() {
+            return multiOfPayloads;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelMergeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelMergeTest.java
@@ -1,0 +1,110 @@
+package io.smallrye.reactive.messaging.inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+
+public class ChannelMergeTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testMissing() {
+        addBeanClass(ChannelConsumer.class);
+        initialize();
+        ChannelConsumer consumer = get(ChannelConsumer.class);
+        assertThatThrownBy(() -> consumer.getMessages().collectItems().asList().await().indefinitely())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("SRMSG00018");
+        assertThatThrownBy(() -> consumer.getPayloads().collectItems().asList().await().indefinitely())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("SRMSG00018");
+    }
+
+    @Test
+    public void testOne() {
+        addBeanClass(ChannelConsumer.class, Producer1.class);
+        initialize();
+        ChannelConsumer consumer = get(ChannelConsumer.class);
+        List<Integer> payloads = new ArrayList<>();
+        List<Message<Integer>> messages = new ArrayList<>();
+        consumer.getPayloads()
+                .subscribe().with(payloads::add);
+        consumer.getMessages()
+                .subscribe().with(messages::add);
+
+        assertThat(messages.stream().map(Message::getPayload).collect(Collectors.toList()))
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertThat(payloads)
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+
+    @Test
+    public void testMerge() {
+        addBeanClass(ChannelConsumer.class, Producer1.class, Producer2.class);
+        initialize();
+        ChannelConsumer consumer = get(ChannelConsumer.class);
+        List<Integer> payloads = new ArrayList<>();
+        List<Message<Integer>> messages = new ArrayList<>();
+        consumer.getPayloads()
+                .subscribe().with(payloads::add);
+        consumer.getMessages()
+                .subscribe().with(messages::add);
+
+        assertThat(messages.stream().map(Message::getPayload).collect(Collectors.toList()))
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertThat(payloads)
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+
+    @ApplicationScoped
+    public static class Producer1 {
+        @Outgoing("foo")
+        @Broadcast(2)
+        public Multi<Integer> produce() {
+            return Multi.createFrom().range(0, 10);
+        }
+    }
+
+    @ApplicationScoped
+    public static class Producer2 {
+        @Outgoing("foo")
+        @Broadcast(2)
+        public Multi<Integer> produce() {
+            return Multi.createFrom().range(0, 10);
+        }
+    }
+
+    @ApplicationScoped
+    public static class ChannelConsumer {
+        @Inject
+        @Channel("foo")
+        Multi<Integer> multiOfPayloads;
+
+        @Inject
+        @Channel("foo")
+        Multi<Message<Integer>> multiOfMessages;
+
+        public Multi<Integer> getPayloads() {
+            return multiOfPayloads;
+        }
+
+        public Multi<Message<Integer>> getMessages() {
+            return multiOfMessages;
+        }
+    }
+
+}


### PR DESCRIPTION
The injected channels will now merge multiple upstreams.
In the case of injecting a stream of payload, it broadcasts the payload to multiple subscribers. It also acknowledges the message.
In the case of a stream of messages, acknowledgment and broadcast are under the user's responsibility. 
﻿
