### PR TITLE
Improve ConnectorConfig

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelper.java
@@ -19,7 +19,7 @@ public class JsonHelper {
             // As kafka properties use `.`, transform "_" into "."
             String key = originalKey.toLowerCase().replace("_", ".");
             try {
-                Optional<Integer> i = config.getOptionalValue(originalKey, Integer.class);
+                Optional<Integer> i = config.getOptionalValue(key, Integer.class);
                 if (i.isPresent() && i.get() instanceof Integer) {
                     json.put(key, i.get());
                     continue;
@@ -29,7 +29,7 @@ public class JsonHelper {
             }
 
             try {
-                Optional<Double> d = config.getOptionalValue(originalKey, Double.class);
+                Optional<Double> d = config.getOptionalValue(key, Double.class);
                 if (d.isPresent() && d.get() instanceof Double) {
                     json.put(key, d.get());
                     continue;
@@ -39,22 +39,25 @@ public class JsonHelper {
             }
 
             try {
-                String value = config.getOptionalValue(originalKey, String.class).orElse("").trim();
-                if (value.equalsIgnoreCase("false")) {
-                    json.put(key, false);
-                } else if (value.equalsIgnoreCase("true")) {
-                    json.put(key, true);
-                } else {
-                    json.put(key, value);
+                Optional<String> s = config.getOptionalValue(key, String.class);
+                if (s.isPresent()) {
+                    String value = s.get().trim();
+                    if (value.equalsIgnoreCase("false")) {
+                        json.put(key, false);
+                    } else if (value.equalsIgnoreCase("true")) {
+                        json.put(key, true);
+                    } else {
+                        json.put(key, value);
+                    }
+                    continue;
                 }
-                continue;
             } catch (ClassCastException e) {
                 // Ignore me
             }
 
             // We need to do boolean last, as it would return `false` for any non parsable object.
             try {
-                Optional<Boolean> d = config.getOptionalValue(originalKey, Boolean.class);
+                Optional<Boolean> d = config.getOptionalValue(key, Boolean.class);
                 d.ifPresent(v -> json.put(key, v));
             } catch (ClassCastException | IllegalArgumentException e) {
                 // Ignore the entry

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelperTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelperTest.java
@@ -2,8 +2,19 @@ package io.smallrye.reactive.messaging.kafka.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Test;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.reactive.messaging.impl.ConnectorConfig;
 import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
 import io.vertx.core.json.JsonObject;
 
@@ -29,12 +40,136 @@ class JsonHelperTest {
         assertThat(object.getDouble("double")).isEqualTo(23.4);
         assertThat(object.getBoolean("trueasstring")).isTrue();
         assertThat(object.getBoolean("falseasstring")).isFalse();
-        assertThat(object.getString("foo.bar")).isEqualTo("value");
+        assertThat(object.getString("foo.bar")).isNull();
+        assertThat(object.getString("FOO_BAR")).isNull();
         assertThat(object.getString("bootstrap.servers")).isEqualTo("not-important");
 
         assertThat(object.getBoolean("boolean.t")).isTrue();
         assertThat(object.getBoolean("boolean.f")).isFalse();
 
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS", value = "testServers")
+    public void testConnectorConfigFromEnv() {
+        JsonObject object = JsonHelper.asJsonObject(createTestConfig());
+        assertThat(object.getString("bootstrap.servers")).isEqualTo("testServers");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_TESTCHANNEL_BOOTSTRAP_SERVERS", value = "testServers")
+    public void testChannelConfigFromEnv() {
+        JsonObject object = JsonHelper.asJsonObject(createTestConfig());
+        assertThat(object.getString("bootstrap.servers")).isEqualTo("testServers");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_TESTCHANNEL_FOO_BAR", value = "a")
+    public void testSysPropsOverrides() {
+        Map<String, String> properties = Collections.singletonMap("mp.messaging.incoming.testChannel.foo.bar", "b");
+        ConfigSource highOrdinalSource = getConfigSourceFromMap(properties, 400);
+
+        JsonObject object = JsonHelper.asJsonObject(createTestConfig(highOrdinalSource));
+        assertThat(object.getString("foo.bar")).isEqualTo("b");
+        assertThat(object.getValue("FOO_BAR")).isNull();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_TESTCHANNEL_FOO_BAR", value = "a")
+    public void testSysPropsCaseSensitive() {
+        Map<String, String> properties = Collections.singletonMap("mp.messaging.incoming.testChannel.FOO_BAR", "b");
+        ConfigSource highOrdinalSource = getConfigSourceFromMap(properties, 400);
+
+        JsonObject object = JsonHelper.asJsonObject(createTestConfig(highOrdinalSource));
+        assertThat(object.getString("foo.bar")).isEqualTo("a");
+        assertThat(object.getValue("FOO_BAR")).isNull();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_TESTCHANNEL_FOO_BAR", value = "a")
+    public void testEnvOverrides() {
+        Map<String, String> extraProperties = new HashMap<>();
+        extraProperties.put("mp.messaging.incoming.testChannel.foo.bar", "b");
+        extraProperties.put("mp.messaging.incoming.testChannel.baz.qux", "c");
+        ConfigSource lowOrdinalSource = getConfigSourceFromMap(extraProperties, 100); // Ordinal 100, lower than environment variables
+
+        JsonObject object = JsonHelper.asJsonObject(createTestConfig(lowOrdinalSource));
+        assertThat(object.getString("foo.bar")).isEqualTo("a");
+        assertThat(object.getString("baz.qux")).isEqualTo("c");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_FOO_BAR", value = "a")
+    public void testConnectorSysPropsOverrides() {
+        Map<String, String> properties = Collections.singletonMap("mp.messaging.connector.smallrye-kafka.foo.bar", "b");
+        ConfigSource highOrdinalSource = getConfigSourceFromMap(properties, 400);
+
+        JsonObject object = JsonHelper.asJsonObject(createTestConfig(highOrdinalSource));
+        assertThat(object.getString("foo.bar")).isEqualTo("b");
+        assertThat(object.getValue("FOO_BAR")).isNull();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_TESTCHANNEL_FOO_BAR", value = "a")
+    public void testChannelOverridesConnector() {
+        Map<String, String> properties = Collections.singletonMap("mp.messaging.connector.smallrye-kafka.foo.bar", "b");
+        ConfigSource highOrdinalSource = getConfigSourceFromMap(properties, 400);
+
+        JsonObject object = JsonHelper.asJsonObject(createTestConfig(highOrdinalSource));
+        assertThat(object.getString("foo.bar")).isEqualTo("a");
+        assertThat(object.getValue("FOO_BAR")).isNull();
+
+        // Sys props are higher ordinal than env vars, but we always prefer channel-scoped config to connector-scoped config
+    }
+
+    private ConnectorConfig createTestConfig(ConfigSource... extraSources) {
+        Map<String, String> channelConnector = Collections.singletonMap("mp.messaging.incoming.testChannel.connector",
+                "smallrye-kafka");
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDefaultSources()
+                .withSources(getConfigSourceFromMap(channelConnector, 0))
+                .withSources(extraSources)
+                .build();
+        return new TestConnectorConfig(config);
+    }
+
+    private ConfigSource getConfigSourceFromMap(Map<String, String> configMap, int ordinal) {
+        return new ConfigSource() {
+
+            @Override
+            public String getValue(String propertyName) {
+                return configMap.get(propertyName);
+            }
+
+            @Override
+            public Set<String> getPropertyNames() {
+                return configMap.keySet();
+            }
+
+            @Override
+            public Map<String, String> getProperties() {
+                return configMap;
+            }
+
+            @Override
+            public int getOrdinal() {
+                return ordinal;
+            }
+
+            @Override
+            public String getName() {
+                return "TestConfigSource" + ordinal;
+            }
+        };
+    }
+
+    /**
+     * Test class to allow calling protected constructor
+     */
+    private static class TestConnectorConfig extends ConnectorConfig {
+        public TestConnectorConfig(Config overall) {
+            super("mp.messaging.incoming.", overall, "testChannel");
+        }
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderExceptions.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderExceptions.java
@@ -10,6 +10,7 @@ import javax.enterprise.inject.spi.DefinitionException;
 import javax.enterprise.inject.spi.DeploymentException;
 import javax.enterprise.inject.spi.InjectionPoint;
 
+import org.eclipse.microprofile.config.spi.Converter;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Cause;
@@ -258,4 +259,12 @@ public interface ProviderExceptions {
     @Message(id = 76, value = "Invalid Emitter injection found for  `%s`. The Emitter expected to be parameterized with the emitted type, such as Emitter<String>.")
     DefinitionException invalidRawEmitter(InjectionPoint ip);
 
+    @Message(id = 77, value = "No converter for type `%s`")
+    NoSuchElementException noConverterForType(Class<?> propertyType);
+
+    @Message(id = 78, value = "Converter `%s` returned null for value `%s`")
+    NoSuchElementException converterReturnedNull(Converter<?> converter, String value);
+
+    @Message(id = 79, value = "The config is not of type `%s`")
+    IllegalArgumentException configNotOfType(Class<?> type);
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/impl/ConnectorConfigTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/impl/ConnectorConfigTest.java
@@ -1,28 +1,36 @@
 package io.smallrye.reactive.messaging.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 
+@SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_ATTR", value = "new-value")
+@SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_AT_TR", value = "another-value")
+@SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_KEY", value = "another-value-from-connector")
+@SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_OTHER_KEY", value = "another-value-other")
+@SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR1", value = "should not be used")
+@SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR3", value = "used")
+@SetEnvironmentVariable(key = "mp_messaging_connector_some_connector_attr4", value = "used")
+@SetEnvironmentVariable(key = "mp_messaging_connector_SOME_CONNECTOR_mixedcase", value = "should not be used")
 public class ConnectorConfigTest {
 
-    @Test
-    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_ATTR", value = "new-value")
-    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_AT_TR", value = "another-value")
-    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_KEY", value = "another-value-from-connector")
-    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_OTHER_KEY", value = "another-value-other")
-    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR1", value = "should not be used")
-    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR3", value = "used")
-    public void testPropertyNames() {
+    private SmallRyeConfig overallConfig;
+    private ConnectorConfig config;
+
+    @BeforeEach
+    public void createTestConfig() {
         Map<String, String> cfg = new HashMap<>();
         cfg.put("mp.messaging.incoming.bar.connector", "some-connector");
         cfg.put("mp.messaging.incoming.bar.test", "test");
@@ -33,6 +41,7 @@ public class ConnectorConfigTest {
         cfg.put("mp.messaging.incoming.foo.at-tr", "test");
         cfg.put("mp.messaging.connector.some-connector.key", "value");
         cfg.put("mp.messaging.connector.some-connector.some-key", "should not be used");
+        cfg.put("MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_CAPSKEY", "should not be used");
 
         SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
         builder.addDefaultSources();
@@ -62,25 +71,90 @@ public class ConnectorConfigTest {
                 return "test";
             }
         });
-        SmallRyeConfig c = builder.build();
+        overallConfig = builder.build();
+        config = new ConnectorConfig("mp.messaging.incoming.", overallConfig, "foo");
+    }
 
-        ConnectorConfig result = new ConnectorConfig("mp.messaging.incoming.", c, "foo");
-        Iterable<String> names = result.getPropertyNames();
+    @Test
+    public void testPropertyNames() {
+
+        // Base config behaviour:
+        // Even though looking up both properties would return the value of the environment variable,
+        // both are included in the set returned from getPropertyNames.
+        assertThat(overallConfig.getPropertyNames())
+                .contains("mp.messaging.incoming.foo.at-tr",
+                        "MP_MESSAGING_INCOMING_FOO_AT_TR");
+
+        Iterable<String> names = config.getPropertyNames();
         assertThat(names)
-                .containsExactlyInAnyOrder("connector", "ATTR1", "attr2", "attr.2", "ATTR", "AT_TR", "key", "SOME_KEY",
-                        "SOME_OTHER_KEY", "ATTR3", "channel-name");
+                .containsExactlyInAnyOrder("connector", "ATTR1", "attr1", "attr2", "attr.2", "ATTR", "AT_TR", "at-tr", "key",
+                        "SOME_KEY", "some-key", "SOME_OTHER_KEY", "ATTR3", "attr4", "channel-name");
 
-        assertThat(result.getOptionalValue("connector", String.class)).hasValue("some-connector");
-        assertThat(result.getOptionalValue("attr1", String.class)).hasValue("value");
-        assertThat(result.getOptionalValue("attr2", Integer.class)).hasValue(23);
-        assertThat(result.getOptionalValue("attr.2", String.class)).hasValue("test");
-        assertThat(result.getOptionalValue("at-tr", String.class)).hasValue("another-value");
-        assertThat(result.getOptionalValue("AT_TR", String.class)).hasValue("another-value");
-        assertThat(result.getOptionalValue("some-key", String.class)).hasValue("another-value-from-connector");
-        assertThat(result.getOptionalValue("SOME_KEY", String.class)).hasValue("another-value-from-connector");
-        assertThat(result.getOptionalValue("key", String.class)).hasValue("value");
-        assertThat(result.getOptionalValue("attr3", String.class)).hasValue("used");
-        assertThat(result.getOptionalValue("ATTR3", String.class)).hasValue("used");
+        assertThat(config.getOptionalValue("connector", String.class)).hasValue("some-connector");
+        assertThat(config.getOptionalValue("attr1", String.class)).hasValue("value");
+        assertThat(config.getOptionalValue("attr2", Integer.class)).hasValue(23);
+        assertThat(config.getOptionalValue("attr.2", String.class)).hasValue("test");
+        assertThat(config.getOptionalValue("at-tr", String.class)).hasValue("another-value");
+        assertThat(config.getOptionalValue("AT_TR", String.class)).hasValue("another-value");
+        assertThat(config.getOptionalValue("some-key", String.class)).hasValue("another-value-from-connector");
+        assertThat(config.getOptionalValue("SOME_KEY", String.class)).hasValue("another-value-from-connector");
+        assertThat(config.getOptionalValue("key", String.class)).hasValue("value");
+        assertThat(config.getOptionalValue("attr3", String.class)).hasValue("used");
+        assertThat(config.getOptionalValue("ATTR3", String.class)).hasValue("used");
+        assertThat(config.getOptionalValue("attr4", String.class)).hasValue("used");
+    }
+
+    @Test
+    public void testGetFromEnv() {
+        // All uppercase value in env
+        assertThat(config.getOptionalValue("attr3", String.class)).hasValue("used");
+        // All lowercase value in env
+        assertThat(config.getOptionalValue("attr4", String.class)).hasValue("used");
+        // Mixed case value in env should not be found as it does not match the key we're looking for
+        // either in its original casing, or after conversion to uppercase.
+        assertThat(config.getOptionalValue("mixedcase", String.class)).isEmpty();
+    }
+
+    @Test
+    public void testNameConversion() {
+        assertThat(config.getValue("channel-name", String.class)).isEqualTo("foo");
+        assertThat(config.getValue("connector", String.class)).isEqualTo("some-connector");
+        assertThat(config.getValue("type", String.class)).isEqualTo("some-connector");
+
+        assertThat(config.getValue("channel-name", boolean.class)).isEqualTo(false);
+        assertThat(config.getValue("connector", boolean.class)).isEqualTo(false);
+        assertThat(config.getValue("type", boolean.class)).isEqualTo(false);
+
+        assertThatIllegalArgumentException().isThrownBy(() -> config.getValue("channel-name", int.class));
+        assertThatIllegalArgumentException().isThrownBy(() -> config.getValue("connector", int.class));
+        assertThatIllegalArgumentException().isThrownBy(() -> config.getValue("type", int.class));
+
+        assertThatIllegalArgumentException().isThrownBy(() -> config.getOptionalValue("channel-name", int.class));
+        assertThatIllegalArgumentException().isThrownBy(() -> config.getOptionalValue("connector", int.class));
+        assertThatIllegalArgumentException().isThrownBy(() -> config.getOptionalValue("type", int.class));
+    }
+
+    @Test
+    public void testGetConfigValue() {
+        ConfigValue attr1 = config.getConfigValue("attr1");
+        assertThat(attr1.getName()).isEqualTo("mp.messaging.incoming.foo.attr1");
+        assertThat(attr1.getValue()).isEqualTo("value");
+        assertThat(attr1.getRawValue()).isEqualTo("value");
+        assertThat(attr1.getSourceName()).isEqualTo("test");
+        assertThat(attr1.getSourceOrdinal()).isEqualTo(ConfigSource.DEFAULT_ORDINAL);
+
+        ConfigValue attr3 = config.getConfigValue("attr3");
+        assertThat(attr3.getName()).isEqualTo("mp.messaging.connector.some-connector.attr3"); // The value looked up in the overall config
+        assertThat(attr3.getValue()).isEqualTo("used");
+        assertThat(attr3.getRawValue()).isEqualTo("used");
+        assertThat(attr3.getSourceOrdinal()).isEqualTo(300); // Env config source default ordinal
+
+        ConfigValue channelName = config.getConfigValue("channel-name");
+        assertThat(channelName.getName()).isEqualTo("channel-name");
+        assertThat(channelName.getValue()).isEqualTo("foo");
+        assertThat(channelName.getRawValue()).isEqualTo("foo");
+        assertThat(channelName.getSourceName()).isEqualTo("ConnectorConfig internal");
+        assertThat(channelName.getSourceOrdinal()).isEqualTo(0);
     }
 
 }


### PR DESCRIPTION
* Do correct conversion for the channel and connector name properties
* Avoid unnecessarily throwing and catching exceptions when we need to
  check several different names for one lookup
* Corrections to the way we create the list of property names, taking
  into account the rules for matching environment variable names
* Create a proper ConfigValue object when looking up the channel or
  connector name as a ConfigValue.
* Don't return the overall config from .unwrap(). If a connector needs
  to access the overall config, they can inject it.

@cescoffier You mentioned in #1002 that you weren't entirely happy with the `ConnectorConfig`. I had a look through and here are my suggested changes.