### PR TITLE
Detect and throw a CDI DefinitionException when trying to inject an Emitter<Message<?>>

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/AbstractEmitter.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/AbstractEmitter.java
@@ -138,7 +138,7 @@ public abstract class AbstractEmitter<T> {
 
         MultiEmitter<? super Message<? extends T>> emitter = verify(internal, name);
         if (synchronousFailure.get() != null) {
-            throw ex.illegalStateForEmitter(synchronousFailure.get());
+            throw ex.incomingNotFoundForEmitter(synchronousFailure.get());
         }
         if (emitter.isCancelled()) {
             throw ex.illegalStateForDownstreamCancel();

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderExceptions.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderExceptions.java
@@ -86,11 +86,11 @@ public interface ProviderExceptions {
     @Message(id = 18, value = "Unable to find a stream with the name %s, available streams are: %s")
     IllegalStateException illegalStateForStream(String name, Set<String> valid);
 
-    @Message(id = 19, value = "Unable to find a emitter with the name %s, available emitters are: %s")
-    IllegalStateException illegalStateForEmitter(String name, Set<String> valid);
+    @Message(id = 19, value = "Unable to connect an emitter with the channel `%s`")
+    DefinitionException incomingNotFoundForEmitter(String name);
 
-    @Message(id = 20, value = "%s qualifier not found on + %s")
-    IllegalStateException illegalStateForAnnotationNotFound(String annotation, InjectionPoint injectionPoint);
+    @Message(id = 20, value = "Missing @Channel qualifier for + `%s`")
+    DefinitionException emitterWithoutChannelAnnotation(InjectionPoint injectionPoint);
 
     @Message(id = 21, value = "The default buffer size must be strictly positive")
     IllegalArgumentException illegalArgumentForDefaultBuffer();
@@ -102,7 +102,7 @@ public interface ProviderExceptions {
     IllegalArgumentException illegalArgumentForNullValue();
 
     @Message(id = 24, value = "The emitter encountered a failure")
-    IllegalStateException illegalStateForEmitter(@Cause Throwable throwable);
+    IllegalStateException incomingNotFoundForEmitter(@Cause Throwable throwable);
 
     @Message(id = 25, value = "The downstream has cancelled the consumption")
     IllegalStateException illegalStateForDownstreamCancel();
@@ -250,5 +250,12 @@ public interface ProviderExceptions {
     DeploymentException deploymentInvalidConfiguration(Set<String> sources);
 
     @Message(id = 74, value = "Unable to retrieve the config")
-    IllegalStateException illegalStateRetieveConfig();
+    IllegalStateException illegalStateRetrieveConfig();
+
+    @Message(id = 75, value = "Invalid Emitter injection found for `%s`. Injecting an `Emitter<Message<T>>` is invalid. You can use an `Emitter<T>` to send instances of `T` and `Message<T>`.")
+    DefinitionException invalidEmitterOfMessage(InjectionPoint ip);
+
+    @Message(id = 76, value = "Invalid Emitter injection found for  `%s`. The Emitter expected to be parameterized with the emitted type, such as Emitter<String>.")
+    DefinitionException invalidRawEmitter(InjectionPoint ip);
+
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
@@ -76,7 +76,7 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
                 log.foundOutgoingConnectors(getConnectors(beanManager, OutgoingConnectorFactory.class));
             }
             this.config = config.stream().findFirst()
-                    .orElseThrow(ex::illegalStateRetieveConfig);
+                    .orElseThrow(ex::illegalStateRetrieveConfig);
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/LegacyEmitterInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/LegacyEmitterInjectionTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.DefinitionException;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -87,7 +88,7 @@ public class LegacyEmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.isCaught()).isTrue();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = DefinitionException.class)
     public void testWithMissingChannel() {
         // The error is only thrown when a message is emitted as the subscription can be delayed.
         installInitializeAndGet(EmitterInjectionTest.BeanWithMissingChannel.class).emitter().send(Message.of("foo"));

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterAndAwaitInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterAndAwaitInjectionTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.DefinitionException;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
@@ -112,10 +113,10 @@ public class MutinyEmitterAndAwaitInjectionTest extends WeldTestBaseWithoutTails
         assertThat(bean.hasCaughtNullPayload()).isTrue();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = DefinitionException.class)
     public void testWithMissingChannel() {
         // The error is only thrown when a message is emitted as the subscription can be delayed.
-        installInitializeAndGet(BeanWithMissingChannel.class).emitter().sendAndAwait(Message.of("foo"));
+        installInitializeAndGet(BeanWithMissingChannel.class).emitter().sendAndAwait("foo");
     }
 
     @Test
@@ -125,6 +126,7 @@ public class MutinyEmitterAndAwaitInjectionTest extends WeldTestBaseWithoutTails
         assertThat(bean.list()).containsExactly("A", "B", "C");
     }
 
+    @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
     @Test
     public void testEmitterAndPublisherInjectedInTheSameClass() {
         EmitterAndPublisher bean = installInitializeAndGet(EmitterAndPublisher.class);
@@ -134,7 +136,6 @@ public class MutinyEmitterAndAwaitInjectionTest extends WeldTestBaseWithoutTails
         assertThat(publisher).isNotNull();
         List<String> list = new ArrayList<>();
         AtomicBoolean completed = new AtomicBoolean();
-        //noinspection SubscriberImplementation
         publisher.subscribe(new Subscriber<String>() {
             private Subscription subscription;
 
@@ -320,9 +321,9 @@ public class MutinyEmitterAndAwaitInjectionTest extends WeldTestBaseWithoutTails
     public static class BeanWithMissingChannel {
         @Inject
         @Channel("missing")
-        MutinyEmitter<Message<String>> emitter;
+        MutinyEmitter<String> emitter;
 
-        public MutinyEmitter<Message<String>> emitter() {
+        public MutinyEmitter<String> emitter() {
             return emitter;
         }
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterAndForgetInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterAndForgetInjectionTest.java
@@ -8,11 +8,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.DefinitionException;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.jboss.logmanager.Level;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +27,7 @@ import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Merge;
 import io.smallrye.testing.logging.LogCapture;
 
+@SuppressWarnings("ConstantConditions")
 public class MutinyEmitterAndForgetInjectionTest extends WeldTestBaseWithoutTails {
 
     @RegisterExtension
@@ -92,8 +93,8 @@ public class MutinyEmitterAndForgetInjectionTest extends WeldTestBaseWithoutTail
     @Test
     public void testWithMissingChannel() {
         try {
-            installInitializeAndGet(BeanWithMissingChannel.class).emitter().sendAndForget(Message.of("foo"));
-        } catch (IllegalStateException e) {
+            installInitializeAndGet(BeanWithMissingChannel.class).emitter().sendAndForget("foo");
+        } catch (DefinitionException e) {
             assertThat(e).hasMessageContaining("SRMSG00019");
         }
     }
@@ -105,6 +106,7 @@ public class MutinyEmitterAndForgetInjectionTest extends WeldTestBaseWithoutTail
         assertThat(bean.list()).containsExactly("A", "B", "C");
     }
 
+    @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
     @Test
     public void testEmitterAndPublisherInjectedInTheSameClass() {
         EmitterAndPublisher bean = installInitializeAndGet(EmitterAndPublisher.class);
@@ -114,7 +116,6 @@ public class MutinyEmitterAndForgetInjectionTest extends WeldTestBaseWithoutTail
         assertThat(publisher).isNotNull();
         List<String> list = new ArrayList<>();
         AtomicBoolean completed = new AtomicBoolean();
-        //noinspection SubscriberImplementation
         publisher.subscribe(new Subscriber<String>() {
             private Subscription subscription;
 
@@ -203,9 +204,9 @@ public class MutinyEmitterAndForgetInjectionTest extends WeldTestBaseWithoutTail
     public static class BeanWithMissingChannel {
         @Inject
         @Channel("missing")
-        MutinyEmitter<Message<String>> emitter;
+        MutinyEmitter<String> emitter;
 
-        public MutinyEmitter<Message<String>> emitter() {
+        public MutinyEmitter<String> emitter() {
             return emitter;
         }
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterInjectionTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.DefinitionException;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
@@ -37,6 +38,7 @@ import io.smallrye.reactive.messaging.annotations.Merge;
 import io.smallrye.reactive.messaging.extension.EmitterConfiguration;
 import io.smallrye.reactive.messaging.extension.MutinyEmitterImpl;
 
+@SuppressWarnings("ConstantConditions")
 public class MutinyEmitterInjectionTest extends WeldTestBaseWithoutTails {
 
     @Test
@@ -161,15 +163,15 @@ public class MutinyEmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.hasCaughtNullMessage()).isTrue();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = DefinitionException.class)
     public void testWithMissingChannel() {
         // The error is only thrown when a message is emitted as the subscription can be delayed.
         final AtomicReference<Throwable> exception = new AtomicReference<>();
         installInitializeAndGet(BeanWithMissingChannel.class).emitter().send(Message.of("foo")).subscribe().with(x -> {
         }, exception::set);
         await().until(() -> exception.get() != null);
-        if (exception.get() instanceof IllegalStateException) {
-            throw (IllegalStateException) exception.get();
+        if (exception.get() instanceof DefinitionException) {
+            throw (DefinitionException) exception.get();
         }
     }
 
@@ -180,6 +182,7 @@ public class MutinyEmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(bean.list()).containsExactly("A", "B", "C");
     }
 
+    @SuppressWarnings("ReactiveStreamsSubscriberImplementation")
     @Test
     public void testEmitterAndPublisherInjectedInTheSameClass() {
         EmitterAndPublisher bean = installInitializeAndGet(EmitterAndPublisher.class);
@@ -189,7 +192,6 @@ public class MutinyEmitterInjectionTest extends WeldTestBaseWithoutTails {
         assertThat(publisher).isNotNull();
         List<String> list = new ArrayList<>();
         AtomicBoolean completed = new AtomicBoolean();
-        //noinspection SubscriberImplementation
         publisher.subscribe(new Subscriber<String>() {
             private Subscription subscription;
 


### PR DESCRIPTION
- Detect the injection of `Emitter<Message<?>>`﻿
- Detect the injection of raw emitter (`Emitter`)
- Detect the injection of `Emitter<Message>>`
- Improve error reporting when the `@Channel` qualifier is missing 
