### PR TITLE
[3.x] Fix  key name extraction when the channel contains dot

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConfigWithDotsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConfigWithDotsTest.java
@@ -1,0 +1,71 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.kafka.base.KafkaBrokerExtension;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+/**
+ * Test configuration where the channel names uses "dots"
+ */
+public class ConfigWithDotsTest extends KafkaTestBase {
+
+    @Test
+    public void testConfigurationWithDots() throws InterruptedException {
+
+        MapBasedConfig config = new MapBasedConfig()
+                .with("mp.messaging.incoming.\"tc.payments.domain_event.job_created\".bootstrap.servers",
+                        KafkaBrokerExtension.getBootstrapServers())
+                .with("mp.messaging.incoming.\"tc.payments.domain_event.job_created\".connector",
+                        KafkaConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.\"tc.payments.domain_event.job_created\".value.deserializer",
+                        StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.\"tc.payments.domain_event.job_created\"."
+                        + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                .with("mp.messaging.incoming.\"tc.payments.domain_event.job_created\".topic", topic);
+
+        KafkaConsumer consumer = runApplication(config, KafkaConsumer.class);
+
+        await().until(() -> isReady() && isAlive());
+        CountDownLatch latch = new CountDownLatch(1);
+        usage.produceStrings(5, latch::countDown, () -> new ProducerRecord<>(topic, "key", "hello"));
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .until(() -> consumer.getMessages().size() == 5);
+    }
+
+    @ApplicationScoped
+    public static class KafkaConsumer {
+
+        private final List<String> messages = new CopyOnWriteArrayList<>();
+
+        @Incoming("tc.payments.domain_event.job_created")
+        public void consume(String incoming) {
+            messages.add(incoming);
+        }
+
+        public List<String> getMessages() {
+            return messages;
+        }
+
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
@@ -523,7 +523,6 @@ public class KafkaSinkTest extends KafkaTestBase {
                 });
 
         KafkaMapBasedConfig config = getKafkaSinkConfigWithMultipleUpstreams(topic);
-        System.out.println(config);
         runApplication(config, BeanWithMultipleUpstreams.class);
 
         await().until(this::isReady);

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConnectorConfig.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/impl/ConnectorConfig.java
@@ -160,6 +160,9 @@ public class ConnectorConfig implements Config {
     @Override
     public Iterable<String> getPropertyNames() {
         String prefix = this.prefix + name + ".";
+        if (name.contains(".")) {
+            prefix = this.prefix + "\"" + name + "\".";
+        }
         String prefixAlpha = toAlpha(prefix);
         String prefixAlphaUpper = prefixAlpha.toUpperCase();
         String connectorPrefix = CONNECTOR_PREFIX + connector + ".";
@@ -208,7 +211,7 @@ public class ConnectorConfig implements Config {
     }
 
     private boolean nameExists(String name) {
-        return overall.getConfigValue(name).getRawValue() == null ? false : true;
+        return overall.getConfigValue(name).getRawValue() != null;
     }
 
     @Override

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/MergeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/merge/MergeTest.java
@@ -21,10 +21,7 @@ public class MergeTest extends WeldTestBaseWithoutTails {
     public void testRegularMerge() {
         initialize();
         BeanUsingMerge merge = container.getBeanManager().createInstance().select(BeanUsingMerge.class).get();
-        await().until(() -> {
-            System.out.println(merge.list());
-            return merge.list().size() == 7;
-        });
+        await().until(() -> merge.list().size() == 7);
         assertThat(merge.list()).contains("a", "b", "c", "D", "E", "F", "G");
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/EmitterMethodCycleTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/wiring/EmitterMethodCycleTest.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.wiring;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -11,8 +13,6 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class EmitterMethodCycleTest extends WeldTestBaseWithoutTails {
 


### PR DESCRIPTION
Backport Fix key name extraction when the channel contains dot #1050 to 3.x

