### PR TITLE
Add merge attribute to outbound connectors

### DIFF
--- a/api/src/main/java/io/smallrye/reactive/messaging/ChannelRegistry.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/ChannelRegistry.java
@@ -19,7 +19,12 @@ public interface ChannelRegistry {
             boolean broadcast);
 
     SubscriberBuilder<? extends Message<?>, Void> register(String name,
-            SubscriberBuilder<? extends Message<?>, Void> subscriber);
+            SubscriberBuilder<? extends Message<?>, Void> subscriber, boolean merge);
+
+    default SubscriberBuilder<? extends Message<?>, Void> register(String name,
+            SubscriberBuilder<? extends Message<?>, Void> subscriber) {
+        return register(name, subscriber, false);
+    }
 
     void register(String name, Emitter<?> emitter);
 
@@ -40,4 +45,7 @@ public interface ChannelRegistry {
     Set<String> getEmitterNames();
 
     Map<String, Boolean> getIncomingChannels();
+
+    Map<String, Boolean> getOutgoingChannels();
+
 }

--- a/documentation/src/main/doc/modules/ROOT/pages/advanced/broadcast.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/advanced/broadcast.adoc
@@ -27,6 +27,8 @@ This allows waiting for the complete graph to be weaved:
 include::example$broadcast/BroadcastWithCountExamples.java[tag=chain]
 ----
 
+NOTE: Inbound connectors also support a `broadcast` attribute that allows broadcasting the messages to multiple downstream subscribers.
+
 == Use with Emitter
 
 For details on how to use `@Broadcast` with `Emitter` see the xref:emitter/emitter.adoc#emitter-broadcast[documentation].

--- a/documentation/src/main/doc/modules/ROOT/pages/advanced/merge.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/advanced/merge.adoc
@@ -26,3 +26,4 @@ The `mode` attribute allows configuring this behavior:
 * `MERGE` (default) gets all the messages as they come, without any defined order. Messages from different producers may be interleaved.
 * `CONCAT` concatenates the producers. The messages from one producer are received until the messages from other producers are received.
 
+NOTE: Outbound connectors also support a `merge` attribute that allows consuming the messages to multiple upstreams. It will dispatch all the received messages.

--- a/documentation/src/main/doc/modules/ROOT/pages/testing/testing.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/testing/testing.adoc
@@ -44,5 +44,6 @@ While these system properties are already set, you can retrieve them and pass th
 include::example$testing/MyTestSetup.java[tags=code]
 ----
 
-NOTE: The in-memory connector support the `broadcast` attribute.
-So if your connector is configured with `broadcast: true`, the connector broadcasts the messages to all the channel consumers.
+NOTE: The in-memory connector support the `broadcast` and `merge` attributes.
+So, if your connector is configured with `broadcast: true`, the connector broadcasts the messages to all the channel consumers.
+If your connector is configured with `merge:true`, the connector receives all the messages sent to the mapped channel even when coming from multiple producers.

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-amqp-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-amqp-outgoing.adoc
@@ -41,6 +41,10 @@ Type: _string_ | false | `localhost`
 
 Type: _string_ | false | 
 
+| *merge* | Whether the connector should allow multiple upstreams
+
+Type: _boolean_ | false | `false`
+
 | *password*
 
 _(amqp-password)_ | The password used to authenticate to the broker

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-camel-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-camel-outgoing.adoc
@@ -7,4 +7,8 @@
 
 Type: _string_ | true | 
 
+| *merge* | Whether the connector should allow multiple upstreams
+
+Type: _boolean_ | false | `false`
+
 |===

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-http-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-http-outgoing.adoc
@@ -7,6 +7,10 @@
 
 Type: _string_ | false | 
 
+| *merge* | Whether the connector should allow multiple upstreams
+
+Type: _boolean_ | false | `false`
+
 | *method* |  The HTTP method (either `POST` or `PUT`)
 
 Type: _string_ | false | `POST`

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-jms-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-jms-outgoing.adoc
@@ -39,6 +39,10 @@ Type: _boolean_ | false |
 
 Type: _boolean_ | false | 
 
