### PR TITLE
various AMQP test improvements

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -35,7 +35,7 @@ jobs:
                   source: ${{ matrix.java.source }}
             - name: Build with Maven
               run: |
-                  mvn -B clean verify --file pom.xml
+                  mvn -B clean verify -Dtest-containers=true --file pom.xml
 
     quality:
         needs: build

--- a/.github/workflows/build-pull.yml
+++ b/.github/workflows/build-pull.yml
@@ -29,7 +29,7 @@ jobs:
                   source: ${{ matrix.java.source }}
             - name: Build with Maven
               run: |
-                mvn -B clean verify --file pom.xml
+                mvn -B clean verify -Dtest-containers=true --file pom.xml
 
 
     up_to_date_antora:

--- a/smallrye-reactive-messaging-amqp/pom.xml
+++ b/smallrye-reactive-messaging-amqp/pom.xml
@@ -94,6 +94,16 @@
           </annotationProcessors>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <!-- Tests that require test-containers
+                 Enable with -Dtest-containers or -Ptest-containers -->
+            <exclude>**/RabbitMQTest.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -108,6 +118,25 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>test-containers</id>
+      <activation>
+        <property>
+          <name>test-containers</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <excludes combine.self="override">
+               </excludes>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpFailureHandlerTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpFailureHandlerTest.java
@@ -3,8 +3,9 @@ package io.smallrye.reactive.messaging.amqp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -12,28 +13,40 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Modified;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
+import org.apache.qpid.proton.amqp.transport.DeliveryState.DeliveryStateType;
+import org.apache.qpid.proton.message.Message;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.core.Vertx;
 
-public class AmqpFailureHandlerTest extends AmqpBrokerTestBase {
+public class AmqpFailureHandlerTest extends AmqpTestBase {
 
     private WeldContainer container;
+    private MockServer server;
 
     @AfterEach
     public void cleanup() {
         if (container != null) {
             container.close();
         }
-        // Release the config objects
-        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+
+        if (server != null) {
+            server.close();
+        }
     }
 
     private MyReceiverBean deploy() {
@@ -53,211 +66,320 @@ public class AmqpFailureHandlerTest extends AmqpBrokerTestBase {
     }
 
     @Test
-    public void testFailStrategy() {
-        String address = UUID.randomUUID().toString();
-        getFailConfig(address);
+    @Timeout(30)
+    public void testFailStrategy() throws Exception {
+        int msgCount = 10;
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
+
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        writeDefaultFailConfig(server.actualPort());
         MyReceiverBean bean = deploy();
-        AtomicInteger counter = new AtomicInteger();
 
         AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
                 ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
-        await().until(() -> isAmqpConnectorReady(connector));
-        await().until(() -> isAmqpConnectorAlive(connector));
 
-        usage.produceTenIntegers(address, counter::getAndIncrement);
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 4);
+        await().atMost(6, TimeUnit.SECONDS).until(() -> bean.list().size() >= 3);
         // Other messages should not have been received.
-        assertThat(bean.list()).containsExactly(0, 1, 2, 3);
+        assertThat(bean.list()).containsExactly(1, 2, 3);
 
-        await().until(() -> !isAmqpConnectorReady(connector));
-        await().until(() -> !isAmqpConnectorAlive(connector));
+        await().atMost(6, TimeUnit.SECONDS).until(() -> !isAmqpConnectorReady(connector));
+        await().atMost(6, TimeUnit.SECONDS).until(() -> !isAmqpConnectorAlive(connector));
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= 2);
+
+        for (int i = 0; i < dispositionsReceived.size(); i++) {
+            DispositionRecord record = dispositionsReceived.get(i);
+
+            int messageNum = i + 1;
+            assertThat(messageNum).isLessThan(3);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+        }
     }
 
     @Test
-    public void testAcceptStrategy() {
-        getAcceptConfig();
+    @Timeout(30)
+    public void testAcceptStrategy() throws Exception {
+        int msgCount = 10;
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
+
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        writeAcceptConfig(server.actualPort());
         MyReceiverBean bean = deploy();
-        AtomicInteger counter = new AtomicInteger();
 
         AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
                 ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
-        await().until(() -> isAmqpConnectorReady(connector));
-        await().until(() -> isAmqpConnectorAlive(connector));
 
-        usage.produceTenIntegers("accept", counter::getAndIncrement);
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 10);
-        // All messages should not have been received.
-        assertThat(bean.list()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        await().atMost(6, TimeUnit.SECONDS).until(() -> bean.list().size() >= 10);
+        // All messages should have been received.
+        assertThat(bean.list()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
         assertThat(isAmqpConnectorAlive(connector)).isTrue();
         assertThat(isAmqpConnectorReady(connector)).isTrue();
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= 10);
+
+        for (int i = 0; i < dispositionsReceived.size(); i++) {
+            DispositionRecord record = dispositionsReceived.get(i);
+
+            int messageNum = i + 1;
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+        }
     }
 
     @Test
-    public void testReleaseStrategy() {
-        getReleaseConfig();
-        MyReceiverBean bean = deploy();
-        AtomicInteger counter = new AtomicInteger();
-        AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
-                ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
-        await().until(() -> isAmqpConnectorReady(connector));
-        await().until(() -> isAmqpConnectorAlive(connector));
+    @Timeout(30)
+    public void testReleaseStrategy() throws Exception {
+        int msgCount = 10;
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
 
-        usage.produceTenIntegers("release", counter::getAndIncrement);
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate());
 
-        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 20);
-        // All messages should not have been received, after 9 the released message should have been re-delivered again.
-        assertThat(bean.list()).contains(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-        assertThat(bean.list()).satisfies(l -> assertThat(l.indexOf(3)).isNotEqualTo(l.lastIndexOf(3)));
-        assertThat(bean.list()).satisfies(l -> assertThat(l.indexOf(6)).isNotEqualTo(l.lastIndexOf(6)));
-        assertThat(bean.list()).satisfies(l -> assertThat(l.indexOf(9)).isNotEqualTo(l.lastIndexOf(9)));
+        writeReleaseConfig(server.actualPort());
 
-        assertThat(isAmqpConnectorAlive(connector)).isTrue();
-        assertThat(isAmqpConnectorReady(connector)).isTrue();
-    }
-
-    @Test
-    public void testRejectStrategy() {
-        getRejectConfig();
-        MyReceiverBean bean = deploy();
-        AtomicInteger counter = new AtomicInteger();
-        AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
-                ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
-        await().until(() -> isAmqpConnectorReady(connector));
-        await().until(() -> isAmqpConnectorAlive(connector));
-
-        usage.produceTenIntegers("reject", counter::getAndIncrement);
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 10);
-        // All messages should not have been received.
-        assertThat(bean.list()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-
-        assertThat(isAmqpConnectorAlive(connector)).isTrue();
-        assertThat(isAmqpConnectorReady(connector)).isTrue();
-    }
-
-    @Test
-    public void testModifiedFailedStrategy() {
-        getModifiedFailedConfig();
         MyReceiverBeanRecovering bean = deployRecovering();
-        AtomicInteger counter = new AtomicInteger();
+
         AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
                 ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
-        await().until(() -> isAmqpConnectorReady(connector));
-        await().until(() -> isAmqpConnectorAlive(connector));
 
-        usage.produceTenIntegers("modified-failed", counter::getAndIncrement);
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 13);
-        // All messages should have been received + 3, 6 and 9 are redelivered
-        assertThat(bean.list()).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3, 6, 9);
+        await().atMost(6, TimeUnit.SECONDS).until(() -> bean.list().size() >= 13);
+        // All messages should have been received, with every 3rd released, which are then re-delivered and accepted.
+        assertThat(bean.list()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 3, 6, 9);
 
         assertThat(isAmqpConnectorAlive(connector)).isTrue();
         assertThat(isAmqpConnectorReady(connector)).isTrue();
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= 13);
+
+        for (int i = 0; i < msgCount; i++) {
+            DispositionRecord record = dispositionsReceived.get(i);
+
+            int messageNum = i + 1;
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            if (messageNum % 3 == 0) {
+                assertThat(record.getState()).isInstanceOf(Released.class);
+            } else {
+                assertThat(record.getState()).isInstanceOf(Accepted.class);
+            }
+            assertThat(record.isSettled()).isTrue();
+        }
+
+        for (int i = 0; i < msgCount / 3; i++) {
+            DispositionRecord record = dispositionsReceived.get(msgCount + i);
+
+            int messageNum = 3 * (i + 1);
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+        }
     }
 
     @Test
