### PR TITLE
Provide access to the low-level Kafka client

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaClientService.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaClientService.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.kafka;
 
+import org.apache.kafka.clients.producer.Producer;
+
 import io.smallrye.common.annotation.Experimental;
 
 @Experimental("experimental api")
@@ -7,6 +9,14 @@ public interface KafkaClientService {
 
     /**
      * Gets the managed Kafka Consumer for the given channel.
+     * This method returns the reactive consumer.
+     * <p>
+     * Be aware that most actions requires to be run on the Kafka polling thread.
+     * You can schedule actions using:
+     * <p>
+     * {@code getConsumer(channel).runOnPollingThread(c -> { ... })}
+     * <p>
+     * You can retrieve the <em>low-level</em> client using the {@link KafkaConsumer#unwrap()} method.
      *
      * @param channel the channel, must not be {@code null}
      * @param <K> the type of the key
@@ -14,5 +24,15 @@ public interface KafkaClientService {
      * @return the consumer, {@code null} if not found
      */
     <K, V> KafkaConsumer<K, V> getConsumer(String channel);
+
+    /**
+     * Gets the managed Kafka Producer for the given channel.
+     *
+     * @param channel the channel, must not be {@code null}
+     * @param <K> the type of the key
+     * @param <V> the type of the value
+     * @return the producer, {@code null} if not found
+     */
+    <K, V> Producer<K, V> getProducer(String channel);
 
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -23,6 +23,7 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.literal.NamedLiteral;
 import javax.inject.Inject;
 
+import org.apache.kafka.clients.producer.Producer;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -106,7 +107,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "cloud-events-mode", type = "string", direction = Direction.OUTGOING, description = "The Cloud Event mode (`structured` or `binary` (default)). Indicates how are written the cloud events in the outgoing record", defaultValue = "binary")
 @ConnectorAttribute(name = "close-timeout", type = "int", direction = Direction.OUTGOING, description = "The amount of milliseconds waiting for a graceful shutdown of the Kafka producer", defaultValue = "10000")
 @ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
-public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnectorFactory, HealthReporter, KafkaClientService {
+public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnectorFactory, HealthReporter {
 
     public static final String CONNECTOR_NAME = "smallrye-kafka";
 
@@ -330,4 +331,11 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
                 .findFirst().orElse(null);
     }
 
+    @SuppressWarnings("unchecked")
+    public <K, V> Producer<K, V> getProducer(String channel) {
+        return (Producer<K, V>) sinks.stream()
+                .filter(ks -> ks.getChannel().equals(channel))
+                .map(KafkaSink::getProducer)
+                .findFirst().orElse(null);
+    }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaClientServiceImpl.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaClientServiceImpl.java
@@ -1,8 +1,11 @@
 package io.smallrye.reactive.messaging.kafka.impl;
 
+import java.util.Objects;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.apache.kafka.clients.producer.Producer;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
 
 import io.smallrye.reactive.messaging.kafka.KafkaClientService;
@@ -18,6 +21,11 @@ public class KafkaClientServiceImpl implements KafkaClientService {
 
     @Override
     public <K, V> KafkaConsumer<K, V> getConsumer(String channel) {
-        return connector.getConsumer(channel);
+        return connector.getConsumer(Objects.requireNonNull(channel));
+    }
+
+    @Override
+    public <K, V> Producer<K, V> getProducer(String channel) {
+        return connector.getProducer(Objects.requireNonNull(channel));
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
@@ -8,6 +8,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.*;
@@ -402,4 +403,7 @@ public class KafkaSink {
         return configuration.getChannel();
     }
 
+    public Producer<?, ?> getProducer() {
+        return stream.unwrap();
+    }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.kafka;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
@@ -194,6 +195,11 @@ public class KafkaSinkTest extends KafkaTestBase {
         assertThat(readiness.getChannels()).hasSize(1);
         assertThat(liveness.getChannels().get(0).getChannel()).isEqualTo("output");
         assertThat(readiness.getChannels().get(0).getChannel()).isEqualTo("output");
+
+        KafkaClientService service = get(KafkaClientService.class);
+        assertThat(service.getProducer("output")).isNotNull();
+        assertThat(service.getProducer("missing")).isNull();
+        assertThatThrownBy(() -> service.getProducer(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -348,6 +348,11 @@ public class KafkaSourceTest extends KafkaTestBase {
         assertThat(readiness.getChannels()).hasSize(1);
         assertThat(liveness.getChannels().get(0).getChannel()).isEqualTo("data");
         assertThat(readiness.getChannels().get(0).getChannel()).isEqualTo("data");
+
+        KafkaClientService service = get(KafkaClientService.class);
+        assertThat(service.getConsumer("data")).isNotNull();
+        assertThat(service.getConsumer("missing")).isNull();
+        assertThatThrownBy(() -> service.getConsumer(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test


### PR DESCRIPTION
Fix #955

This is done using the `io.smallrye.reactive.messaging.kafka.KafkaClientService` (experimental API for now, so not documented on purpose). 