### PR TITLE
[3.x] Allow support for channel names with dots

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+    pull_request:
+        types:
+            - closed
+            - labeled
+
+jobs:
+    backport:
+        runs-on: ubuntu-18.04
+        name: Backport
+        steps:
+            - name: Backport
+              uses: tibdex/backport@v1
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Backports the following commits to 3.x:
 - Merge pull request #1050 from smallrye/kafka-channel-with-dots (#1050)