### PR TITLE
Clean the 'enabled' property to avoid some warning

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
@@ -13,6 +13,7 @@ public class ConfigurationCleaner {
             "connector",
             "channel-name",
             "topic",
+            "enabled",
 
             "health-enabled",
             "health-readiness-enabled",


### PR DESCRIPTION
This avoid logs like

```
2021-01-26 10:04:50,065 WARN  [org.apa.kaf.cli.pro.ProducerConfig] (Quarkus Main Thread) The configuration 'enabled' was supplied but isn't a known config.
```

When using the `enabled` configuration property of a channel.