### PR TITLE
[sr-rm-kafka] Add a `bean-discovery-mode` attribute into beans.xml

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-kafka/src/main/resources/META-INF/beans.xml
@@ -3,6 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
       http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+  bean-discovery-mode="annotated">
 
 </beans>


### PR DESCRIPTION
To comply with the XSD definition file of beans.xml [1].

This change is motivated with a warning message present in WildFly
from the Weld subsystem after incorporating SmallRye ReactiveMessaging
project, see [2].

[1] http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd
[2] https://issues.redhat.com/browse/WFLY-14643

Note: there are much more `beans.xml` files that would deserve such update. My intention was to make this as small change as possible. Please, let me know whether you feel this is okay for you.