### PR TITLE
improve error handling in the AMQP connector

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -219,7 +219,10 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
 
         return ReactiveStreams.<Message<?>> builder()
                 .via(processor)
-                .onError(t -> opened.put(oc.getChannel(), false))
+                .onError(t -> {
+                    log.failureReported(oc.getChannel(), t);
+                    opened.put(oc.getChannel(), false);
+                })
                 .ignore();
     }
 


### PR DESCRIPTION
The outgoing part of the AMQP connector used to silently mark
the channel as closed in case of an error. Now, the error is
also properly logged.

Resolves #1125