### PR TITLE
Update Weld to 3.1.7.Final

### DIFF
--- a/documentation/src/main/doc/antora.yml
+++ b/documentation/src/main/doc/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
     attributes:
         version: '2.10'
         project-version: '2.10.0-SNAPSHOT'
-        weld-version: '3.1.3.Final'
+        weld-version: '3.1.7.Final'
         smallrye-config-version: '1.10.0'
         mutiny-version: '0.14.0'
         camel-version: '3.8.0'

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <vertx.version>3.9.6</vertx.version>
     <rxjava.version>2.2.21</rxjava.version>
     <cloudevent.version>1.1.0</cloudevent.version>
-    <weld.version>3.1.3.Final</weld.version>
+    <weld.version>3.1.7.Final</weld.version>
     <camel.version>3.8.0</camel.version>
 
     <microprofile-reactive-messaging.version>1.0</microprofile-reactive-messaging.version>


### PR DESCRIPTION
@cescoffier here is the promised Weld update that should avoid illegal reflective access warning. I know it won't solve your issues but hey, you'll have one less framework to blame ;-)