### PR TITLE
Fix#1053: Use passedConfig over defaultConfig in KafkaConnector

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -203,21 +203,24 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
             @SuppressWarnings("unchecked")
             @Override
             public <T> T getValue(String propertyName, Class<T> propertyType) {
-                T t = (T) defaultKafkaCfg.get(propertyName);
-                if (t == null) {
-                    return passedCfg.getValue(propertyName, propertyType);
+                T passedCgfValue = passedCfg.getValue(propertyName, propertyType);
+                if (passedCgfValue == null) {
+                    return (T) defaultKafkaCfg.get(propertyName);
+                } else {
+                    return passedCgfValue;
                 }
-                return t;
             }
 
             @SuppressWarnings("unchecked")
             @Override
             public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
-                T def = (T) defaultKafkaCfg.get(propertyName);
-                if (def != null) {
-                    return Optional.of(def);
+                Optional<T> passedCfgValue = passedCfg.getOptionalValue(propertyName, propertyType);
+                if (!passedCfgValue.isPresent()) {
+                    T defaultValue = (T) defaultKafkaCfg.get(propertyName);
+                    return Optional.of(defaultValue);
+                } else {
+                    return passedCfgValue;
                 }
-                return passedCfg.getOptionalValue(propertyName, propertyType);
             }
 
             @Override

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -217,7 +217,7 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
                 Optional<T> passedCfgValue = passedCfg.getOptionalValue(propertyName, propertyType);
                 if (!passedCfgValue.isPresent()) {
                     T defaultValue = (T) defaultKafkaCfg.get(propertyName);
-                    return Optional.of(defaultValue);
+                    return Optional.ofNullable(defaultValue);
                 } else {
                     return passedCfgValue;
                 }


### PR DESCRIPTION
This fixes the issue that the default config took precedence over the more specific configuration