+| *merge* | Whether the connector should allow multiple upstreams
+
+Type: _boolean_ | false | `false`
+
 | *password* | The password to connect to to the JMS server
 
 Type: _String_ | false | 

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
@@ -89,6 +89,10 @@ Type: _string_ | false | `org.apache.kafka.common.serialization.StringSerializer
 
 Type: _long_ | false | `1024`
 
+| *merge* | Whether the connector should allow multiple upstreams
+
+Type: _boolean_ | false | `false`
+
 | *partition* | The target partition id. -1 to let the client determine the partition
 
 Type: _int_ | false | `-1`

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-mqtt-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-mqtt-outgoing.adoc
@@ -39,6 +39,10 @@ Type: _int_ | false | `10`
 
 Type: _int_ | false | `8092`
 
+| *merge* | Whether the connector should allow multiple upstreams
+
+Type: _boolean_ | false | `false`
+
 | *password* | Set the password to connect to the server
 
 Type: _string_ | false | 

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-vertx-eventbus-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-vertx-eventbus-outgoing.adoc
@@ -15,6 +15,10 @@ Type: _string_ | false |
 
 Type: _boolean_ | false | `false`
 
+| *merge* | Whether the connector should allow multiple upstreams
+
+Type: _boolean_ | false | `false`
+
 | *publish* | Whether the to _publish_ the message to multiple Event Bus consumers. You cannot use `publish` in combination with `expect-reply`.
 
 Type: _boolean_ | false | `false`

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -69,6 +69,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "ttl", direction = OUTGOING, description = "The time-to-live of the send AMQP messages. 0 to disable the TTL", type = "long", defaultValue = "0")
 @ConnectorAttribute(name = "credit-retrieval-period", direction = OUTGOING, description = "The period (in milliseconds) between two attempts to retrieve the credits granted by the broker. This time is used when the sender run out of credits.", type = "int", defaultValue = "2000")
 @ConnectorAttribute(name = "use-anonymous-sender", direction = OUTGOING, description = "Whether or not the connector should use an anonymous sender.", type = "boolean", defaultValue = "true")
+@ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 
 public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnectorFactory, HealthReporter {
 

--- a/smallrye-reactive-messaging-aws-sns/src/main/java/io/smallrye/reactive/messaging/aws/sns/SnsConnector.java
+++ b/smallrye-reactive-messaging-aws-sns/src/main/java/io/smallrye/reactive/messaging/aws/sns/SnsConnector.java
@@ -1,7 +1,6 @@
 package io.smallrye.reactive.messaging.aws.sns;
 
-import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.INCOMING;
-import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.INCOMING_AND_OUTGOING;
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.*;
 import static io.smallrye.reactive.messaging.aws.sns.i18n.SnsLogging.log;
 
 import java.util.Objects;
@@ -49,6 +48,7 @@ import software.amazon.awssdk.services.sns.model.PublishRequest;
 @ConnectorAttribute(name = "broadcast", description = "Whether the SNS messages are dispatched to multiple subscribers (`@Incoming`)", type = "boolean", defaultValue = "false", direction = INCOMING)
 @ConnectorAttribute(name = "mock-sns-topics", description = "Indicates to the connector to use mock/fake topics. _For testing only_", type = "boolean", defaultValue = "false", direction = INCOMING_AND_OUTGOING, alias = "sns-mock-topics")
 @ConnectorAttribute(name = "app-url", description = "Configures AWS App public URL. This URL should be accessible by AWS SNS (subscription url). It can be a public URL or an URL accessible by SNS within the same VPC.", type = "string", direction = INCOMING, alias = "sns-app-url")
+@ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 
 public class SnsConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
 

--- a/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/CamelConnector.java
+++ b/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/CamelConnector.java
@@ -1,5 +1,6 @@
 package io.smallrye.reactive.messaging.camel;
 
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.OUTGOING;
 import static io.smallrye.reactive.messaging.camel.i18n.CamelExceptions.ex;
 import static io.smallrye.reactive.messaging.camel.i18n.CamelLogging.log;
 
@@ -32,6 +33,7 @@ import io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction;
 @Connector(CamelConnector.CONNECTOR_NAME)
 @ConnectorAttribute(name = "endpoint-uri", description = "The URI of the Camel endpoint (read from or written to)", mandatory = true, type = "string", direction = Direction.INCOMING_AND_OUTGOING)
 @ConnectorAttribute(name = "failure-strategy", type = "string", direction = Direction.INCOMING, description = "Specify the failure strategy to apply when a message produced from a Camel exchange is nacked. Values can be `fail` (default) or `ignore`", defaultValue = "fail")
+@ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 public class CamelConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
 
     private static final String REACTIVE_STREAMS_SCHEME = "reactive-streams:";

--- a/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/HttpConnector.java
+++ b/smallrye-reactive-messaging-http/src/main/java/io/smallrye/reactive/messaging/http/HttpConnector.java
@@ -25,6 +25,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "url", type = "string", direction = OUTGOING, description = "The targeted URL", mandatory = true)
 @ConnectorAttribute(name = "method", type = "string", direction = OUTGOING, description = " The HTTP method (either `POST` or `PUT`)", defaultValue = "POST")
 @ConnectorAttribute(name = "converter", type = "string", direction = OUTGOING, description = "The converter classname used to serialized the outgoing message in the HTTP body")
+@ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 
 @ConnectorAttribute(name = "host", type = "string", direction = INCOMING, description = "the host (interface) on which the server is opened", defaultValue = "0.0.0.0")
 @ConnectorAttribute(name = "port", type = "int", direction = INCOMING, description = "the port", defaultValue = "8080")

--- a/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/InMemoryConnectorWithMergeTest.java
+++ b/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/connectors/InMemoryConnectorWithMergeTest.java
@@ -1,0 +1,68 @@
+package io.smallrye.reactive.messaging.connectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class InMemoryConnectorWithMergeTest extends WeldTestBase {
+
+    @Before
+    public void install() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("mp.messaging.outgoing.bar.connector", InMemoryConnector.CONNECTOR);
+        conf.put("mp.messaging.outgoing.bar.merge", "true");
+
+        installConfig(new MapBasedConfig(conf));
+    }
+
+    @After
+    public void cleanup() {
+        releaseConfig();
+    }
+
+    @Test
+    public void testWithStrings() {
+        addBeanClass(FirstProducer.class);
+        addBeanClass(SecondProducer.class);
+        initialize();
+        InMemoryConnector bean = container.getBeanManager().createInstance()
+                .select(InMemoryConnector.class, ConnectorLiteral.of(InMemoryConnector.CONNECTOR)).get();
+        assertThat(bean).isNotNull();
+        InMemorySink<String> bar = bean.sink("bar");
+        assertThat(bar.received()).hasSize(6).extracting(Message::getPayload).contains("a", "b", "c", "d", "e", "f");
+    }
+
+    @ApplicationScoped
+    public static class FirstProducer {
+
+        @Outgoing("bar")
+        public Multi<String> produce() {
+            return Multi.createFrom().items("a", "b", "c");
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class SecondProducer {
+
+        @Outgoing("bar")
+        public Multi<String> produce() {
+            return Multi.createFrom().items("d", "e", "f");
+        }
+
+    }
+
+}

--- a/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
+++ b/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
@@ -1,5 +1,6 @@
 package io.smallrye.reactive.messaging.jms;
 
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.OUTGOING;
 import static io.smallrye.reactive.messaging.jms.i18n.JmsExceptions.ex;
 
 import java.util.Iterator;
@@ -57,6 +58,7 @@ import io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction;
 @ConnectorAttribute(name = "priority", description = "The JMS Message priority", direction = Direction.OUTGOING, type = "int")
 @ConnectorAttribute(name = "reply-to", description = "The reply to destination if any", direction = Direction.OUTGOING, type = "string")
 @ConnectorAttribute(name = "reply-to-destination-type", description = "The type of destination for the response. It can be either `queue` or `topic`", direction = Direction.OUTGOING, type = "string", defaultValue = "queue")
+@ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 public class JmsConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
 
     /**

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -1,5 +1,6 @@
 package io.smallrye.reactive.messaging.kafka;
 
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.OUTGOING;
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
 import java.util.ArrayList;
@@ -95,6 +96,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "cloud-events-insert-timestamp", type = "boolean", direction = Direction.OUTGOING, description = "Whether or not the connector should insert automatically the `time` attribute` into the outgoing Cloud Event. Requires `cloud-events` to be set to `true`. This value is used if the message does not configure the `time` attribute itself", alias = "cloud-events-default-timestamp", defaultValue = "true")
 @ConnectorAttribute(name = "cloud-events-mode", type = "string", direction = Direction.OUTGOING, description = "The Cloud Event mode (`structured` or `binary` (default)). Indicates how are written the cloud events in the outgoing record", defaultValue = "binary")
 @ConnectorAttribute(name = "close-timeout", type = "int", direction = Direction.OUTGOING, description = "The amount of milliseconds waiting for a graceful shutdown of the Kafka producer", defaultValue = "10000")
