### PR TITLE
Use @Identifier instead of @Named

### DIFF
--- a/documentation/src/main/doc/modules/amqp/examples/customization/ClientProducers.java
+++ b/documentation/src/main/doc/modules/amqp/examples/customization/ClientProducers.java
@@ -1,17 +1,17 @@
 package customization;
 
+import io.smallrye.common.annotation.Identifier;
 import io.vertx.amqp.AmqpClientOptions;
 import io.vertx.core.net.PemKeyCertOptions;
 import io.vertx.core.net.PemTrustOptions;
 
 import javax.enterprise.inject.Produces;
-import javax.inject.Named;
 
 public class ClientProducers {
 
     // tag::named[]
     @Produces
-    @Named("my-named-options")
+    @Identifier("my-named-options")
     public AmqpClientOptions getNamedOptions() {
         // You can use the produced options to configure the TLS connection
         PemKeyCertOptions keycert = new PemKeyCertOptions()

--- a/documentation/src/main/doc/modules/amqp/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/amqp/pages/inbound.adoc
@@ -101,9 +101,9 @@ public static class Consumer {
 
 Messages coming from AMQP contains an instance of {javadoc-base}/io/smallrye/reactive/messaging/amqp/IncomingAmqpMetadata.html[`IncomingAmqpMetadata`] in the metadata.
 
-[source, java]
+[source,java,indent=0]
 ----
-include::example$inbound/AmqpMetadataExample.java[]
+include::example$inbound/AmqpMetadataExample.java[tag=code]
 ----
 
 === Acknowledgement

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -113,15 +113,15 @@ Type: _string_ | false |
 
 Type: _int_ | false | `1`
 
-| *consumer-rebalance-listener.name* | The name set in `javax.inject.Named` of a bean that implements `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener`. If set, this rebalance listener is applied to the consumer.
+| *consumer-rebalance-listener.name* | The name set in `@Identifier` of a bean that implements `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener`. If set, this rebalance listener is applied to the consumer.
 
 Type: _string_ | false | 
 
-| *key-deserialization-failure-handler* | The name set in `javax.inject.Named` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing keys are delegated to this handler which may provide a fallback value.
+| *key-deserialization-failure-handler* | The name set in `@Identifier` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing keys are delegated to this handler which may provide a fallback value.
 
 Type: _string_ | false | 
 
-| *value-deserialization-failure-handler* | The name set in `javax.inject.Named` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing values are delegated to this handler which may provide a fallback value.
+| *value-deserialization-failure-handler* | The name set in `@Identifier` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing values are delegated to this handler which may provide a fallback value.
 
 Type: _string_ | false | 
 

--- a/documentation/src/main/doc/modules/jms/pages/executor.adoc
+++ b/documentation/src/main/doc/modules/jms/pages/executor.adoc
@@ -13,10 +13,10 @@ You can configure the thread pool providing these worker threads using the follo
 
 === Selecting the ConnectionFactory
 
-The JMS Connector requires a `javax.jms.ConnectionFactory` to be exposed (as CDI bean).
+The JMS Connector requires a `javax.jms.ConnectionFactory` to be exposed as a CDI bean.
 The connector looks for a `javax.jms.ConnectionFactory` and delegate the interaction with the JMS server to this factory.
 
-In case you have several connection factories, you can use the `@Named` qualifier on your factory to specify the name.
+In case you have several connection factories, you can use the `@Identifier` qualifier on your factory to specify the name.
 Then, in the channel configuration, configure the name as follows:
 
 [source,properties]

--- a/documentation/src/main/doc/modules/jms/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/jms/pages/inbound.adoc
@@ -59,9 +59,9 @@ If not, the default behavior is used (Java deserialization).
 
 Messages coming from JMS contains an instance of {javadoc-base}/apidocs/io/smallrye/reactive/messaging/jms/IncomingJmsMessageMetadata.html[`IncomingJmsMessageMetadata`] in the metadata.
 
-[source, java]
+[source,java,indent=0]
 ----
-include::example$inbound/JmsMetadataExample.java[]
+include::example$inbound/JmsMetadataExample.java[tag=code]
 ----
 
 === Acknowledgement

--- a/documentation/src/main/doc/modules/jms/pages/outbound.adoc
+++ b/documentation/src/main/doc/modules/jms/pages/outbound.adoc
@@ -71,9 +71,9 @@ The classname is passed in the `JMSType` property and `_classname` property.
 
 When sending `Messages`, you can add an instance of {javadoc-base}/apidocs/io/smallrye/reactive/messaging/jms/OutgoingJmsMessageMetadata.html[`OutgoingJmsMessageMetadata`] to influence how the message is going to written to JMS.
 
-[source, java]
+[source,java,indent=0]
 ----
-include::example$outbound/JmsOutboundMetadataExample.java[]
+include::example$outbound/JmsOutboundMetadataExample.java[tag=code]
 ----
 
 These metadata allow adding properties but also override the destination.

--- a/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumerRebalanceListener.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRebalancedConsumerRebalanceListener.java
@@ -1,18 +1,18 @@
 package inbound;
 
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
 @ApplicationScoped
-@Named("rebalanced-example.rebalancer")
+@Identifier("rebalanced-example.rebalancer")
 public class KafkaRebalancedConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
 
     private static final Logger LOGGER = Logger.getLogger(KafkaRebalancedConsumerRebalanceListener.class.getName());

--- a/documentation/src/main/doc/modules/kafka/pages/consumer-rebalance-listener.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/consumer-rebalance-listener.adoc
@@ -2,7 +2,7 @@
 === Consumer Rebalance Listener
 
 To handle offset commit and assigned partitions yourself, you can provide a consumer rebalance listener.
-To achieve this, implement the `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener` interface and exposed it as a `@Named` bean.
+To achieve this, implement the `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener` interface, make the implementing class a bean, and add the `@Identifier` qualifier.
 A usual use case is to store offset in a separate data store to implement exactly-once semantic, or starting the processing at a specific offset.
 
 The listener is invoked every time the consumer topic/partition assignment changes.
@@ -21,9 +21,9 @@ Unlike the `ConsumerRebalanceListener`  from Apache Kafka, the `io.smallrye.reac
 
 ==== Example
 
-In this example we set-up a consumer that always starts on messages from at most 10 minutes ago (of offset 0). First we need to provide
-a bean managed implementation of `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener` annotated with
-`javax.inject.Named`. We then must configure our inbound connector to use this named bean.
+In this example we set-up a consumer that always starts on messages from at most 10 minutes ago (or offset 0). First we need to provide
+a bean that implements the `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener` interface and is annotated with
+`@Identifier`. We then must configure our inbound connector to use this named bean.
 
 [source, java]
 ----
@@ -43,4 +43,4 @@ Or have the listener's name be the same as the group id:
 
 * `mp.messaging.incoming.rebalanced-example.group.id=rebalanced-example.rebalancer`
 
-Setting the consumer re-balance listener's name takes precedence over using the group id.
+Setting the consumer rebalance listener's name takes precedence over using the group id.

--- a/documentation/src/main/doc/modules/kafka/pages/default-configuration.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/default-configuration.adoc
@@ -1,8 +1,8 @@
 [#kafka-default-configuration]
 == Retrieving Kafka default configuration
 
-If your application/runtime exposes as a CDI _bean_ a `Map<String, Object` named `default-kafka-broker`, this configuration is used to
-establish the connection with the Kafka broker:
+If your application/runtime exposes as a CDI _bean_ of type `Map<String, Object` with the identifier `default-kafka-broker`, this configuration is used to
+establish the connection with the Kafka broker.
 
 For example, you can imagine exposing this map as follows:
 
@@ -10,7 +10,7 @@ For example, you can imagine exposing this map as follows:
 ----
 @Produces
 @ApplicationScoped
-@Named("default-kafka-broker")
+@Identifier("default-kafka-broker")
 public Map<String, Object> createKafkaRuntimeConfig() {
     Map<String, Object> properties = new HashMap<>();
 
@@ -35,5 +35,5 @@ This previous example would extract all the configuration keys from MicroProfile
 [NOTE]
 .Quarkus
 ====
-Starting Quarkus 1.5, this map is automatically exposed.
+Starting with Quarkus 1.5, a map corresponding to the previous example is automatically provided.
 ====

--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -148,7 +148,7 @@ To achieve this, create a CDI bean implementing the {javadoc-base}/io/smallrye/r
 [source, java]
 ----
 @ApplicationScoped
-@Named("failure-fallback") // Set the name of the failure handler
+@Identifier("failure-fallback") // Set the name of the failure handler
 public class MyDeserializationFailureHandler
     implements DeserializationFailureHandler<JsonObject> { // Specify the expected type
 
@@ -161,7 +161,7 @@ public class MyDeserializationFailureHandler
 }
 ----
 
-The bean must be exposed with the `@Named` qualifier specifying the name of the bean.
+The bean must be exposed with the `@Identifier` qualifier specifying the name of the bean.
 Then, in the connector configuration, specify the following attribute:
 
 * `mp.messaging.incoming.$channel.key-deserialization-failure-handler`: name of the bean handling deserialization failures happening for the record's key

--- a/examples/amqp-quickstart/src/main/java/acme/AmqpConfiguration.java
+++ b/examples/amqp-quickstart/src/main/java/acme/AmqpConfiguration.java
@@ -1,14 +1,14 @@
 package acme;
 
 import javax.enterprise.inject.Produces;
-import javax.inject.Named;
 
+import io.smallrye.common.annotation.Identifier;
 import io.vertx.amqp.AmqpClientOptions;
 
 public class AmqpConfiguration {
 
     @Produces
-    @Named("my-topic-config")
+    @Identifier("my-topic-config")
     public AmqpClientOptions options() {
         return new AmqpClientOptions()
                 .setHost("localhost")
@@ -18,7 +18,7 @@ public class AmqpConfiguration {
     }
 
     @Produces
-    @Named("my-topic-config2")
+    @Identifier("my-topic-config2")
     public AmqpClientOptions options2() {
         return new AmqpClientOptions()
                 .setHost("localhost")

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
     <smallrye-config.version>1.10.0</smallrye-config.version>
     <smallrye-metrics.version>2.4.6</smallrye-metrics.version>
-    <smallrye-common.version>1.5.0</smallrye-common.version>
+    <smallrye-common.version>1.6.0</smallrye-common.version>
     <smallrye-health.version>2.2.6</smallrye-health.version>
     <smallrye-testing.version>0.1.0</smallrye-testing.version>
     <smallrye-fault-tolerance.version>4.3.2</smallrye-fault-tolerance.version>

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpClientHelper.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpClientHelper.java
@@ -9,6 +9,7 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.literal.NamedLiteral;
 
 import io.smallrye.common.annotation.Identifier;
+import io.smallrye.reactive.messaging.i18n.ProviderLogging;
 import io.vertx.amqp.AmqpClientOptions;
 import io.vertx.mutiny.amqp.AmqpClient;
 import io.vertx.mutiny.core.Vertx;
@@ -39,6 +40,9 @@ public class AmqpClientHelper {
         if (options.isUnsatisfied()) {
             // this `if` block should be removed when support for the `@Named` annotation is removed
             options = instance.select(NamedLiteral.of(optionsBeanName));
+            if (!options.isUnsatisfied()) {
+                ProviderLogging.log.deprecatedNamed();
+            }
         }
         if (options.isUnsatisfied()) {
             throw ex.illegalStateFindingBean(AmqpClientOptions.class.getName(), optionsBeanName);

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpClientHelper.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpClientHelper.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.literal.NamedLiteral;
 
+import io.smallrye.common.annotation.Identifier;
 import io.vertx.amqp.AmqpClientOptions;
 import io.vertx.mutiny.amqp.AmqpClient;
 import io.vertx.mutiny.core.Vertx;
@@ -34,7 +35,11 @@ public class AmqpClientHelper {
 
     static AmqpClient createClientFromClientOptionsBean(Vertx vertx, Instance<AmqpClientOptions> instance,
             String optionsBeanName) {
-        Instance<AmqpClientOptions> options = instance.select(NamedLiteral.of(optionsBeanName));
+        Instance<AmqpClientOptions> options = instance.select(Identifier.Literal.of(optionsBeanName));
+        if (options.isUnsatisfied()) {
+            // this `if` block should be removed when support for the `@Named` annotation is removed
+            options = instance.select(NamedLiteral.of(optionsBeanName));
+        }
         if (options.isUnsatisfied()) {
             throw ex.illegalStateFindingBean(AmqpClientOptions.class.getName(), optionsBeanName);
         }

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -16,6 +16,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.BeforeDestroyed;
 import javax.enterprise.event.Observes;
 import javax.enterprise.event.Reception;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
@@ -81,6 +82,7 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
     private ExecutionHolder executionHolder;
 
     @Inject
+    @Any
     private Instance<AmqpClientOptions> clientOptions;
 
     private final List<AmqpClient> clients = new CopyOnWriteArrayList<>();

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ClientConfigurationBean.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ClientConfigurationBean.java
@@ -2,15 +2,15 @@ package io.smallrye.reactive.messaging.amqp;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
-import javax.inject.Named;
 
+import io.smallrye.common.annotation.Identifier;
 import io.vertx.amqp.AmqpClientOptions;
 
 @ApplicationScoped
 public class ClientConfigurationBean {
 
     @Produces
-    @Named("myclientoptions")
+    @Identifier("myclientoptions")
     public AmqpClientOptions options() {
         return new AmqpClientOptions()
                 .setHost(System.getProperty("amqp-host"))

--- a/smallrye-reactive-messaging-jms/pom.xml
+++ b/smallrye-reactive-messaging-jms/pom.xml
@@ -103,7 +103,6 @@
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-reactive-messaging-provider</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>

--- a/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
+++ b/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction;
+import io.smallrye.reactive.messaging.i18n.ProviderLogging;
 
 @ApplicationScoped
 @Connector(JmsConnector.CONNECTOR_NAME)
@@ -164,6 +165,9 @@ public class JmsConnector implements IncomingConnectorFactory, OutgoingConnector
             if (matching.isUnsatisfied()) {
                 // this `if` block should be removed when support for the `@Named` annotation is removed
                 matching = factories.select(NamedLiteral.of(factoryName));
+                if (!matching.isUnsatisfied()) {
+                    ProviderLogging.log.deprecatedNamed();
+                }
             }
             iterator = matching.iterator();
         }

--- a/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
+++ b/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.literal.NamedLiteral;
 import javax.inject.Inject;
@@ -31,6 +32,7 @@ import org.eclipse.microprofile.reactive.messaging.spi.OutgoingConnectorFactory;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction;
 
@@ -79,6 +81,7 @@ public class JmsConnector implements IncomingConnectorFactory, OutgoingConnector
     static final String DEFAULT_THREAD_TTL = "60";
 
     @Inject
+    @Any
     Instance<ConnectionFactory> factories;
 
     @Inject
@@ -157,7 +160,12 @@ public class JmsConnector implements IncomingConnectorFactory, OutgoingConnector
         if (factoryName == null) {
             iterator = factories.iterator();
         } else {
-            iterator = factories.select(NamedLiteral.of(factoryName)).iterator();
+            Instance<ConnectionFactory> matching = factories.select(Identifier.Literal.of(factoryName));
+            if (matching.isUnsatisfied()) {
+                // this `if` block should be removed when support for the `@Named` annotation is removed
+                matching = factories.select(NamedLiteral.of(factoryName));
+            }
+            iterator = matching.iterator();
         }
 
         if (!iterator.hasNext()) {

--- a/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/jms/DeprecatedNamedFactoryTest.java
+++ b/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/jms/DeprecatedNamedFactoryTest.java
@@ -9,17 +9,19 @@ import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.DeploymentException;
+import javax.inject.Named;
 import javax.jms.ConnectionFactory;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.Test;
 
-import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.jms.support.JmsTestBase;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 
-public class NamedFactoryTest extends JmsTestBase {
+// this entire file should be removed when support for the `@Named` annotation is removed
+
+public class DeprecatedNamedFactoryTest extends JmsTestBase {
 
     @Override
     protected boolean withConnectionFactory() {
@@ -99,7 +101,7 @@ public class NamedFactoryTest extends JmsTestBase {
     public static class BarConnectionFactoryBean {
 
         @Produces
-        @Identifier("bar")
+        @Named("bar")
         ConnectionFactory factory() {
             return new ActiveMQJMSConnectionFactory(
                     "tcp://localhost:61618", // Wrong on purpose
@@ -112,7 +114,7 @@ public class NamedFactoryTest extends JmsTestBase {
     public static class FooConnectionFactoryBean {
 
         @Produces
-        @Identifier("foo")
+        @Named("foo")
         ConnectionFactory factory() {
             return new ActiveMQJMSConnectionFactory(
                     "tcp://localhost:61616",

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/DeserializationFailureHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/DeserializationFailureHandler.java
@@ -5,7 +5,7 @@ import org.apache.kafka.common.header.Headers;
 /**
  * Bean invoked on Kafka deserialization failure.
  * <p>
- * Implementors must use {@code @Named} to provide a name to the bean.
+ * Implementors must use {@code @Identifier} to provide a name to the bean.
  * This name is then referenced in the channel configuration:
  * {@code mp.messaging.incoming.my-channel.[key|value]-deserialization-failure-handler=name}.
  * <p>
@@ -18,7 +18,7 @@ import org.apache.kafka.common.header.Headers;
 public interface DeserializationFailureHandler<T> {
 
     /**
-     * Handles a deserialization issue for a record's key.
+     * Handles a deserialization issue for a record's key or value.
      *
      * @param topic the topic
      * @param isKey whether the failure happened when deserializing a record's key.

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -43,6 +43,7 @@ import io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.health.HealthReporter;
+import io.smallrye.reactive.messaging.i18n.ProviderLogging;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaThrottledLatestProcessedCommit;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSink;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
@@ -154,6 +155,9 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
             // this `if` block should be removed when support for the `@Named` annotation is removed
             // then, we can add `@Identifier("default-kafka-broker")` back to the injection point, instead of `@Any`
             matching = defaultKafkaConfiguration.select(NamedLiteral.of(DEFAULT_KAFKA_BROKER));
+            if (!matching.isUnsatisfied()) {
+                ProviderLogging.log.deprecatedNamed();
+            }
         }
         if (!matching.isUnsatisfied()) {
             c = merge(config, matching.get());
@@ -208,6 +212,9 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
         if (matching.isUnsatisfied()) {
             // this `if` block should be removed when support for the `@Named` annotation is removed
             matching = defaultKafkaConfiguration.select(NamedLiteral.of(DEFAULT_KAFKA_BROKER));
+            if (!matching.isUnsatisfied()) {
+                ProviderLogging.log.deprecatedNamed();
+            }
         }
         if (!matching.isUnsatisfied()) {
             c = merge(config, defaultKafkaConfiguration.get());

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -18,9 +18,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.BeforeDestroyed;
 import javax.enterprise.event.Observes;
 import javax.enterprise.event.Reception;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.literal.NamedLiteral;
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -35,6 +36,7 @@ import org.reactivestreams.Publisher;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction;
@@ -76,9 +78,9 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "dead-letter-queue.key.serializer", type = "string", direction = Direction.INCOMING, description = "When the `failure-strategy` is set to `dead-letter-queue` indicates the key serializer to use. If not set the serializer associated to the key deserializer is used")
 @ConnectorAttribute(name = "dead-letter-queue.value.serializer", type = "string", direction = Direction.INCOMING, description = "When the `failure-strategy` is set to `dead-letter-queue` indicates the value serializer to use. If not set the serializer associated to the value deserializer is used")
 @ConnectorAttribute(name = "partitions", type = "int", direction = Direction.INCOMING, description = "The number of partitions to be consumed concurrently. The connector creates the specified amount of Kafka consumers. It should match the number of partition of the targeted topic", defaultValue = "1")
-@ConnectorAttribute(name = "consumer-rebalance-listener.name", type = "string", direction = Direction.INCOMING, description = "The name set in `javax.inject.Named` of a bean that implements `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener`. If set, this rebalance listener is applied to the consumer.")
-@ConnectorAttribute(name = "key-deserialization-failure-handler", type = "string", direction = Direction.INCOMING, description = "The name set in `javax.inject.Named` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing keys are delegated to this handler which may provide a fallback value.")
-@ConnectorAttribute(name = "value-deserialization-failure-handler", type = "string", direction = Direction.INCOMING, description = "The name set in `javax.inject.Named` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing values are delegated to this handler which may provide a fallback value.")
+@ConnectorAttribute(name = "consumer-rebalance-listener.name", type = "string", direction = Direction.INCOMING, description = "The name set in `@Identifier` of a bean that implements `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener`. If set, this rebalance listener is applied to the consumer.")
+@ConnectorAttribute(name = "key-deserialization-failure-handler", type = "string", direction = Direction.INCOMING, description = "The name set in `@Identifier` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing keys are delegated to this handler which may provide a fallback value.")
+@ConnectorAttribute(name = "value-deserialization-failure-handler", type = "string", direction = Direction.INCOMING, description = "The name set in `@Identifier` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing values are delegated to this handler which may provide a fallback value.")
 @ConnectorAttribute(name = "graceful-shutdown", type = "boolean", direction = Direction.INCOMING, description = "Whether or not a graceful shutdown should be attempted when the application terminates.", defaultValue = "true")
 
 @ConnectorAttribute(name = "key.serializer", type = "string", direction = Direction.OUTGOING, description = "The serializer classname used to serialize the record's key", defaultValue = "org.apache.kafka.common.serialization.StringSerializer")
@@ -105,13 +107,17 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
 
     public static Tracer TRACER;
 
+    private static final String DEFAULT_KAFKA_BROKER = "default-kafka-broker";
+
     @Inject
     ExecutionHolder executionHolder;
 
     @Inject
+    @Any
     Instance<KafkaConsumerRebalanceListener> consumerRebalanceListeners;
 
     @Inject
+    @Any
     Instance<DeserializationFailureHandler<?>> deserializationFailureHandlers;
 
     @Inject
@@ -121,7 +127,7 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     private final List<KafkaSink> sinks = new CopyOnWriteArrayList<>();
 
     @Inject
-    @Named("default-kafka-broker")
+    @Any
     Instance<Map<String, Object>> defaultKafkaConfiguration;
 
     private Vertx vertx;
@@ -142,8 +148,15 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     @Override
     public PublisherBuilder<? extends Message<?>> getPublisherBuilder(Config config) {
         Config c = config;
-        if (!defaultKafkaConfiguration.isUnsatisfied()) {
-            c = merge(config, defaultKafkaConfiguration.get());
+
+        Instance<Map<String, Object>> matching = defaultKafkaConfiguration.select(Identifier.Literal.of(DEFAULT_KAFKA_BROKER));
+        if (matching.isUnsatisfied()) {
+            // this `if` block should be removed when support for the `@Named` annotation is removed
+            // then, we can add `@Identifier("default-kafka-broker")` back to the injection point, instead of `@Any`
+            matching = defaultKafkaConfiguration.select(NamedLiteral.of(DEFAULT_KAFKA_BROKER));
+        }
+        if (!matching.isUnsatisfied()) {
+            c = merge(config, matching.get());
         }
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(c);
         int partitions = ic.getPartitions();
@@ -191,7 +204,12 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     @Override
     public SubscriberBuilder<? extends Message<?>, Void> getSubscriberBuilder(Config config) {
         Config c = config;
-        if (!defaultKafkaConfiguration.isUnsatisfied()) {
+        Instance<Map<String, Object>> matching = defaultKafkaConfiguration.select(Identifier.Literal.of(DEFAULT_KAFKA_BROKER));
+        if (matching.isUnsatisfied()) {
+            // this `if` block should be removed when support for the `@Named` annotation is removed
+            matching = defaultKafkaConfiguration.select(NamedLiteral.of(DEFAULT_KAFKA_BROKER));
+        }
+        if (!matching.isUnsatisfied()) {
             c = merge(config, defaultKafkaConfiguration.get());
         }
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(c);

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
@@ -9,28 +9,35 @@ import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.mutiny.kafka.client.consumer.KafkaConsumer;
 
 /**
- *
- * When implemented by a managed bean annotated with {@link javax.inject.Named} and
- * configured against an inbound connector will be applied as a consumer re-balance listener
+ * When implemented by a managed bean annotated with {@link io.smallrye.common.annotation.Identifier @Identifier}
+ * and configured against an inbound connector, it will be applied as a consumer rebalance listener
  * to that inbound connector's consumer.
+ * <p>
+ * To configure which listener you want to use, set the name in the inbound connector's consumer rebalance listener
+ * attribute. For example:
  *
+ * <pre>
+ * mp.messaging.incoming.example.consumer-rebalance-listener.name=ExampleConsumerRebalanceListener
  *
- * To configure which listener you want to use, set the name in the inbound connector's consumer re-balance listener attribute,
- * ex:
- * {@code
- *  mp.messaging.incoming.example.consumer-rebalance- listener.name=ExampleConsumerRebalanceListener
+ * &#64;Identifier("ExampleConsumerRebalanceListener")
+ * public class ExampleConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
+ *     ...
  * }
- * {@code @Named("ExampleConsumerRebalanceListener")}
+ * </pre>
  *
- * Alternatively, name your listener (using the {@code @Named} annotation) to be the group id used by the connector, ex:
- * {@code
- *  mp.messaging.incoming.example.group.id=my-group
+ * Alternatively, name your listener (using the {@code @Identifier} annotation) to be the group id used by the connector.
+ * For example:
+ *
+ * <pre>
+ * mp.messaging.incoming.example.group.id=my-group
+ *
+ * &#64;Identifier("my-group")
+ * public class MyGroupConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
+ *     ...
  * }
- * {@code @Named("my-group")}
- *
- * Setting the consumer re-balance listener name takes precedence over using the group id.
- *
- * For more details:
+ * </pre>
+ * <p>
+ * Setting the consumer rebalance listener name takes precedence over using the group id.
  *
  * @see org.apache.kafka.clients.consumer.ConsumerRebalanceListener
  */

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -29,6 +29,7 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
 import io.smallrye.reactive.messaging.TracingMetadata;
 import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.i18n.ProviderLogging;
 import io.smallrye.reactive.messaging.kafka.*;
 import io.smallrye.reactive.messaging.kafka.commit.*;
 import io.smallrye.reactive.messaging.kafka.fault.*;
@@ -236,6 +237,9 @@ public class KafkaSource<K, V> {
         if (matching.isUnsatisfied()) {
             // this `if` block should be removed when support for the `@Named` annotation is removed
             matching = deserializationFailureHandlers.select(NamedLiteral.of(name));
+            if (!matching.isUnsatisfied()) {
+                ProviderLogging.log.deprecatedNamed();
+            }
         }
         if (matching.isUnsatisfied()) {
             throw ex.unableToFindDeserializationFailureHandler(name, configuration.getChannel());

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -23,6 +23,7 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
@@ -231,7 +232,11 @@ public class KafkaSource<K, V> {
         }
 
         Instance<DeserializationFailureHandler<?>> matching = deserializationFailureHandlers
-                .select(NamedLiteral.of(name));
+                .select(Identifier.Literal.of(name));
+        if (matching.isUnsatisfied()) {
+            // this `if` block should be removed when support for the `@Named` annotation is removed
+            matching = deserializationFailureHandlers.select(NamedLiteral.of(name));
+        }
         if (matching.isUnsatisfied()) {
             throw ex.unableToFindDeserializationFailureHandler(name, configuration.getChannel());
         } else if (matching.stream().count() > 1) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
@@ -11,6 +11,7 @@ import javax.enterprise.inject.literal.NamedLiteral;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
 
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler;
@@ -109,7 +110,11 @@ public class RebalanceListeners {
         return config.getConsumerRebalanceListenerName()
                 .map(name -> {
                     log.loadingConsumerRebalanceListenerFromConfiguredName(name);
-                    Instance<KafkaConsumerRebalanceListener> matching = instances.select(NamedLiteral.of(name));
+                    Instance<KafkaConsumerRebalanceListener> matching = instances.select(Identifier.Literal.of(name));
+                    if (matching.isUnsatisfied()) {
+                        // this `if` block should be removed when support for the `@Named` annotation is removed
+                        matching = instances.select(NamedLiteral.of(name));
+                    }
                     // We want to fail if a name if set, but no match or too many matches
                     if (matching.isUnsatisfied()) {
                         throw KafkaExceptions.ex.unableToFindRebalanceListener(name, config.getChannel());
@@ -123,7 +128,11 @@ public class RebalanceListeners {
                     }
                 })
                 .orElseGet(() -> {
-                    Instance<KafkaConsumerRebalanceListener> matching = instances.select(NamedLiteral.of(consumerGroup));
+                    Instance<KafkaConsumerRebalanceListener> matching = instances.select(Identifier.Literal.of(consumerGroup));
+                    if (matching.isUnsatisfied()) {
+                        // this `if` block should be removed when support for the `@Named` annotation is removed
+                        matching = instances.select(NamedLiteral.of(consumerGroup));
+                    }
                     if (!matching.isUnsatisfied()) {
                         log.loadingConsumerRebalanceListenerFromGroupId(consumerGroup);
                         return Optional.of(matching.get());

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
@@ -12,6 +12,7 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
 
 import io.smallrye.common.annotation.Identifier;
+import io.smallrye.reactive.messaging.i18n.ProviderLogging;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler;
@@ -114,6 +115,9 @@ public class RebalanceListeners {
                     if (matching.isUnsatisfied()) {
                         // this `if` block should be removed when support for the `@Named` annotation is removed
                         matching = instances.select(NamedLiteral.of(name));
+                        if (!matching.isUnsatisfied()) {
+                            ProviderLogging.log.deprecatedNamed();
+                        }
                     }
                     // We want to fail if a name if set, but no match or too many matches
                     if (matching.isUnsatisfied()) {
@@ -132,6 +136,9 @@ public class RebalanceListeners {
                     if (matching.isUnsatisfied()) {
                         // this `if` block should be removed when support for the `@Named` annotation is removed
                         matching = instances.select(NamedLiteral.of(consumerGroup));
+                        if (!matching.isUnsatisfied()) {
+                            ProviderLogging.log.deprecatedNamed();
+                        }
                     }
                     if (!matching.isUnsatisfied()) {
                         log.loadingConsumerRebalanceListenerFromGroupId(consumerGroup);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionConsumerRebalanceListener.java
@@ -5,13 +5,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
+import io.smallrye.common.annotation.Identifier;
+
 @ApplicationScoped
-@Named("ConsumptionConsumerRebalanceListener")
+@Identifier("ConsumptionConsumerRebalanceListener")
 public class ConsumptionConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
 
     private final Map<Integer, TopicPartition> assigned = new ConcurrentHashMap<>();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/DeprecatedDefaultConfigTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/DeprecatedDefaultConfigTest.java
@@ -17,6 +17,7 @@ import java.util.stream.StreamSupport;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
@@ -28,14 +29,15 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.Test;
 
-import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
 import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+
+// this entire file should be removed when support for the `@Named` annotation is removed
 
 /**
  * Test that the config can be retrieved from a Map produced using the {@code default-kafka-broker} name
  */
-public class DefaultConfigTest extends KafkaTestBase {
+public class DeprecatedDefaultConfigTest extends KafkaTestBase {
 
     @Test
     public void testFromKafkaToAppToKafka() {
@@ -96,7 +98,7 @@ public class DefaultConfigTest extends KafkaTestBase {
 
         @Produces
         @ApplicationScoped
-        @Identifier("default-kafka-broker")
+        @Named("default-kafka-broker")
         public Map<String, Object> createKafkaRuntimeConfig() {
             Map<String, Object> properties = new HashMap<>();
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -20,7 +20,6 @@ import java.util.stream.IntStream;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.UnsatisfiedResolutionException;
-import javax.enterprise.inject.literal.NamedLiteral;
 import javax.inject.Inject;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -33,6 +32,7 @@ import org.jboss.weld.exceptions.DeploymentException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.health.HealthReport;
@@ -535,7 +535,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         return getBeanManager()
                 .createInstance()
                 .select(ConsumptionConsumerRebalanceListener.class)
-                .select(NamedLiteral.of(ConsumptionConsumerRebalanceListener.class.getSimpleName()))
+                .select(Identifier.Literal.of(ConsumptionConsumerRebalanceListener.class.getSimpleName()))
                 .get();
 
     }
@@ -545,7 +545,7 @@ public class KafkaSourceTest extends KafkaTestBase {
         return getBeanManager()
                 .createInstance()
                 .select(StartFromFifthOffsetFromLatestConsumerRebalanceListener.class)
-                .select(NamedLiteral.of(name))
+                .select(Identifier.Literal.of(name))
                 .get();
 
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener.java
@@ -4,14 +4,14 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
 
-import io.vertx.kafka.client.common.TopicPartition;
+import io.smallrye.common.annotation.Identifier;
 
 @ApplicationScoped
-@Named("my-group-starting-on-fifth-fail-on-first-attempt")
+@Identifier("my-group-starting-on-fifth-fail-on-first-attempt")
 public class StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListener
         extends StartFromFifthOffsetFromLatestConsumerRebalanceListener {
 
@@ -19,7 +19,7 @@ public class StartFromFifthOffsetFromLatestButFailOnFirstConsumerRebalanceListen
 
     @Override
     public void onPartitionsAssigned(Consumer<?, ?> consumer,
-            Collection<org.apache.kafka.common.TopicPartition> partitions) {
+            Collection<TopicPartition> partitions) {
         super.onPartitionsAssigned(consumer, partitions);
         if (!partitions.isEmpty() && failOnFirstAttempt.getAndSet(false)) {
             throw new IllegalArgumentException("testing failure");

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener.java
@@ -4,13 +4,14 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
+import io.smallrye.common.annotation.Identifier;
+
 @ApplicationScoped
-@Named("my-group-starting-on-fifth-fail-until-second-rebalance")
+@Identifier("my-group-starting-on-fifth-fail-until-second-rebalance")
 public class StartFromFifthOffsetFromLatestButFailUntilSecondRebalanceConsumerRebalanceListener
         extends StartFromFifthOffsetFromLatestConsumerRebalanceListener {
     private final AtomicBoolean failOnFirstAttempt = new AtomicBoolean(true);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/StartFromFifthOffsetFromLatestConsumerRebalanceListener.java
@@ -5,13 +5,14 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
+import io.smallrye.common.annotation.Identifier;
+
 @ApplicationScoped
-@Named("my-group-starting-on-fifth-happy-path")
+@Identifier("my-group-starting-on-fifth-happy-path")
 public class StartFromFifthOffsetFromLatestConsumerRebalanceListener implements KafkaConsumerRebalanceListener {
 
     private final AtomicInteger rebalanceCount = new AtomicInteger();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/DoubleInstance.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/DoubleInstance.java
@@ -5,8 +5,9 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.literal.NamedLiteral;
 import javax.enterprise.util.TypeLiteral;
+
+import io.smallrye.common.annotation.Identifier;
 
 public class DoubleInstance<T> implements Instance<T> {
 
@@ -25,8 +26,8 @@ public class DoubleInstance<T> implements Instance<T> {
         if (qualifiers.length == 0) {
             return this;
         }
-        if (qualifiers.length == 1 && qualifiers[0] instanceof NamedLiteral) {
-            if (((NamedLiteral) qualifiers[0]).value().equalsIgnoreCase(name)) {
+        if (qualifiers.length == 1 && qualifiers[0] instanceof Identifier) {
+            if (((Identifier) qualifiers[0]).value().equalsIgnoreCase(name)) {
                 return this;
             }
         }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/SingletonInstance.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/SingletonInstance.java
@@ -5,8 +5,9 @@ import java.util.Collections;
 import java.util.Iterator;
 
 import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.literal.NamedLiteral;
 import javax.enterprise.util.TypeLiteral;
+
+import io.smallrye.common.annotation.Identifier;
 
 public class SingletonInstance<T> implements Instance<T> {
 
@@ -23,8 +24,8 @@ public class SingletonInstance<T> implements Instance<T> {
         if (qualifiers.length == 0) {
             return this;
         }
-        if (qualifiers.length == 1 && qualifiers[0] instanceof NamedLiteral) {
-            if (((NamedLiteral) qualifiers[0]).value().equalsIgnoreCase(name)) {
+        if (qualifiers.length == 1 && qualifiers[0] instanceof Identifier) {
+            if (((Identifier) qualifiers[0]).value().equalsIgnoreCase(name)) {
                 return this;
             }
         }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/fault/KafkaNackOnExpirationTimeFailureTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/fault/KafkaNackOnExpirationTimeFailureTest.java
@@ -1,8 +1,14 @@
 package io.smallrye.reactive.messaging.kafka.fault;
 
-import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
-import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
-import io.strimzi.StrimziKafkaContainer;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -10,13 +16,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.await;
+import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.strimzi.StrimziKafkaContainer;
 
 public class KafkaNackOnExpirationTimeFailureTest extends KafkaTestBase {
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/DeprecatedDeserializationFailureHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/DeprecatedDeserializationFailureHandlerTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.UUID;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;
@@ -15,7 +16,6 @@ import org.apache.kafka.common.serialization.DoubleSerializer;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.junit.jupiter.api.Test;
 
-import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler;
 import io.smallrye.reactive.messaging.kafka.KafkaConnector;
 import io.smallrye.reactive.messaging.kafka.Record;
@@ -26,7 +26,9 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 import io.vertx.kafka.client.serialization.JsonObjectSerializer;
 
-public class DeserializationFailureHandlerTest extends KafkaTestBase {
+// this entire file should be removed when support for the `@Named` annotation is removed
+
+public class DeprecatedDeserializationFailureHandlerTest extends KafkaTestBase {
 
     static JsonObject fallbackForValue = new JsonObject().put("fallback", "fallback");
     static JsonObject fallbackForKey = new JsonObject().put("fallback", "key");
@@ -112,7 +114,7 @@ public class DeserializationFailureHandlerTest extends KafkaTestBase {
     }
 
     @ApplicationScoped
-    @Identifier("key-fallback")
+    @Named("key-fallback")
     public static class MyKeyDeserializationFailureHandler implements DeserializationFailureHandler<JsonObject> {
 
         @Override
@@ -123,7 +125,7 @@ public class DeserializationFailureHandlerTest extends KafkaTestBase {
     }
 
     @ApplicationScoped
-    @Identifier("value-fallback")
+    @Named("value-fallback")
     public static class MyValueDeserializationFailureHandler implements DeserializationFailureHandler<JsonObject> {
         @Override
         public JsonObject handleDeserializationFailure(String topic, boolean isKey, String deserializer, byte[] data,

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
@@ -41,9 +41,11 @@ public class MediatorManager {
     WorkerPoolRegistry workerPoolRegistry;
 
     @Inject
+    // @Any would only be needed if we wanted to allow implementations with qualifiers
     Instance<PublisherDecorator> decorators;
 
     @Inject
+    // @Any would only be needed if we wanted to allow implementations with qualifiers
     Instance<MessageConverter> converters;
 
     private final List<EmitterConfiguration> emitters = new ArrayList<>();
@@ -56,6 +58,7 @@ public class MediatorManager {
     @Inject
     Wiring wiring;
     @Inject
+    // @Any would only be needed if we wanted to allow implementations with qualifiers
     Instance<ChannelRegistar> registars;
 
     @Inject

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderLogging.java
@@ -10,6 +10,7 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.Once;
 
 import io.smallrye.reactive.messaging.wiring.Wiring;
 
@@ -120,4 +121,8 @@ public interface ProviderLogging extends BasicLogger {
     @Message(id = 236, value = "Materialization completed in %d ns")
     void materializationCompleted(long duration);
 
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 237, value = "Use of @javax.inject.Named in Reactive Messaging is deprecated, use @io.smallrye.common.annotation.Identifier instead")
+    @Once
+    void deprecatedNamed();
 }


### PR DESCRIPTION
Support for `@Named` is retained, as well as a couple of tests,
but `@Identifier` is preferred now. At some point, support for
`@Named` should be removed altogether.

Resolves #1096 