-    public void testModifiedFailedUndeliverableHereStrategy() {
-        getModifiedFailedUndeliverableConfig();
-        MyReceiverBeanRecovering bean = deployRecovering();
-        AtomicInteger counter = new AtomicInteger();
+    @Timeout(30)
+    public void testRejectStrategy() throws Exception {
+        int msgCount = 10;
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
+
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        writeRejectConfig(server.actualPort());
+
+        MyReceiverBean bean = deploy();
+
         AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
                 ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
-        await().until(() -> isAmqpConnectorReady(connector));
-        await().until(() -> isAmqpConnectorAlive(connector));
 
-        usage.produceTenIntegers("modified-failed-undeliverable-here", counter::getAndIncrement);
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.list().size() >= 10);
-        // All messages should have been received, 3 6 and 9 are NOT redelivered
-        assertThat(bean.list()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        await().atMost(6, TimeUnit.SECONDS).until(() -> bean.list().size() >= 10);
+        // All messages should have been received, with every 3rd rejected, which are then NOT re-delivered.
+        assertThat(bean.list()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
         assertThat(isAmqpConnectorAlive(connector)).isTrue();
         assertThat(isAmqpConnectorReady(connector)).isTrue();
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= 10);
+
+        for (int i = 0; i < msgCount; i++) {
+            DispositionRecord record = dispositionsReceived.get(i);
+
+            int messageNum = i + 1;
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            if (messageNum % 3 == 0) {
+                assertThat(record.getState()).isInstanceOf(Rejected.class);
+            } else {
+                assertThat(record.getState()).isInstanceOf(Accepted.class);
+            }
+            assertThat(record.isSettled()).isTrue();
+        }
     }
 
-    private void getFailConfig(String address) {
-        new MapBasedConfig()
-                .put("mp.messaging.incoming.amqp.address", address)
-                .put("mp.messaging.incoming.amqp.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.amqp.host", host)
-                .put("mp.messaging.incoming.amqp.port", port)
-                .put("mp.messaging.incoming.amqp.durable", true)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
-                // fail is the default.
+    @Test
+    @Timeout(30)
+    public void testModifiedFailedStrategy() throws Exception {
+        int msgCount = 10;
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
+
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        writeModifiedFailedConfig(server.actualPort());
+
+        MyReceiverBeanRecovering bean = deployRecovering();
+
+        AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
+                ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
+
+        await().atMost(6, TimeUnit.SECONDS).until(() -> bean.list().size() >= 13);
+        // All messages should have been received, with every 3rd modified-failed, which are then re-delivered and accepted.
+        assertThat(bean.list()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 3, 6, 9);
+
+        assertThat(isAmqpConnectorAlive(connector)).isTrue();
+        assertThat(isAmqpConnectorReady(connector)).isTrue();
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= 13);
+
+        for (int i = 0; i < msgCount; i++) {
+            DispositionRecord record = dispositionsReceived.get(i);
+
+            int messageNum = i + 1;
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            if (messageNum % 3 == 0) {
+                assertThat(record.getState()).isInstanceOf(Modified.class);
+                Modified state = (Modified) record.getState();
+
+                assertThat(state.getDeliveryFailed()).isTrue();
+                assertThat(state.getUndeliverableHere()).isFalse();
+            } else {
+                assertThat(record.getState()).isInstanceOf(Accepted.class);
+            }
+            assertThat(record.isSettled()).isTrue();
+        }
+
+        for (int i = 0; i < msgCount / 3; i++) {
+            DispositionRecord record = dispositionsReceived.get(msgCount + i);
+
+            int messageNum = 3 * (i + 1);
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testModifiedFailedUndeliverableHereStrategy() throws Exception {
+        int msgCount = 10;
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
+
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        writeModifiedFailedUndeliverableConfig(server.actualPort());
+
+        MyReceiverBeanRecovering bean = deployRecovering();
+
+        AmqpConnector connector = container.getBeanManager().createInstance().select(AmqpConnector.class,
+                ConnectorLiteral.of(AmqpConnector.CONNECTOR_NAME)).get();
+
+        await().atMost(6, TimeUnit.SECONDS).until(() -> bean.list().size() >= 10);
+        // All messages should have been received, with every 3rd modified-failed, which are then NOT re-delivered.
+        assertThat(bean.list()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        assertThat(isAmqpConnectorAlive(connector)).isTrue();
+        assertThat(isAmqpConnectorReady(connector)).isTrue();
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= 10);
+
+        for (int i = 0; i < msgCount; i++) {
+            DispositionRecord record = dispositionsReceived.get(i);
+
+            int messageNum = i + 1;
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            if (messageNum % 3 == 0) {
+                assertThat(record.getState()).isInstanceOf(Modified.class);
+                Modified state = (Modified) record.getState();
+
+                assertThat(state.getDeliveryFailed()).isTrue();
+                assertThat(state.getUndeliverableHere()).isTrue();
+            } else {
+                assertThat(record.getState()).isInstanceOf(Accepted.class);
+            }
+            assertThat(record.isSettled()).isTrue();
+        }
+    }
+
+    private MapBasedConfig createBaseConnectorConfig(int port) {
+        MapBasedConfig config = new MapBasedConfig();
+        config.put("mp.messaging.incoming.amqp.connector", AmqpConnector.CONNECTOR_NAME);
+        config.put("mp.messaging.incoming.amqp.host", "localhost");
+        config.put("mp.messaging.incoming.amqp.port", port);
+
+        return config;
+    }
+
+    private void writeDefaultFailConfig(int port) {
+        // fail is the default, so we dont specify a failure-strategy
+        createBaseConnectorConfig(port)
+                .put("mp.messaging.incoming.amqp.address", "default-fail")
                 .write();
     }
 
-    private void getAcceptConfig() {
-        new MapBasedConfig()
+    private void writeAcceptConfig(int port) {
+        createBaseConnectorConfig(port)
                 .put("mp.messaging.incoming.amqp.address", "accept")
-                .put("mp.messaging.incoming.amqp.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.amqp.host", host)
-                .put("mp.messaging.incoming.amqp.port", port)
-                .put("mp.messaging.incoming.amqp.durable", true)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
                 .put("mp.messaging.incoming.amqp.failure-strategy", "accept")
                 .write();
     }
 
-    private void getRejectConfig() {
-        new MapBasedConfig()
+    private void writeRejectConfig(int port) {
+        createBaseConnectorConfig(port)
                 .put("mp.messaging.incoming.amqp.address", "reject")
-                .put("mp.messaging.incoming.amqp.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.amqp.host", host)
-                .put("mp.messaging.incoming.amqp.port", port)
-                .put("mp.messaging.incoming.amqp.durable", true)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
                 .put("mp.messaging.incoming.amqp.failure-strategy", "reject")
                 .write();
     }
 
-    private void getReleaseConfig() {
-        new MapBasedConfig()
+    private void writeReleaseConfig(int port) {
+        createBaseConnectorConfig(port)
                 .put("mp.messaging.incoming.amqp.address", "release")
-                .put("mp.messaging.incoming.amqp.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.amqp.host", host)
-                .put("mp.messaging.incoming.amqp.port", port)
-                .put("mp.messaging.incoming.amqp.durable", true)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
                 .put("mp.messaging.incoming.amqp.failure-strategy", "release")
                 .write();
     }
 
-    private void getModifiedFailedConfig() {
-        new MapBasedConfig()
+    private void writeModifiedFailedConfig(int port) {
+        createBaseConnectorConfig(port)
                 .put("mp.messaging.incoming.amqp.address", "modified-failed")
-                .put("mp.messaging.incoming.amqp.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.amqp.host", host)
-                .put("mp.messaging.incoming.amqp.port", port)
-                .put("mp.messaging.incoming.amqp.durable", true)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
                 .put("mp.messaging.incoming.amqp.failure-strategy", "modified-failed")
                 .write();
     }
 
-    private void getModifiedFailedUndeliverableConfig() {
-        new MapBasedConfig()
+    private void writeModifiedFailedUndeliverableConfig(int port) {
+        createBaseConnectorConfig(port)
                 .put("mp.messaging.incoming.amqp.address", "modified-failed-undeliverable-here")
-                .put("mp.messaging.incoming.amqp.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.amqp.host", host)
-                .put("mp.messaging.incoming.amqp.port", port)
-                .put("mp.messaging.incoming.amqp.durable", true)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
                 .put("mp.messaging.incoming.amqp.failure-strategy", "modified-failed-undeliverable-here")
                 .write();
     }
 
     @ApplicationScoped
     public static class MyReceiverBean {
+        // Receiver that fails to process every 3rd message [payload] of the
+        // original messages, every time that the payload is seen.
         private final List<Integer> received = new CopyOnWriteArrayList<>();
 
         @Incoming("amqp")
@@ -273,11 +395,12 @@ public class AmqpFailureHandlerTest extends AmqpBrokerTestBase {
         public List<Integer> list() {
             return received;
         }
-
     }
 
     @ApplicationScoped
     public static class MyReceiverBeanRecovering {
+        // Receiver that fails to process every 3rd message [payload] of the
+        // original messages the first time it is seen, then succeeds if seen again.
         private final List<Integer> received = new CopyOnWriteArrayList<>();
         private final List<Integer> failed = new CopyOnWriteArrayList<>();
 
@@ -295,6 +418,62 @@ public class AmqpFailureHandlerTest extends AmqpBrokerTestBase {
         public List<Integer> list() {
             return received;
         }
+    }
 
+    @SuppressWarnings("incomplete-switch")
+    private MockServer setupMockServer(int msgCount, List<DispositionRecord> dispositions, Vertx vertx)
+            throws Exception {
+        AtomicInteger sent = new AtomicInteger(1);
+
+        return new MockServer(vertx, serverConnection -> {
+            serverConnection.openHandler(serverSender -> {
+                serverConnection.closeHandler(x -> serverConnection.close());
+                serverConnection.open();
+            });
+
+            serverConnection.sessionOpenHandler(serverSession -> {
+                serverSession.closeHandler(x -> serverSession.close());
+                serverSession.open();
+            });
+
+            serverConnection.senderOpenHandler(serverSender -> {
+                serverSender.sendQueueDrainHandler(x -> {
+                    while (sent.get() <= msgCount && !serverSender.sendQueueFull()) {
+                        final Message m = Proton.message();
+                        final int i = sent.getAndIncrement();
+                        m.setBody(new AmqpValue(i));
+
+                        serverSender.send(m, delivery -> {
+                            DeliveryState deliveryState = delivery.getRemoteState();
+                            dispositions.add(new DispositionRecord(i, deliveryState, delivery.remotelySettled()));
+
+                            if (deliveryState != null) {
+                                DeliveryStateType type = deliveryState.getType();
+                                switch (type) {
+                                    // This will only re-send a given message one time, that is sufficient for these tests.
+                                    case Released:
+                                        serverSender.send(m, delivery2 -> {
+                                            dispositions.add(new DispositionRecord(i, delivery2.getRemoteState(),
+                                                    delivery2.remotelySettled()));
+                                        });
+                                        break;
+                                    case Modified:
+                                        Modified ds = (Modified) deliveryState;
+                                        if (!Boolean.TRUE.equals(ds.getUndeliverableHere())) {
+                                            serverSender.send(m, delivery2 -> {
+                                                dispositions.add(new DispositionRecord(i, delivery2.getRemoteState(),
+                                                        delivery2.remotelySettled()));
+                                            });
+                                        }
+                                        break;
+                                }
+                            }
+                        });
+                    }
+                });
+
+                serverSender.open();
+            });
+        });
     }
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpLinkTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpLinkTest.java
@@ -3,28 +3,38 @@ package io.smallrye.reactive.messaging.amqp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
+import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonSender;
 
-public class AmqpLinkTest extends AmqpBrokerTestBase {
+public class AmqpLinkTest extends AmqpTestBase {
 
     private WeldContainer container;
+    private MockServer server;
 
     @AfterEach
     public void cleanup() {
@@ -32,62 +42,70 @@ public class AmqpLinkTest extends AmqpBrokerTestBase {
             container.shutdown();
         }
 
-        MapBasedConfig.cleanup();
-        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+        if (server != null) {
+            server.close();
+        }
     }
 
     @Test
-    public void test() {
+    public void testIncoming() throws Exception {
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>());
+
+        AtomicReference<ProtonConnection> connectionRef = new AtomicReference<>();
+        AtomicReference<ProtonSender> senderRef = new AtomicReference<>();
+        server = setupMockServer(connectionRef, senderRef, dispositionsReceived, executionHolder.vertx().getDelegate());
+
         Weld weld = new Weld();
 
-        weld.addBeanClass(MyProducer.class);
         weld.addBeanClass(MyConsumer.class);
 
+        String containerId = "myContainerId";
+        String subscriptionName = "mySubName";
+        String address = "people";
+
         new MapBasedConfig()
-                .put("mp.messaging.outgoing.people-out.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.outgoing.people-out.address", "people")
-                .put("mp.messaging.outgoing.people-out.link-name", "people")
-                .put("mp.messaging.outgoing.people-out.host", host)
-                .put("mp.messaging.outgoing.people-out.port", port)
-                .put("mp.messaging.outgoing.people-out.durable", false)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
-
                 .put("mp.messaging.incoming.people-in.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.people-in.address", "people")
-                .put("mp.messaging.incoming.people-in.link-name", "people")
-                .put("mp.messaging.incoming.people-in.host", host)
-                .put("mp.messaging.incoming.people-in.port", port)
+                .put("mp.messaging.incoming.people-in.container-id", containerId)
+                .put("mp.messaging.incoming.people-in.address", address)
+                .put("mp.messaging.incoming.people-in.link-name", subscriptionName)
+                .put("mp.messaging.incoming.people-in.host", "localhost")
+                .put("mp.messaging.incoming.people-in.port", server.actualPort())
                 .put("mp.messaging.incoming.people-in.durable", true)
-
                 .write();
 
         container = weld.initialize();
-        await().until(() -> isAmqpConnectorReady(container));
-        await().until(() -> isAmqpConnectorAlive(container));
-
-        MyProducer producer = container.getBeanManager().createInstance().select(MyProducer.class).get();
-        producer.run();
 
         MyConsumer consumer = container.getBeanManager().createInstance().select(MyConsumer.class).get();
-        await()
-                .atMost(1, TimeUnit.MINUTES)
-                .until(() -> consumer.list().size() == 3);
+
+        await().atMost(6, TimeUnit.SECONDS).until(() -> consumer.list().size() >= 3);
+
         assertThat(consumer.list()).containsExactly("Luke", "Leia", "Han");
-    }
 
-    @ApplicationScoped
-    public static class MyProducer {
+        await().atMost(3, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= 3);
 
-        @Inject
-        @Channel("people-out")
-        Emitter<String> emitter;
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            assertThat(record.getMessageNumber()).isEqualTo(count.get() + 1);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
 
-        public void run() {
-            emitter.send("Luke");
-            emitter.send("Leia");
-            emitter.send("Han");
-        }
+            count.incrementAndGet();
+        });
+        assertThat(count.get()).isEqualTo(3);
+
+        // Verify details of the connection and link created
+        ProtonConnection serverConnection = connectionRef.get();
+        assertThat(serverConnection).isNotNull();
+        assertThat(serverConnection.getRemoteContainer()).isEqualTo(containerId);
+
+        ProtonSender serverSender = senderRef.get();
+        assertThat(serverSender).isNotNull();
+        assertThat(serverSender.getName()).isEqualTo(subscriptionName);
+        Source source = (org.apache.qpid.proton.amqp.messaging.Source) serverSender.getRemoteSource();
+        assertThat(source).isNotNull();
+        assertThat(source.getAddress()).isEqualTo(address);
+        assertThat(source.getDurable()).isEqualTo(TerminusDurability.UNSETTLED_STATE);
+        assertThat(source.getExpiryPolicy()).isEqualTo(TerminusExpiryPolicy.NEVER);
     }
 
     @ApplicationScoped
@@ -103,6 +121,44 @@ public class AmqpLinkTest extends AmqpBrokerTestBase {
         public List<String> list() {
             return list;
         }
+    }
+
+    private MockServer setupMockServer(AtomicReference<ProtonConnection> connectionRef, AtomicReference<ProtonSender> senderRef,
+            List<DispositionRecord> dispositions, Vertx vertx) throws Exception {
+        return new MockServer(vertx, serverConnection -> {
+            connectionRef.compareAndSet(null, serverConnection);
+
+            serverConnection.openHandler(serverSender -> {
+                serverConnection.closeHandler(x -> serverConnection.close());
+                serverConnection.open();
+            });
+
+            serverConnection.sessionOpenHandler(serverSession -> {
+                serverSession.closeHandler(x -> serverSession.close());
+                serverSession.open();
+            });
+
+            serverConnection.senderOpenHandler(serverSender -> {
+                senderRef.compareAndSet(null, serverSender);
+                serverSender.open();
+
+                // Just immediately buffer some sends.
+                sendMessage(serverSender, "Luke", 1, dispositions);
+                sendMessage(serverSender, "Leia", 2, dispositions);
+                sendMessage(serverSender, "Han", 3, dispositions);
+            });
+        });
+    }
+
+    private void sendMessage(ProtonSender serverSender, String content, int messageNumber,
+            List<DispositionRecord> dispositions) {
+        final org.apache.qpid.proton.message.Message msg = Proton.message();
+        msg.setBody(new AmqpValue(content));
+
+        serverSender.send(msg, delivery -> {
+            DeliveryState deliveryState = delivery.getRemoteState();
+            dispositions.add(new DispositionRecord(messageNumber, deliveryState, delivery.remotelySettled()));
+        });
     }
 
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkCDIConfigTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkCDIConfigTest.java
@@ -1,0 +1,181 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.exceptions.DeploymentException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class AmqpSinkCDIConfigTest extends AmqpBrokerTestBase {
+
+    private WeldContainer container;
+    private AmqpConnector provider;
+
+    @AfterEach
+    public void cleanup() {
+        if (provider != null) {
+            provider.terminate(null);
+        }
+
+        if (container != null) {
+            container.shutdown();
+        }
+
+        MapBasedConfig.cleanup();
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+
+        System.clearProperty("mp-config");
+        System.clearProperty("client-options-name");
+        System.clearProperty("amqp-client-options-name");
+    }
+
+    @Test
+    public void testConfigByCDIMissingBean() {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ProducingBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.outgoing.sink.address", "sink")
+                .put("mp.messaging.outgoing.sink.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.outgoing.sink.host", host)
+                .put("mp.messaging.outgoing.sink.port", port)
+
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("mp.messaging.outgoing.sink.client-options-name", "myclientoptions")
+                .write();
+
+        assertThatThrownBy(() -> container = weld.initialize()).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testConfigByCDIIncorrectBean() {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ProducingBean.class);
+        weld.addBeanClass(ClientConfigurationBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.outgoing.sink.address", "sink")
+                .put("mp.messaging.outgoing.sink.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.outgoing.sink.host", host)
+                .put("mp.messaging.outgoing.sink.port", port)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("mp.messaging.outgoing.sink.client-options-name", "dummyoptionsnonexistent")
+                .write();
+
+        assertThatThrownBy(() -> container = weld.initialize()).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testConfigByCDICorrect() throws InterruptedException {
+        Weld weld = new Weld();
+
+        CountDownLatch latch = new CountDownLatch(10);
+        usage.consumeIntegers("sink",
+                v -> latch.countDown());
+
+        weld.addBeanClass(ProducingBean.class);
+        weld.addBeanClass(ClientConfigurationBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.outgoing.sink.address", "sink")
+                .put("mp.messaging.outgoing.sink.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.outgoing.sink.host", host)
+                .put("mp.messaging.outgoing.sink.port", port)
+                .put("mp.messaging.outgoing.sink.durable", false)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("mp.messaging.outgoing.sink.client-options-name", "myclientoptions")
+                .write();
+
+        container = weld.initialize();
+
+        assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+    }
+
+    @Test
+    @Disabled("Failing on CI - need to be investigated")
+    public void testConfigGlobalOptionsByCDIMissingBean() {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ProducingBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.outgoing.sink.address", "sink")
+                .put("mp.messaging.outgoing.sink.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.outgoing.sink.host", host)
+                .put("mp.messaging.outgoing.sink.port", port)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("amqp-client-options-name", "dummyoptionsnonexistent")
+                .write();
+
+        assertThatThrownBy(() -> {
+            container = weld.initialize();
+        }).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    @Disabled("Failing on CI - to be investigated")
+    public void testConfigGlobalOptionsByCDIIncorrectBean() {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ProducingBean.class);
+        weld.addBeanClass(ClientConfigurationBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.outgoing.sink.address", "sink")
+                .put("mp.messaging.outgoing.sink.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.outgoing.sink.host", host)
+                .put("mp.messaging.outgoing.sink.port", port)
+                .put("mp.messaging.outgoing.sink.durable", false)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("amqp-client-options-name", "dummyoptionsnonexistent")
+                .write();
+
+        assertThatThrownBy(() -> {
+            container = weld.initialize();
+        }).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testConfigGlobalOptionsByCDICorrect() throws InterruptedException {
+        Weld weld = new Weld();
+
+        CountDownLatch latch = new CountDownLatch(10);
+        usage.consumeIntegers("sink",
+                v -> latch.countDown());
+
+        weld.addBeanClass(ProducingBean.class);
+        weld.addBeanClass(ClientConfigurationBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.outgoing.sink.address", "sink")
+                .put("mp.messaging.outgoing.sink.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.outgoing.sink.host", host)
+                .put("mp.messaging.outgoing.sink.port", port)
+                .put("mp.messaging.outgoing.sink.durable", false)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("amqp-client-options-name", "myclientoptions")
+                .write();
+
+        container = weld.initialize();
+
+        assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+    }
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceCDIConfigTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceCDIConfigTest.java
@@ -1,0 +1,220 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.CHANNEL_NAME_ATTRIBUTE;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.exceptions.DeploymentException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.common.constraint.NotNull;
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class AmqpSourceCDIConfigTest extends AmqpBrokerTestBase {
+
+    private AmqpConnector provider;
+
+    private WeldContainer container;
+
+    @AfterEach
+    public void cleanup() {
+        if (provider != null) {
+            provider.terminate(null);
+        }
+
+        if (container != null) {
+            container.shutdown();
+        }
+
+        MapBasedConfig.cleanup();
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+
+        System.clearProperty("mp-config");
+        System.clearProperty("client-options-name");
+        System.clearProperty("amqp-client-options-name");
+    }
+
+    @Test
+    public void testConfigByCDIMissingBean() {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ConsumptionBean.class);
+        weld.addBeanClass(ExecutionHolder.class);
+
+        new MapBasedConfig()
+                .with("mp.messaging.incoming.data.address", "data")
+                .with("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.host", host)
+                .with("mp.messaging.incoming.data.port", port)
+                .with("amqp-username", username)
+                .with("amqp-password", password)
+                .with("mp.messaging.incoming.data.client-options-name", "myclientoptions")
+                .write();
+
+        assertThatThrownBy(() -> container = weld.initialize())
+                .isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testConfigByCDIIncorrectBean() {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ConsumptionBean.class);
+        weld.addBeanClass(ClientConfigurationBean.class);
+        weld.addBeanClass(ExecutionHolder.class);
+
+        new MapBasedConfig()
+                .with("mp.messaging.incoming.data.address", "data")
+                .with("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.host", host)
+                .with("mp.messaging.incoming.data.port", port)
+                .with("amqp-username", username)
+                .with("amqp-password", password)
+                .with("mp.messaging.incoming.data.client-options-name", "dummyoptionsnonexistent")
+                .write();
+
+        assertThatThrownBy(() -> container = weld.initialize())
+                .isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testConfigByCDICorrect() {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ClientConfigurationBean.class);
+        weld.addBeanClass(ConsumptionBean.class);
+
+        new MapBasedConfig()
+                .with("mp.messaging.incoming.data.address", "data")
+                .with("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.host", host)
+                .with("mp.messaging.incoming.data.port", port)
+                .with("amqp-username", username)
+                .with("amqp-password", password)
+                .with("mp.messaging.incoming.data.client-options-name", "myclientoptions")
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isAmqpConnectorAlive(container));
+        await().until(() -> isAmqpConnectorReady(container));
+        List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
+        assertThat(list).isEmpty();
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers("data", counter::getAndIncrement);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
+        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void testConfigGlobalOptionsByCDICorrect() {
+        Weld weld = new Weld();
+
+        String address = UUID.randomUUID().toString();
+        weld.addBeanClass(ClientConfigurationBean.class);
+        weld.addBeanClass(ConsumptionBean.class);
+
+        new MapBasedConfig()
+                .with("mp.messaging.incoming.data.address", address)
+                .with("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.host", host)
+                .with("mp.messaging.incoming.data.port", port)
+                .with("amqp-username", username)
+                .with("amqp-password", password)
+                .with("amqp-client-options-name", "myclientoptions")
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isAmqpConnectorAlive(container));
+        await().until(() -> isAmqpConnectorReady(container));
+        List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
+        assertThat(list).isEmpty();
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers(address, counter::getAndIncrement);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
+        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+    }
+
+    @Test
+    public void testConfigGlobalOptionsByCDIMissingBean() {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ConsumptionBean.class);
+        weld.addBeanClass(ExecutionHolder.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.data.address", "data")
+                .put("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data.host", host)
+                .put("mp.messaging.incoming.data.port", port)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("amqp-client-options-name", "myclientoptions")
+                .write();
+
+        assertThatThrownBy(() -> container = weld.initialize())
+                .isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testConfigGlobalOptionsByCDIIncorrectBean() {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ConsumptionBean.class);
+        weld.addBeanClass(ClientConfigurationBean.class);
+        weld.addBeanClass(ExecutionHolder.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.data.address", "data")
+                .put("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data.host", host)
+                .put("mp.messaging.incoming.data.port", port)
+                .put("amqp-username", username)
+                .put("amqp-password", password)
+                .put("amqp-client-options-name", "dummyoptionsnonexistent")
+                .write();
+
+        assertThatThrownBy(() -> container = weld.initialize())
+                .isInstanceOf(DeploymentException.class);
+    }
+
+    @NotNull
+    private Map<String, Object> getConfig(String topic) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("address", topic);
+        config.put(CHANNEL_NAME_ATTRIBUTE, UUID.randomUUID().toString());
+        config.put("host", host);
+        config.put("port", port);
+        config.put("name", "some name");
+        config.put("username", username);
+        config.put("password", password);
+        return config;
+    }
+
+    @NotNull
+    private Map<String, Object> getConfigUsingChannelName(String topic) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(CHANNEL_NAME_ATTRIBUTE, topic);
+        config.put("host", host);
+        config.put("port", port);
+        config.put("name", "some name");
+        config.put("username", username);
+        config.put("password", password);
+        return config;
+    }
+
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
@@ -4,43 +4,46 @@ import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.CHANNEL_NAME_ATTRIBUTE;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.AmqpSequence;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.Data;
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.jboss.logging.Logger;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
-import org.jboss.weld.exceptions.DeploymentException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import io.smallrye.common.constraint.NotNull;
-import io.smallrye.config.SmallRyeConfigProviderResolver;
-import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.mutiny.amqp.AmqpMessage;
-import io.vertx.mutiny.core.buffer.Buffer;
 
-public class AmqpSourceTest extends AmqpBrokerTestBase {
+public class AmqpSourceTest extends AmqpTestBase {
 
-    private AmqpConnector provider;
+    private final static Logger LOGGER = Logger.getLogger(AmqpSourceTest.class);
 
     private WeldContainer container;
+    private AmqpConnector provider;
+    private MockServer server;
 
     @AfterEach
     public void cleanup() {
@@ -52,20 +55,37 @@ public class AmqpSourceTest extends AmqpBrokerTestBase {
             container.shutdown();
         }
 
-        MapBasedConfig.cleanup();
-        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
-
-        System.clearProperty("mp-config");
-        System.clearProperty("client-options-name");
-        System.clearProperty("amqp-client-options-name");
+        if (server != null) {
+            server.close();
+        }
     }
 
     @Test
-    public void testSource() {
+    @Timeout(30)
+    public void testSource() throws Exception {
+        doSourceTestImpl(false);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSourceUsingChannelName() throws Exception {
+        doSourceTestImpl(true);
+    }
+
+    private void doSourceTestImpl(boolean useChannelName) throws Exception {
+        int msgCount = 10;
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
+
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate());
+
         String topic = UUID.randomUUID().toString();
-        Map<String, Object> config = getConfig(topic);
-        config.put("ttl", 10000);
-        config.put("durable", false);
+
+        Map<String, Object> config;
+        if (useChannelName) {
+            config = getConfigUsingChannelName(topic, server.actualPort());
+        } else {
+            config = getConfig(topic, server.actualPort());
+        }
 
         provider = new AmqpConnector();
         provider.setup(executionHolder);
@@ -73,55 +93,30 @@ public class AmqpSourceTest extends AmqpBrokerTestBase {
 
         List<Message<Integer>> messages = new ArrayList<>();
 
-        AtomicBoolean opened = new AtomicBoolean();
-        builder.buildRs().subscribe(createSubscriber(messages, opened));
-        await().until(opened::get);
+        builder.buildRs().subscribe(createSubscriber(messages, new AtomicBoolean()));
 
-        await().until(() -> isAmqpConnectorReady(provider));
-        await().until(() -> isAmqpConnectorAlive(provider));
-
-        AtomicInteger counter = new AtomicInteger();
-        new Thread(() -> usage.produceTenIntegers(topic,
-                counter::getAndIncrement)).start();
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> messages.size() >= 10);
         assertThat(messages.stream()
                 .peek(m -> m.ack().toCompletableFuture().join())
                 .map(Message::getPayload)
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-    }
+                        .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-    @Test
-    public void testSourceUsingChannelName() {
-        String topic = UUID.randomUUID().toString();
-        Map<String, Object> config = getConfigUsingChannelName(topic);
-        config.put("ttl", 10000);
-        config.put("durable", false);
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= msgCount);
 
-        provider = new AmqpConnector();
-        provider.setup(executionHolder);
-        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            int messageNum = count.get() + 1;
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
 
-        List<Message<Integer>> messages = new ArrayList<>();
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
 
-        AtomicBoolean opened = new AtomicBoolean();
-        builder.buildRs().subscribe(createSubscriber(messages, opened));
-        await().until(opened::get);
+            count.incrementAndGet();
+        });
 
-        await().until(() -> isAmqpConnectorReady(provider));
-        await().until(() -> isAmqpConnectorAlive(provider));
-
-        AtomicInteger counter = new AtomicInteger();
-        new Thread(() -> usage.produceTenIntegers(topic,
-                counter::getAndIncrement)).start();
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
-        assertThat(messages.stream()
-                .peek(m -> m.ack().toCompletableFuture().join())
-                .map(Message::getPayload)
-                .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertThat(count.get()).isEqualTo(msgCount);
     }
 
     @NotNull
@@ -156,78 +151,470 @@ public class AmqpSourceTest extends AmqpBrokerTestBase {
         };
     }
 
-    @RepeatedTest(10)
-    public void testBroadcast() {
-        String topic = UUID.randomUUID().toString();
+    @Test
+    @Timeout(30)
+    public void testBroadcast() throws Exception {
+        int msgCount = 10;
+        CountDownLatch sendStartLatch = new CountDownLatch(1);
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
+
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate(), sendStartLatch);
+
+        String topic = "broadcast-" + UUID.randomUUID().toString();
         Map<String, Object> config = new HashMap<>();
         config.put("address", topic);
         config.put(CHANNEL_NAME_ATTRIBUTE, topic);
-        config.put("host", host);
+        config.put("host", "localhost");
         config.put("name", "the name for broadcast");
-        config.put("port", port);
+        config.put("port", server.actualPort());
         config.put("broadcast", true);
-        config.put("username", username);
-        config.put("password", password);
 
         provider = new AmqpConnector();
         provider.setup(executionHolder);
         PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
         Publisher<? extends Message<?>> rs = builder.buildRs();
+
         List<Message<Integer>> messages1 = new ArrayList<>();
         List<Message<Integer>> messages2 = new ArrayList<>();
-
         AtomicBoolean o1 = new AtomicBoolean();
         AtomicBoolean o2 = new AtomicBoolean();
+
         rs.subscribe(createSubscriber(messages1, o1));
         rs.subscribe(createSubscriber(messages2, o2));
 
+        await().until(() -> o1.get() && o2.get());
+        sendStartLatch.countDown();
+
         await().until(() -> isAmqpConnectorReady(provider));
 
-        await()
-                .pollDelay(5, TimeUnit.SECONDS)
-                .until(() -> o1.get() && o2.get());
-
-        AtomicInteger counter = new AtomicInteger();
-        new Thread(() -> usage.produceTenIntegers(topic,
-                counter::getAndIncrement)).start();
-
-        await().atMost(1, TimeUnit.MINUTES).until(() -> messages1.size() >= 10);
-        await().atMost(1, TimeUnit.MINUTES).until(() -> messages2.size() >= 10);
-        assertThat(messages1.stream().map(Message::getPayload)
+        await().atMost(5, TimeUnit.SECONDS).until(() -> messages1.size() >= 10);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> messages2.size() >= 10);
+        assertThat(messages1.stream().peek(m -> m.ack().toCompletableFuture().join())
+                .map(Message::getPayload)
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-        assertThat(messages2.stream().map(Message::getPayload)
+                        .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertThat(messages2.stream().peek(m -> m.ack().toCompletableFuture().join())
+                .map(Message::getPayload)
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                        .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-        MapBasedConfig.cleanup();
-        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= msgCount);
+
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            int messageNum = count.get() + 1;
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+
+            count.incrementAndGet();
+        });
+
+        assertThat(count.get()).isEqualTo(msgCount);
     }
 
     @Test
-    public void testABeanConsumingTheAMQPMessages() {
+    @Timeout(30)
+    public void testABeanConsumingTheAMQPMessages() throws Exception {
+        int msgCount = 10;
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
+
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate());
+
         new MapBasedConfig()
                 .put("mp.messaging.incoming.data.address", "data")
                 .put("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.data.host", host)
-                .put("mp.messaging.incoming.data.port", port)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
+                .put("mp.messaging.incoming.data.host", "localhost")
+                .put("mp.messaging.incoming.data.port", server.actualPort())
                 .write();
 
         ConsumptionBean bean = deploy();
 
-        await().until(() -> isAmqpConnectorReady(container));
-        await().until(() -> isAmqpConnectorAlive(container));
-
         List<Integer> list = bean.getResults();
-        assertThat(list).isEmpty();
 
-        AtomicInteger counter = new AtomicInteger();
-        usage.produceTenIntegers("data", counter::getAndIncrement);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> list.size() >= 10);
+        // ConsumptionBean adds 1, thus shifting original values by 1
+        assertThat(list).containsExactly(2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
 
-        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
-        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= msgCount);
+
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            int messageNum = count.get() + 1;
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+
+            count.incrementAndGet();
+        });
+
+        assertThat(count.get()).isEqualTo(msgCount);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSourceWithDataContent() throws Exception {
+        doDataContentTestImpl(false);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSourceWithDataContentWithOctectStreamContentType() throws Exception {
+        doDataContentTestImpl(true);
+    }
+
+    private void doDataContentTestImpl(boolean setContentType) throws Exception {
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>());
+
+        final org.apache.qpid.proton.message.Message msg = Proton.message();
+        msg.setBody(new Data(new Binary("foo".getBytes(StandardCharsets.UTF_8))));
+        if (setContentType) {
+            msg.setContentType("application/octet-stream");
+        }
+
+        server = setupMockServerForTypeTest(msg, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        String topic = UUID.randomUUID().toString();
+        Map<String, Object> config = getConfig(topic, server.actualPort());
+        provider = new AmqpConnector();
+        provider.setup(executionHolder);
+
+        List<Message<byte[]>> messages = new ArrayList<>();
+        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
+
+        builder.to(createSubscriber(messages, new AtomicBoolean())).run();
+
+        await().atMost(6, TimeUnit.SECONDS).until(() -> !messages.isEmpty());
+
+        assertThat(messages.stream()
+                .peek(m -> m.ack().toCompletableFuture().join())
+                .map(Message::getPayload)
+                .collect(Collectors.toList()))
+                        .containsExactly("foo".getBytes(StandardCharsets.UTF_8));
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> !dispositionsReceived.isEmpty());
+
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            assertThat(record.getMessageNumber()).isEqualTo(1);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+
+            count.incrementAndGet();
+        });
+
+        assertThat(count.get()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSourceWithBinaryContent() throws Exception {
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>());
+
+        final org.apache.qpid.proton.message.Message msg = Proton.message();
+        msg.setBody(new AmqpValue(new Binary("foo".getBytes(StandardCharsets.UTF_8))));
+
+        server = setupMockServerForTypeTest(msg, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        String topic = UUID.randomUUID().toString();
+        Map<String, Object> config = getConfig(topic, server.actualPort());
+        provider = new AmqpConnector();
+        provider.setup(executionHolder);
+
+        List<Message<byte[]>> messages = new ArrayList<>();
+        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
+
+        builder.to(createSubscriber(messages, new AtomicBoolean())).run();
+
+        await().atMost(6, TimeUnit.SECONDS).until(() -> !messages.isEmpty());
+
+        assertThat(messages.stream()
+                .peek(m -> m.ack().toCompletableFuture().join())
+                .map(Message::getPayload)
+                .collect(Collectors.toList()))
+                        .containsExactly("foo".getBytes(StandardCharsets.UTF_8));
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> !dispositionsReceived.isEmpty());
+
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            assertThat(record.getMessageNumber()).isEqualTo(1);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+
+            count.incrementAndGet();
+        });
+
+        assertThat(count.get()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSourceWithJsonObjectDataContent() throws Exception {
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>());
+
+        JsonObject json = new JsonObject();
+        String id = UUID.randomUUID().toString();
+        json.put("key", id);
+        json.put("some", "content");
+
+        final org.apache.qpid.proton.message.Message msg = Proton.message();
+        msg.setBody(new Data(new Binary(json.toBuffer().getBytes())));
+        msg.setContentType("application/json");
+
+        server = setupMockServerForTypeTest(msg, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        String topic = UUID.randomUUID().toString();
+        Map<String, Object> config = getConfig(topic, server.actualPort());
+        provider = new AmqpConnector();
+        provider.setup(executionHolder);
+
+        List<Message<JsonObject>> messages = new ArrayList<>();
+        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
+
+        builder.to(createSubscriber(messages, new AtomicBoolean())).run();
+
+        await().atMost(6, TimeUnit.SECONDS).until(() -> !messages.isEmpty());
+
+        Message<JsonObject> receivedMessage = messages.get(0);
+        JsonObject result = receivedMessage.getPayload();
+        assertThat(result).containsOnly(entry("key", id), entry("some", "content"));
+        receivedMessage.ack().toCompletableFuture().join();
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> !dispositionsReceived.isEmpty());
+
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            assertThat(record.getMessageNumber()).isEqualTo(1);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+
+            count.incrementAndGet();
+        });
+
+        assertThat(count.get()).isEqualTo(1);
+        assertThat(messages.size()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSourceWithListJsonArrayDataContent() throws Exception {
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>());
+
+        JsonArray list = new JsonArray();
+        String id = UUID.randomUUID().toString();
+        list.add("ola");
+        list.add(id);
+
+        final org.apache.qpid.proton.message.Message msg = Proton.message();
+        msg.setBody(new Data(new Binary(list.toBuffer().getBytes())));
+        msg.setContentType("application/json");
+
+        server = setupMockServerForTypeTest(msg, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        String topic = UUID.randomUUID().toString();
+        Map<String, Object> config = getConfig(topic, server.actualPort());
+        provider = new AmqpConnector();
+        provider.setup(executionHolder);
+
+        List<Message<JsonArray>> messages = new ArrayList<>();
+        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
+
+        builder.to(createSubscriber(messages, new AtomicBoolean())).run();
+
+        await().atMost(6, TimeUnit.SECONDS).until(() -> !messages.isEmpty());
+
+        Message<JsonArray> receivedMessage = messages.get(0);
+        JsonArray result = receivedMessage.getPayload();
+        assertThat(result).containsExactly("ola", id);
+        receivedMessage.ack().toCompletableFuture().join();
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> !dispositionsReceived.isEmpty());
+
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            assertThat(record.getMessageNumber()).isEqualTo(1);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+
+            count.incrementAndGet();
+        });
+
+        assertThat(count.get()).isEqualTo(1);
+        assertThat(messages.size()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSourceWithListContent() throws Exception {
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>());
+
+        List<String> list = new ArrayList<>();
+        String id = UUID.randomUUID().toString();
+        list.add("ola");
+        list.add(id);
+
+        final org.apache.qpid.proton.message.Message msg = Proton.message();
+        msg.setBody(new AmqpValue(list));
+
+        server = setupMockServerForTypeTest(msg, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        String topic = UUID.randomUUID().toString();
+        Map<String, Object> config = getConfig(topic, server.actualPort());
+        provider = new AmqpConnector();
+        provider.setup(executionHolder);
+
+        List<Message<List<String>>> messages = new ArrayList<>();
+        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
+
+        builder.to(createSubscriber(messages, new AtomicBoolean())).run();
+
+        await().atMost(6, TimeUnit.SECONDS).until(() -> !messages.isEmpty());
+
+        Message<List<String>> receivedMessage = messages.get(0);
+        List<String> result = receivedMessage.getPayload();
+        assertThat(result).containsExactly("ola", id);
+        receivedMessage.ack().toCompletableFuture().join();
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> !dispositionsReceived.isEmpty());
+
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            assertThat(record.getMessageNumber()).isEqualTo(1);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+
+            count.incrementAndGet();
+        });
+
+        assertThat(count.get()).isEqualTo(1);
+        assertThat(messages.size()).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSourceWithAmqpSequenceContent() throws Exception {
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>());
+
+        List<String> list = new ArrayList<>();
+        String id = UUID.randomUUID().toString();
+        list.add("ola");
+        list.add(id);
+
+        final org.apache.qpid.proton.message.Message msg = Proton.message();
+        msg.setBody(new AmqpSequence(list));
+
+        server = setupMockServerForTypeTest(msg, dispositionsReceived, executionHolder.vertx().getDelegate());
+
+        String topic = UUID.randomUUID().toString();
+        Map<String, Object> config = getConfig(topic, server.actualPort());
+        provider = new AmqpConnector();
+        provider.setup(executionHolder);
+
+        List<Message<List<String>>> messages = new ArrayList<>();
+        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
+
+        builder.to(createSubscriber(messages, new AtomicBoolean())).run();
+
+        await().atMost(6, TimeUnit.SECONDS).until(() -> !messages.isEmpty());
+
+        Message<List<String>> receivedMessage = messages.get(0);
+        List<String> result = receivedMessage.getPayload();
+        assertThat(result).containsExactly("ola", id);
+        receivedMessage.ack().toCompletableFuture().join();
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> !dispositionsReceived.isEmpty());
+
+        AtomicInteger count = new AtomicInteger();
+        dispositionsReceived.forEach(record -> {
+            assertThat(record.getMessageNumber()).isEqualTo(1);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+
+            count.incrementAndGet();
+        });
+
+        assertThat(count.get()).isEqualTo(1);
+        assertThat(messages.size()).isEqualTo(1);
+    }
+
+    private MockServer setupMockServer(int msgCount, List<DispositionRecord> dispositions, Vertx vertx) throws Exception {
+        return setupMockServer(msgCount, dispositions, vertx, new CountDownLatch(0));
+    }
+
+    private MockServer setupMockServer(int msgCount, List<DispositionRecord> dispositions, Vertx vertx,
+            final CountDownLatch startSendLatch) throws Exception {
+        AtomicInteger sent = new AtomicInteger(1);
+
+        return new MockServer(vertx, serverConnection -> {
+            serverConnection.openHandler(serverSender -> {
+                serverConnection.closeHandler(x -> serverConnection.close());
+                serverConnection.open();
+            });
+
+            serverConnection.sessionOpenHandler(serverSession -> {
+                serverSession.closeHandler(x -> serverSession.close());
+                serverSession.open();
+            });
+
+            serverConnection.senderOpenHandler(serverSender -> {
+                serverSender.sendQueueDrainHandler(x -> {
+
+                    // Naughty, but should be fine for the test, normally taking 0.0X seconds total.
+                    try {
+                        if (!startSendLatch.await(6, TimeUnit.SECONDS)) {
+                            LOGGER.error("Test server did not get signal to start sending in alotted time");
+                            return;
+                        }
+                    } catch (InterruptedException ie) {
+                        LOGGER.warn("Test server interrupted awaiting signal to start sending");
+                        return;
+                    }
+
+                    while (sent.get() <= msgCount && !serverSender.sendQueueFull()) {
+                        final org.apache.qpid.proton.message.Message m = Proton.message();
+                        final int i = sent.getAndIncrement();
+                        m.setBody(new AmqpValue(i));
+
+                        serverSender.send(m, delivery -> {
+                            DeliveryState deliveryState = delivery.getRemoteState();
+                            dispositions.add(new DispositionRecord(i, deliveryState, delivery.remotelySettled()));
+                        });
+                    }
+                });
+
+                serverSender.open();
+            });
+        });
+    }
+
+    private MockServer setupMockServerForTypeTest(org.apache.qpid.proton.message.Message msg,
+            List<DispositionRecord> dispositions, Vertx vertx) throws Exception {
+        return new MockServer(vertx, serverConnection -> {
+            serverConnection.openHandler(serverSender -> {
+                serverConnection.closeHandler(x -> serverConnection.close());
+                serverConnection.open();
+            });
+
+            serverConnection.sessionOpenHandler(serverSession -> {
+                serverSession.closeHandler(x -> serverSession.close());
+                serverSession.open();
+            });
+
+            serverConnection.senderOpenHandler(serverSender -> {
+                serverSender.open();
+
+                // Just immediately buffer a single send.
+                serverSender.send(msg, delivery -> {
+                    DeliveryState deliveryState = delivery.getRemoteState();
+                    dispositions.add(new DispositionRecord(1, deliveryState, delivery.remotelySettled()));
+                });
+            });
+        });
     }
 
     private ConsumptionBean deploy() {
@@ -238,315 +625,24 @@ public class AmqpSourceTest extends AmqpBrokerTestBase {
         return container.getBeanManager().createInstance().select(ConsumptionBean.class).get();
     }
 
-    @Test
-    public void testSourceWithBinaryContent() {
-        String topic = UUID.randomUUID().toString();
-        Map<String, Object> config = getConfig(topic);
-        provider = new AmqpConnector();
-        provider.setup(executionHolder);
-
-        List<Message<byte[]>> messages = new ArrayList<>();
-        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
-        AtomicBoolean opened = new AtomicBoolean();
-
-        builder.to(createSubscriber(messages, opened)).run();
-        await().until(opened::get);
-
-        await().until(() -> isAmqpConnectorReady(provider));
-        await().until(() -> isAmqpConnectorAlive(provider));
-
-        usage.produce(topic, 1, () -> AmqpMessage.create().withBufferAsBody(Buffer.buffer("foo".getBytes())).build());
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> !messages.isEmpty());
-        assertThat(messages.stream().map(Message::getPayload)
-                .collect(Collectors.toList()))
-                        .containsExactly("foo".getBytes());
-    }
-
-    @Test
-    public void testSourceWithJsonObjectContent() {
-        String topic = UUID.randomUUID().toString();
-        Map<String, Object> config = getConfig(topic);
-        provider = new AmqpConnector();
-        provider.setup(executionHolder);
-
-        List<Message<JsonObject>> messages = new ArrayList<>();
-        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
-        AtomicBoolean opened = new AtomicBoolean();
-
-        builder.to(createSubscriber(messages, opened)).run();
-        await().until(opened::get);
-
-        await().until(() -> isAmqpConnectorReady(provider));
-        await().until(() -> isAmqpConnectorAlive(provider));
-
-        JsonObject json = new JsonObject();
-        String id = UUID.randomUUID().toString();
-        json.put("key", id);
-        json.put("some", "content");
-        usage.produce(topic, 1, () -> AmqpMessage.create().withJsonObjectAsBody(json).build());
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> !messages.isEmpty());
-        JsonObject result = messages.get(0).getPayload();
-        assertThat(result)
-                .containsOnly(entry("key", id), entry("some", "content"));
-    }
-
-    @Test
-    public void testSourceWithListContent() {
-        String topic = UUID.randomUUID().toString();
-        Map<String, Object> config = getConfig(topic);
-        provider = new AmqpConnector();
-        provider.setup(executionHolder);
-
-        List<Message<JsonArray>> messages = new ArrayList<>();
-        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
-        AtomicBoolean opened = new AtomicBoolean();
-
-        builder.to(createSubscriber(messages, opened)).run();
-        await().until(opened::get);
-
-        await().until(() -> isAmqpConnectorReady(provider));
-        await().until(() -> isAmqpConnectorAlive(provider));
-
-        JsonArray list = new JsonArray();
-        String id = UUID.randomUUID().toString();
-        list.add("ola");
-        list.add(id);
-        usage.produce(topic, 1, () -> AmqpMessage.create().withJsonArrayAsBody(list).build());
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> !messages.isEmpty());
-        JsonArray result = messages.get(0).getPayload();
-        assertThat(result)
-                .containsExactly("ola", id);
-    }
-
-    @Test
-    public void testSourceWithSeqContent() {
-        String topic = UUID.randomUUID().toString();
-        Map<String, Object> config = getConfig(topic);
-        List<Message<List<String>>> messages = new ArrayList<>();
-        provider = new AmqpConnector();
-        provider.setup(executionHolder);
-
-        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
-        AtomicBoolean opened = new AtomicBoolean();
-
-        builder.to(createSubscriber(messages, opened)).run();
-        await().until(opened::get);
-
-        await().until(() -> isAmqpConnectorReady(provider));
-        await().until(() -> isAmqpConnectorAlive(provider));
-
-        List<String> list = new ArrayList<>();
-        list.add("tag");
-        list.add("bonjour");
-        usage.produce(topic, 1, () -> new AmqpSequence(list));
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> !messages.isEmpty());
-        List<String> result = messages.get(0).getPayload();
-        assertThat(result)
-                .containsOnly("tag", "bonjour");
-    }
-
-    @Test
-    public void testSourceWithDataContent() {
-        String topic = UUID.randomUUID().toString();
-        Map<String, Object> config = getConfig(topic);
-        List<Message<byte[]>> messages = new ArrayList<>();
-        provider = new AmqpConnector();
-        provider.setup(executionHolder);
-
-        PublisherBuilder<? extends Message<?>> builder = provider.getPublisherBuilder(new MapBasedConfig(config));
-        AtomicBoolean opened = new AtomicBoolean();
-
-        builder.to(createSubscriber(messages, opened)).run();
-        await().until(opened::get);
-
-        await().until(() -> isAmqpConnectorReady(provider));
-        await().until(() -> isAmqpConnectorAlive(provider));
-
-        List<String> list = new ArrayList<>();
-        list.add("hello");
-        list.add("world");
-        usage.produce(topic, 1, () -> new Data(new Binary(list.toString().getBytes())));
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> !messages.isEmpty());
-        byte[] result = messages.get(0).getPayload();
-        assertThat(new String(result))
-                .isEqualTo(list.toString());
-    }
-
-    @Test
-    public void testConfigByCDIMissingBean() {
-        Weld weld = new Weld();
-
-        weld.addBeanClass(ConsumptionBean.class);
-        weld.addBeanClass(ExecutionHolder.class);
-
-        new MapBasedConfig()
-                .with("mp.messaging.incoming.data.address", "data")
-                .with("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
-                .with("mp.messaging.incoming.data.host", host)
-                .with("mp.messaging.incoming.data.port", port)
-                .with("amqp-username", username)
-                .with("amqp-password", password)
-                .with("mp.messaging.incoming.data.client-options-name", "myclientoptions")
-                .write();
-
-        assertThatThrownBy(() -> container = weld.initialize())
-                .isInstanceOf(DeploymentException.class);
-    }
-
-    @Test
-    public void testConfigByCDIIncorrectBean() {
-        Weld weld = new Weld();
-
-        weld.addBeanClass(ConsumptionBean.class);
-        weld.addBeanClass(ClientConfigurationBean.class);
-        weld.addBeanClass(ExecutionHolder.class);
-
-        new MapBasedConfig()
-                .with("mp.messaging.incoming.data.address", "data")
-                .with("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
-                .with("mp.messaging.incoming.data.host", host)
-                .with("mp.messaging.incoming.data.port", port)
-                .with("amqp-username", username)
-                .with("amqp-password", password)
-                .with("mp.messaging.incoming.data.client-options-name", "dummyoptionsnonexistent")
-                .write();
-
-        assertThatThrownBy(() -> container = weld.initialize())
-                .isInstanceOf(DeploymentException.class);
-    }
-
-    @Test
-    public void testConfigByCDICorrect() {
-        Weld weld = new Weld();
-
-        weld.addBeanClass(ClientConfigurationBean.class);
-        weld.addBeanClass(ConsumptionBean.class);
-
-        new MapBasedConfig()
-                .with("mp.messaging.incoming.data.address", "data")
-                .with("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
-                .with("mp.messaging.incoming.data.host", host)
-                .with("mp.messaging.incoming.data.port", port)
-                .with("amqp-username", username)
-                .with("amqp-password", password)
-                .with("mp.messaging.incoming.data.client-options-name", "myclientoptions")
-                .write();
-
-        container = weld.initialize();
-        await().until(() -> isAmqpConnectorAlive(container));
-        await().until(() -> isAmqpConnectorReady(container));
-        List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
-        assertThat(list).isEmpty();
-
-        AtomicInteger counter = new AtomicInteger();
-        usage.produceTenIntegers("data", counter::getAndIncrement);
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
-        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    }
-
-    @Test
-    public void testConfigGlobalOptionsByCDICorrect() {
-        Weld weld = new Weld();
-
-        String address = UUID.randomUUID().toString();
-        weld.addBeanClass(ClientConfigurationBean.class);
-        weld.addBeanClass(ConsumptionBean.class);
-
-        new MapBasedConfig()
-                .with("mp.messaging.incoming.data.address", address)
-                .with("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
-                .with("mp.messaging.incoming.data.host", host)
-                .with("mp.messaging.incoming.data.port", port)
-                .with("amqp-username", username)
-                .with("amqp-password", password)
-                .with("amqp-client-options-name", "myclientoptions")
-                .write();
-
-        container = weld.initialize();
-        await().until(() -> isAmqpConnectorAlive(container));
-        await().until(() -> isAmqpConnectorReady(container));
-        List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
-        assertThat(list).isEmpty();
-
-        AtomicInteger counter = new AtomicInteger();
-        usage.produceTenIntegers(address, counter::getAndIncrement);
-
-        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
-        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-
-    }
-
-    @Test
-    public void testConfigGlobalOptionsByCDIMissingBean() {
-        Weld weld = new Weld();
-
-        weld.addBeanClass(ConsumptionBean.class);
-        weld.addBeanClass(ExecutionHolder.class);
-
-        new MapBasedConfig()
-                .put("mp.messaging.incoming.data.address", "data")
-                .put("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.data.host", host)
-                .put("mp.messaging.incoming.data.port", port)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
-                .put("amqp-client-options-name", "myclientoptions")
-                .write();
-
-        assertThatThrownBy(() -> container = weld.initialize())
-                .isInstanceOf(DeploymentException.class);
-    }
-
-    @Test
-    public void testConfigGlobalOptionsByCDIIncorrectBean() {
-        Weld weld = new Weld();
-
-        weld.addBeanClass(ConsumptionBean.class);
-        weld.addBeanClass(ClientConfigurationBean.class);
-        weld.addBeanClass(ExecutionHolder.class);
-
-        new MapBasedConfig()
-                .put("mp.messaging.incoming.data.address", "data")
-                .put("mp.messaging.incoming.data.connector", AmqpConnector.CONNECTOR_NAME)
-                .put("mp.messaging.incoming.data.host", host)
-                .put("mp.messaging.incoming.data.port", port)
-                .put("amqp-username", username)
-                .put("amqp-password", password)
-                .put("amqp-client-options-name", "dummyoptionsnonexistent")
-                .write();
-
-        assertThatThrownBy(() -> container = weld.initialize())
-                .isInstanceOf(DeploymentException.class);
-    }
-
     @NotNull
-    private Map<String, Object> getConfig(String topic) {
+    private Map<String, Object> getConfig(String topic, int port) {
         Map<String, Object> config = new HashMap<>();
         config.put("address", topic);
         config.put(CHANNEL_NAME_ATTRIBUTE, UUID.randomUUID().toString());
-        config.put("host", host);
+        config.put("host", "localhost");
         config.put("port", port);
         config.put("name", "some name");
-        config.put("username", username);
-        config.put("password", password);
         return config;
     }
 
     @NotNull
-    private Map<String, Object> getConfigUsingChannelName(String topic) {
+    private Map<String, Object> getConfigUsingChannelName(String topic, int port) {
         Map<String, Object> config = new HashMap<>();
         config.put(CHANNEL_NAME_ATTRIBUTE, topic);
-        config.put("host", host);
+        config.put("host", "localhost");
         config.put("port", port);
         config.put("name", "some name");
-        config.put("username", username);
-        config.put("password", password);
         return config;
     }
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpTestBase.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpTestBase.java
@@ -1,8 +1,16 @@
 package io.smallrye.reactive.messaging.amqp;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
@@ -11,10 +19,25 @@ import io.vertx.mutiny.core.Vertx;
 
 public class AmqpTestBase {
 
+    private final Logger logger = Logger.getLogger(getClass());
+
     ExecutionHolder executionHolder;
 
+    @BeforeAll
+    public static void setupClass(TestInfo testInfo) {
+        Awaitility.setDefaultPollDelay(Duration.ZERO);
+        Awaitility.setDefaultPollInterval(5, TimeUnit.MILLISECONDS);
+    }
+
+    @AfterAll
+    public static void tearDownClass(TestInfo testInfo) {
+        Awaitility.reset();
+    }
+
     @BeforeEach
-    public void setup() {
+    public void setup(TestInfo testInfo) {
+        logger.infof("========== start %s.%s ==========", getClass().getSimpleName(), testInfo.getDisplayName());
+
         executionHolder = new ExecutionHolder(Vertx.vertx());
 
         SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
@@ -22,9 +45,19 @@ public class AmqpTestBase {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown(TestInfo testInfo) {
+        logger.infof("========== tearDown %s.%s ==========", getClass().getSimpleName(), testInfo.getDisplayName());
+
         executionHolder.terminate(null);
         SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
         MapBasedConfig.cleanup();
+    }
+
+    public boolean isAmqpConnectorReady(AmqpConnector connector) {
+        return connector.getReadiness().isOk();
+    }
+
+    public boolean isAmqpConnectorAlive(AmqpConnector connector) {
+        return connector.getLiveness().isOk();
     }
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpWithConverterTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpWithConverterTest.java
@@ -1,58 +1,96 @@
 package io.smallrye.reactive.messaging.amqp;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.se.SeContainer;
 import javax.enterprise.inject.se.SeContainerInitializer;
 
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.jboss.weld.environment.se.Weld;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import io.smallrye.reactive.messaging.MessageConverter;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.core.Vertx;
 
-public class AmqpWithConverterTest extends AmqpBrokerTestBase {
+public class AmqpWithConverterTest extends AmqpTestBase {
 
     private SeContainer container;
+    private MockServer server;
 
     @AfterEach
     public void cleanup() {
-        container.close();
+        if (container != null) {
+            container.close();
+        }
+
+        if (server != null) {
+            server.close();
+        }
     }
 
     @Test
-    public void testAckWithConverter() {
+    @Timeout(30)
+    public void testAckWithConverter() throws Exception {
         String address = UUID.randomUUID().toString();
+        int msgCount = 10;
+        List<DispositionRecord> dispositionsReceived = Collections.synchronizedList(new ArrayList<>(msgCount));
+
+        server = setupMockServer(msgCount, dispositionsReceived, executionHolder.vertx().getDelegate());
+
         SeContainerInitializer weld = Weld.newInstance();
         new MapBasedConfig()
                 .with("mp.messaging.incoming.in.connector", AmqpConnector.CONNECTOR_NAME)
-                .with("mp.messaging.incoming.in.host", host)
-                .with("mp.messaging.incoming.in.port", port)
-                .with("mp.messaging.incoming.in.username", username)
-                .with("mp.messaging.incoming.in.password", password)
+                .with("mp.messaging.incoming.in.host", "localhost")
+                .with("mp.messaging.incoming.in.port", server.actualPort())
                 .with("mp.messaging.incoming.in.address", address)
                 .write();
         weld.addBeanClasses(DummyConverter.class, MyApp.class);
         container = weld.initialize();
 
-        await().until(() -> isAmqpConnectorAlive(container));
-        await().until(() -> isAmqpConnectorReady(container));
-
-        AtomicInteger counter = new AtomicInteger();
-        usage.produceTenIntegers(address, counter::incrementAndGet);
-
         MyApp app = container.getBeanManager().createInstance().select(MyApp.class).get();
-        await().until(() -> app.list().size() == 10);
+        List<DummyData> appList = app.list();
+        await().atMost(5, TimeUnit.SECONDS).until(() -> appList.size() >= msgCount);
+
+        AtomicInteger count = new AtomicInteger();
+        appList.forEach(dummy -> {
+            assertThat(dummy).isInstanceOf(DummyData.class);
+            count.incrementAndGet();
+        });
+        assertThat(count.get()).isEqualTo(msgCount);
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= msgCount);
+
+        count.set(0);
+        dispositionsReceived.forEach(record -> {
+            int messageNum = count.get() + 1;
+            assertThat(messageNum).isLessThanOrEqualTo(msgCount);
+
+            assertThat(record.getMessageNumber()).isEqualTo(messageNum);
+            assertThat(record.getState()).isInstanceOf(Accepted.class);
+            assertThat(record.isSettled()).isTrue();
+
+            count.incrementAndGet();
+        });
+
+        assertThat(count.get()).isEqualTo(msgCount);
     }
 
     @ApplicationScoped
@@ -85,5 +123,38 @@ public class AmqpWithConverterTest extends AmqpBrokerTestBase {
 
     public static class DummyData {
 
+    }
+
+    private MockServer setupMockServer(int msgCount, List<DispositionRecord> dispositions, Vertx vertx) throws Exception {
+        AtomicInteger sent = new AtomicInteger(1);
+
+        return new MockServer(vertx, serverConnection -> {
+            serverConnection.openHandler(serverSender -> {
+                serverConnection.closeHandler(x -> serverConnection.close());
+                serverConnection.open();
+            });
+
+            serverConnection.sessionOpenHandler(serverSession -> {
+                serverSession.closeHandler(x -> serverSession.close());
+                serverSession.open();
+            });
+
+            serverConnection.senderOpenHandler(serverSender -> {
+                serverSender.sendQueueDrainHandler(x -> {
+                    while (sent.get() <= msgCount && !serverSender.sendQueueFull()) {
+                        final org.apache.qpid.proton.message.Message m = Proton.message();
+                        final int i = sent.getAndIncrement();
+                        m.setBody(new AmqpValue(i));
+
+                        serverSender.send(m, delivery -> {
+                            DeliveryState deliveryState = delivery.getRemoteState();
+                            dispositions.add(new DispositionRecord(i, deliveryState, delivery.remotelySettled()));
+                        });
+                    }
+                });
+
+                serverSender.open();
+            });
+        });
     }
 }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/DispositionRecord.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/DispositionRecord.java
@@ -1,0 +1,27 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import org.apache.qpid.proton.amqp.transport.DeliveryState;
+
+class DispositionRecord {
+    private int messageNumber;
+    private DeliveryState state;
+    private boolean settled;
+
+    DispositionRecord(int messageNumber, DeliveryState state, boolean settled) {
+        this.messageNumber = messageNumber;
+        this.state = state;
+        this.settled = settled;
+    }
+
+    public int getMessageNumber() {
+        return messageNumber;
+    }
+
+    public DeliveryState getState() {
+        return state;
+    }
+
+    public boolean isSettled() {
+        return settled;
+    }
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/IncomingAmqpMetadataTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/IncomingAmqpMetadataTest.java
@@ -1,0 +1,88 @@
+package io.smallrye.reactive.messaging.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.amqp.messaging.DeliveryAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Footer;
+import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.junit.jupiter.api.Test;
+
+public class IncomingAmqpMetadataTest extends AmqpTestBase {
+
+    @Test
+    public void testIncomingAmqpMetadata() {
+        String topic = UUID.randomUUID().toString();
+
+        // Create an underlying proton message, as might be received
+        org.apache.qpid.proton.message.Message protonMessage = Proton.message();
+        protonMessage.setAddress(topic);
+        protonMessage.setSubject("subject");
+        protonMessage.setMessageId("my-id");
+        protonMessage.setReplyTo("reply-to");
+        protonMessage.setReplyToGroupId("reply-to-group");
+        protonMessage.setPriority((short) 6);
+        protonMessage.setTtl(2000);
+        protonMessage.setGroupId("group");
+        protonMessage.setContentType("text/plain");
+        protonMessage.setCorrelationId("correlation-id");
+        protonMessage.setUserId("user".getBytes(StandardCharsets.UTF_8));
+
+        Map<Symbol, Object> daMap = new HashMap<>();
+        daMap.put(Symbol.valueOf("some-delivery-annotation"), "da-value");
+        DeliveryAnnotations da = new DeliveryAnnotations(daMap);
+        protonMessage.setDeliveryAnnotations(da);
+
+        Map<Symbol, Object> maMap = new HashMap<>();
+        maMap.put(Symbol.valueOf("some-msg-annotation"), "ma-value");
+        MessageAnnotations ma = new MessageAnnotations(maMap);
+        protonMessage.setMessageAnnotations(ma);
+
+        Map<String, Object> appPropsMap = new HashMap<>();
+        appPropsMap.put("key", "value");
+        ApplicationProperties appProps = new ApplicationProperties(appPropsMap);
+        protonMessage.setApplicationProperties(appProps);
+
+        Map<String, Object> footerMap = new HashMap<>();
+        footerMap.put("my-trailer", "hello-footer");
+        Footer footer = new Footer(footerMap);
+        protonMessage.setFooter(footer);
+
+        // Now test the metadata object accesses the metadata values as expected
+
+        io.vertx.amqp.AmqpMessage vertxAmqpMessage = io.vertx.amqp.AmqpMessage.create(protonMessage).build();
+        IncomingAmqpMetadata metadata = new IncomingAmqpMetadata(vertxAmqpMessage);
+
+        assertThat(metadata.getAddress()).isEqualTo(topic);
+        assertThat(metadata.getSubject()).isEqualTo("subject");
+        assertThat(metadata.getId()).isEqualTo("my-id");
+        assertThat(metadata.getReplyTo()).isEqualTo("reply-to");
+        assertThat(metadata.getReplyToGroupId()).isEqualTo("reply-to-group");
+        assertThat(metadata.getPriority()).isEqualTo((short) 6);
+        assertThat(metadata.getTtl()).isEqualTo(2000);
+        assertThat(metadata.getGroupId()).isEqualTo("group");
+        assertThat(metadata.getContentType()).isEqualTo("text/plain");
+        assertThat(metadata.getCorrelationId()).isEqualTo("correlation-id");
+        assertThat(metadata.getUserId()).isEqualTo("user");
+        assertThat(metadata.isFirstAcquirer()).isFalse();
+
+        assertThat(metadata.getDeliveryAnnotations().getValue())
+                .containsExactly(entry(Symbol.valueOf("some-delivery-annotation"), "da-value"));
+
+        assertThat(metadata.getMessageAnnotations().getValue())
+                .containsExactly(entry(Symbol.valueOf("some-msg-annotation"), "ma-value"));
+
+        assertThat(metadata.getProperties()).containsExactly(entry("key", "value"));
+
+        //noinspection unchecked
+        assertThat(metadata.getFooter().getValue()).containsExactly(entry("my-trailer", "hello-footer"));
+    }
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBeanUsingOutboundMetadata.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBeanUsingOutboundMetadata.java
@@ -18,8 +18,8 @@ public class ProducingBeanUsingOutboundMetadata {
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(Message<Integer> input) {
         OutgoingAmqpMetadata metadata = OutgoingAmqpMetadata.builder()
-                .withSubject("subject")
-                .withAddress("sink")
+                .withSubject("metadata-subject")
+                .withAddress("metadata-address")
                 .build();
 
         return Message.of(input.getPayload() + 1, input::ack).addMetadata(metadata);


### PR DESCRIPTION
Update various tests to use a test server rather than full broker, more closely validates the client behaviour of interest directly rather than through loose observation from the other side of an intermediary. Follows on from #800. Also adds a better test for #806. Knocks about 60sec off the time of the tests updated (plus maybe another ~20sec off a local build by default due to the test-containers profile addition; not precisely sure since it doesnt work in my local env, another reason to put it in a profile).