+@ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnectorFactory, HealthReporter {
 
     public static final String CONNECTOR_NAME = "smallrye-kafka";

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
@@ -1,7 +1,6 @@
 package io.smallrye.reactive.messaging.mqtt;
 
-import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.INCOMING;
-import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.INCOMING_AND_OUTGOING;
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.*;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -50,6 +49,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "qos", type = "int", defaultValue = "0", direction = INCOMING_AND_OUTGOING, description = "Set the QoS level when subscribing to the topic or when sending a message")
 @ConnectorAttribute(name = "broadcast", description = "Whether or not the messages should be dispatched to multiple consumers", type = "boolean", direction = INCOMING, defaultValue = "false")
 @ConnectorAttribute(name = "failure-strategy", type = "string", direction = INCOMING, description = "Specify the failure strategy to apply when a message produced from a MQTT message is nacked. Values can be `fail` (default), or `ignore`", defaultValue = "fail")
+@ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 public class MqttConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
 
     static final String CONNECTOR_NAME = "smallrye-mqtt";

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConfiguredChannelFactory.java
@@ -161,7 +161,8 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
                 String channel = entry.getKey();
                 ConnectorConfig config = entry.getValue();
                 if (config.getOptionalValue(ConnectorConfig.CHANNEL_ENABLED_PROPERTY, Boolean.TYPE).orElse(true)) {
-                    registry.register(channel, createSubscriberBuilder(channel, config));
+                    registry.register(channel, createSubscriberBuilder(channel, config),
+                            config.getOptionalValue(ConnectorConfig.MERGE_PROPERTY, Boolean.class).orElse(false));
                 } else {
                     log.outgoingChannelDisabled(channel);
                 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConnectorConfig.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConnectorConfig.java
@@ -25,6 +25,11 @@ public class ConnectorConfig implements Config {
      */
     public static final String BROADCAST_PROPERTY = "broadcast";
 
+    /**
+     * Name of the attribute configuring the merge on a connector.
+     */
+    public static final String MERGE_PROPERTY = "merge";
+
     private final String prefix;
     private final Config overall;
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/InternalChannelRegistry.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/InternalChannelRegistry.java
@@ -19,6 +19,7 @@ public class InternalChannelRegistry implements ChannelRegistry {
 
     private final Map<String, List<PublisherBuilder<? extends Message<?>>>> publishers = new HashMap<>();
     private final Map<String, Boolean> outgoing = new HashMap<>();
+    private final Map<String, Boolean> incoming = new HashMap<>();
     private final Map<String, List<SubscriberBuilder<? extends Message<?>, Void>>> subscribers = new HashMap<>();
     private final Map<String, Emitter<?>> emitters = new HashMap<>();
     private final Map<String, MutinyEmitter<?>> mutinyEmitters = new HashMap<>();
@@ -35,10 +36,11 @@ public class InternalChannelRegistry implements ChannelRegistry {
 
     @Override
     public synchronized SubscriberBuilder<? extends Message<?>, Void> register(String name,
-            SubscriberBuilder<? extends Message<?>, Void> subscriber) {
+            SubscriberBuilder<? extends Message<?>, Void> subscriber, boolean merge) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         Objects.requireNonNull(subscriber, msg.subscriberMustBeSet());
         register(subscribers, name, subscriber);
+        incoming.put(name, merge);
         return subscriber;
     }
 
@@ -106,6 +108,11 @@ public class InternalChannelRegistry implements ChannelRegistry {
     @Override
     public Map<String, Boolean> getIncomingChannels() {
         return outgoing;
+    }
+
+    @Override
+    public Map<String, Boolean> getOutgoingChannels() {
+        return incoming;
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyUpstreamCandidatesException.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/TooManyUpstreamCandidatesException.java
@@ -23,7 +23,11 @@ public class TooManyUpstreamCandidatesException extends WiringException {
                     "'%s' supports a single upstream producer for channel '%s', but found %d: %s. You may want to add the '@Merge' annotation on the method.",
                     component, incoming, upstreams.size(), upstreams);
         } else {
-            if (component instanceof Wiring.ProcessorMediatorComponent
+            if (component instanceof Wiring.OutgoingConnectorComponent) {
+                // outgoing connectors have a single incoming channel
+                return "'mp.messaging.outgoing." + component.incomings().get(0)
+                        + ".merge=true' + to allow multiple upstreams.";
+            } else if (component instanceof Wiring.ProcessorMediatorComponent
                     || component instanceof Wiring.SubscriberMediatorComponent) {
                 return String.format(
                         "'%s' supports a single upstream producer, but found %d: %s. You may want to add the '@Merge' annotation on the method.",

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/Wiring.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/wiring/Wiring.java
@@ -77,10 +77,9 @@ public class Wiring {
             components.add(new InboundConnectorComponent(entry.getKey(), entry.getValue()));
         }
 
-        for (String outgoingName : registry.getOutgoingNames()) {
-            components.add(new OutgoingConnectorComponent(outgoingName));
+        for (Map.Entry<String, Boolean> entry : registry.getOutgoingChannels().entrySet()) {
+            components.add(new OutgoingConnectorComponent(entry.getKey(), entry.getValue()));
         }
-
     }
 
     public Graph resolve() {
@@ -311,9 +310,11 @@ public class Wiring {
 
         private final String name;
         private final Set<Component> upstreams = new LinkedHashSet<>();
+        private final boolean merge;
 
-        public OutgoingConnectorComponent(String name) {
+        public OutgoingConnectorComponent(String name, boolean merge) {
             this.name = name;
+            this.merge = merge;
         }
 
         @Override
@@ -323,7 +324,7 @@ public class Wiring {
 
         @Override
         public boolean merge() {
-            return false; // TODO is that true?
+            return merge;
         }
 
         @Override
@@ -360,7 +361,7 @@ public class Wiring {
 
         @Override
         public void validate() throws WiringException {
-            if (upstreams().size() > 1) {
+            if (upstreams().size() > 1 && !merge) {
                 throw new TooManyUpstreamCandidatesException(this);
             }
         }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
@@ -149,7 +149,6 @@ public class SubscriberShapeTest extends WeldTestBaseWithoutTails {
         collector.close();
     }
 
-    @SuppressWarnings("unchecked")
     private void assertThatSubscriberWasPublished(SeContainer container) {
         assertThat(registry(container).getOutgoingNames()).contains("subscriber");
         List<SubscriberBuilder<? extends Message<?>, Void>> subscriber = registry(container).getSubscribers("subscriber");

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/WiringTest.java
@@ -221,7 +221,7 @@ class WiringTest {
     public void testConnectorProcessorConnectorChain() {
         ChannelRegistry registry = mock(ChannelRegistry.class);
         when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", false));
-        when(registry.getOutgoingNames()).thenReturn(Collections.singleton("b"));
+        when(registry.getOutgoingChannels()).thenReturn(Collections.singletonMap("b", false));
         Bean bean = mock(Bean.class);
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
@@ -249,7 +249,7 @@ class WiringTest {
     public void testConnectorNoProcessorConnectorChain() {
         ChannelRegistry registry = mock(ChannelRegistry.class);
         when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", false));
-        when(registry.getOutgoingNames()).thenReturn(Collections.singleton("b"));
+        when(registry.getOutgoingChannels()).thenReturn(Collections.singletonMap("b", false));
         Bean bean = mock(Bean.class);
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
@@ -273,7 +273,31 @@ class WiringTest {
     public void testConnectorToConnectorChain() {
         ChannelRegistry registry = mock(ChannelRegistry.class);
         when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", false));
-        when(registry.getOutgoingNames()).thenReturn(Collections.singleton("a"));
+        when(registry.getOutgoingChannels()).thenReturn(Collections.singletonMap("a", false));
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(WiringTest.class);
+
+        Wiring wiring = new Wiring();
+        wiring.prepare(false, registry, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        Graph graph = wiring.resolve();
+        assertThat(graph.getResolvedComponents()).hasSize(2);
+        assertThat(graph.getUnresolvedComponents()).hasSize(0);
+        assertThat(graph.isClosed()).isTrue();
+        assertThat(graph.hasWiringErrors()).isFalse();
+
+        assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
+        assertThat(graph.getOutbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.incomings()).containsExactly("a"));
+    }
+
+    /**
+     * Two connectors (inbound, outbound) connected directly.
+     * connector -> connector.
+     */
+    @Test
+    public void testConnectorToConnectorChainWithOutgoingConnectorAbleToMerge() {
+        ChannelRegistry registry = mock(ChannelRegistry.class);
+        when(registry.getIncomingChannels()).thenReturn(Collections.singletonMap("a", false));
+        when(registry.getOutgoingChannels()).thenReturn(Collections.singletonMap("a", true));
         Bean bean = mock(Bean.class);
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 

--- a/smallrye-reactive-messaging-vertx-eventbus/src/main/java/io/smallrye/reactive/messaging/eventbus/VertxEventBusConnector.java
+++ b/smallrye-reactive-messaging-vertx-eventbus/src/main/java/io/smallrye/reactive/messaging/eventbus/VertxEventBusConnector.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.eventbus;
 
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.OUTGOING;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -26,6 +28,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "publish", type = "boolean", direction = Direction.OUTGOING, description = "Whether the to _publish_ the message to multiple Event Bus consumers. You cannot use `publish` in combination with `expect-reply`.", defaultValue = "false")
 @ConnectorAttribute(name = "codec", type = "string", direction = Direction.OUTGOING, description = "The name of the codec used to encode the outgoing message. The codec must have been registered.")
 @ConnectorAttribute(name = "timeout", type = "long", direction = Direction.OUTGOING, description = "The reply timeout (in ms), -1 to not set a timeout", defaultValue = "-1")
+@ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 public class VertxEventBusConnector implements OutgoingConnectorFactory, IncomingConnectorFactory {
 
     static final String CONNECTOR_NAME = "smallrye-vertx-eventbus";


### PR DESCRIPTION
Fix #920


﻿Add the support for `merge` for outbound connector:

* add a `merge` attribute to all outbound connector
* handle the wiring and error handling (with the hint to indicate that the attribute is missing)
