### PR TITLE
manage Kafka sending thread manually instead of using Vert.x Kafka client

### DIFF
--- a/documentation/src/main/doc/modules/kafka/pages/client-service.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/client-service.adoc
@@ -9,16 +9,17 @@ For advanced use cases, SmallRye Reactive Messaging provides a bean of type `Kaf
 KafkaClientService kafka;
 ----
 
-From there, you can obtain an `org.apache.kafka.clients.producer.Producer` and an `io.smallrye.reactive.messaging.kafka.KafkaConsumer`.
+From there, you can obtain an `io.smallrye.reactive.messaging.kafka.KafkaProducer` and an `io.smallrye.reactive.messaging.kafka.KafkaConsumer`.
 
-The Kafka `Producer` is thread safe and may be used from multiple threads, so SmallRye Reactive Messaging exposes it directly.
+`KafkaProducer` and `KafkaConsumer` expose a non-blocking API on top of the Kafka client API.
+They also mediate access to the threads that SmallRye Reactive Messaging uses to run all Kafka operations: the _polling thread_, used for consuming records from Kafka topics, and the _sending thread_, used for producing records to Kafka topics.
+(Just to be clear: each _channel_ has its own polling thread and sending thread.)
 
-The Kafka `Consumer`, on the other hand, is _not_ thread safe.
-For that reason, SmallRye Reactive Messaging runs all Kafka consumption operations on a single thread, called _polling thread_.
-(Just to be clear: each _channel_ has its own polling thread.)
-Access to this polling thread is mediated by the `KafkaConsumer`.
-It exposes common `Consumer` operations with an asynchronous API, so it can be used from arbitrary application threads.
+The reason why SmallRye Reactive Messaging uses a special thread to run the poll loop should be obvious: the `Consumer` API is blocking.
+The `Producer` API, on the other hand, is documented to be non-blocking.
+However, in present versions, Kafka doesn't guarantee that in all cases; see link:https://issues.apache.org/jira/browse/KAFKA-3539[KAFKA-3539] for more details.
+That is why SmallRye Reactive Messaging uses a dedicated thread to run the send operations as well.
 
-Sometimes, SmallRye Reactive Messaging provides direct access to the Kafka `Consumer`.
+Sometimes, SmallRye Reactive Messaging provides direct access to the Kafka `Producer` or `Consumer`.
 For example, a <<kafka-consumer-rebalance-listener,`KafkaConsumerRebalanceListener`>> methods are always invoked on the polling thread, so they give you direct access to `Consumer`.
-In such case, you should use the synchronous `Consumer` API directly, instead of using the asynchronous `KafkaConsumer` API.
+In such case, you should use the `Producer`/`Consumer` API directly, instead of the `KafkaProducer`/`KafkaConsumer` API.

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaClientService.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaClientService.java
@@ -1,7 +1,5 @@
 package io.smallrye.reactive.messaging.kafka;
 
-import org.apache.kafka.clients.producer.Producer;
-
 import io.smallrye.common.annotation.Experimental;
 
 @Experimental("experimental api")
@@ -27,12 +25,20 @@ public interface KafkaClientService {
 
     /**
      * Gets the managed Kafka Producer for the given channel.
+     * This method returns the reactive producer.
+     * <p>
+     * Be aware that most actions require to be run on the Kafka sending thread.
+     * You can schedule actions using:
+     * <p>
+     * {@code getProducer(channel).runOnSendingThread(c -> { ... })}
+     * <p>
+     * You can retrieve the <em>low-level</em> client using the {@link KafkaProducer#unwrap()} method.
      *
      * @param channel the channel, must not be {@code null}
      * @param <K> the type of the key
      * @param <V> the type of the value
      * @return the producer, {@code null} if not found
      */
-    <K, V> Producer<K, V> getProducer(String channel);
+    <K, V> KafkaProducer<K, V> getProducer(String channel);
 
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -23,7 +23,6 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.literal.NamedLiteral;
 import javax.inject.Inject;
 
-import org.apache.kafka.clients.producer.Producer;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -332,8 +331,8 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     }
 
     @SuppressWarnings("unchecked")
-    public <K, V> Producer<K, V> getProducer(String channel) {
-        return (Producer<K, V>) sinks.stream()
+    public <K, V> KafkaProducer<K, V> getProducer(String channel) {
+        return (KafkaProducer<K, V>) sinks.stream()
                 .filter(ks -> ks.getChannel().equals(channel))
                 .map(KafkaSink::getProducer)
                 .findFirst().orElse(null);

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumer.java
@@ -27,9 +27,9 @@ public interface KafkaConsumer<K, V> {
      * <p>
      * The action is a function taking as parameter the {@link Consumer} and that returns a result (potentially {@code null}).
      * The produced {@link Uni} emits the returned result when the action completes. If the action throws an exception,
-     * the produced using emits the exception as failure.
+     * the produced {@code Uni} emits the exception as failure.
      * <p>
-     * If the action does not return a result, use {@link #runOnPollingThread(Consumer)}.
+     * If the action does not return a result, use {@link #runOnPollingThread(java.util.function.Consumer)}.
      *
      * @param action the action to execute, must not be {@code null}
      * @param <R> the type of result, can be {@code Void}
@@ -42,7 +42,7 @@ public interface KafkaConsumer<K, V> {
      * <p>
      * The action is a consumer receiving the {@link Consumer}.
      * The produced {@link Uni} emits {@code null} when the action completes. If the action throws an exception,
-     * the produced using emits the exception as failure.
+     * the produced {@code Uni} emits the exception as failure.
      *
      * @param action the action, must not be {@code null}
      * @return the Uni emitting {@code null} or the failure when the action completes.

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaProducer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaProducer.java
@@ -1,0 +1,81 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.PartitionInfo;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Kafka Producer API.
+ * <p>
+ * Unlike {@link org.apache.kafka.clients.producer.KafkaProducer}, this API is guaranteed to be asynchronous.
+ * Note that even though the {@code org.apache.kafka.clients.producer.KafkaProducer} is documented to be asynchronous,
+ * it actually may block in some cases; see <a href="https://issues.apache.org/jira/browse/KAFKA-3539">KAFKA-3539</a>
+ * for more info.
+ * </p>
+ * <p>
+ * The way asynchrony is guaranteed here is an implementation detail. Currently, the sending actions are executed
+ * on a special <em>sending</em> thread, but when KAFKA-3539 is fixed, the implementation may become just a simple
+ * wrapper providing a {@code Uni} API.
+ * </p>
+ *
+ * @param <K> the type of key
+ * @param <V> the type of value
+ */
+public interface KafkaProducer<K, V> {
+    /**
+     * Runs an action on the sending thread.
+     * <p>
+     * The action is a function taking as parameter the {@link Producer} and that returns a result (potentially {@code null}).
+     * The produced {@link Uni} emits the returned result when the action completes. If the action throws an exception,
+     * the produced {@code Uni} emits the exception as failure.
+     * <p>
+     * If the action does not return a result, use {@link #runOnSendingThread(java.util.function.Consumer)}.
+     *
+     * @param action the action to execute, must not be {@code null}
+     * @param <R> the type of result, can be {@code Void}
+     * @return the Uni emitting the result or the failure when the action completes.
+     */
+    <R> Uni<R> runOnSendingThread(Function<Producer<K, V>, R> action);
+
+    /**
+     * Runs an action on the sending thread.
+     * <p>
+     * The action is a consumer receiving the {@link Producer}.
+     * The produced {@link Uni} emits {@code null} when the action completes. If the action throws an exception,
+     * the produced {@code Uni} emits the exception as failure.
+     *
+     * @param action the action, must not be {@code null}
+     * @return the Uni emitting {@code null} or the failure when the action completes.
+     */
+    Uni<Void> runOnSendingThread(java.util.function.Consumer<Producer<K, V>> action);
+
+    /**
+     * Send a record to a topic. The returned {@link Uni} completes with {@link RecordMetadata} when the send
+     * has been acknowledged, or with an exception in case of an error.
+     */
+    Uni<RecordMetadata> send(ProducerRecord<K, V> record);
+
+    /**
+     * Sends all buffered records immediately. The returned {@link Uni} completes when all requests belonging
+     * to the buffered records complete. In other words, when the returned {@code Uni} completes, all
+     * previous {@link #send(ProducerRecord)} operations are known to be complete as well.
+     * No guarantee is made about the completion of records sent after {@code flush} was called.
+     */
+    Uni<Void> flush();
+
+    /**
+     * Returns a list of partition metadata for given topic.
+     */
+    Uni<List<PartitionInfo>> partitionsFor(String topic);
+
+    /**
+     * @return the underlying producer. Be aware that to use it you needs to be on the sending thread.
+     */
+    Producer<K, V> unwrap();
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -101,7 +101,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
 
     /**
      * New partitions are assigned.
-     * This method is called from the Kafka pool thread.
+     * This method is called from the Kafka poll thread.
      *
      * @param partitions the list of partitions that are now assigned to the consumer
      *        (may include partitions previously assigned to the consumer)

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSinkReadinessHealth.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSinkReadinessHealth.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.kafka.health;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -22,14 +23,15 @@ public class KafkaSinkReadinessHealth extends BaseHealth {
     private final String topic;
 
     public KafkaSinkReadinessHealth(Vertx vertx, KafkaConnectorOutgoingConfiguration config,
-            Map<String, Object> kafkaConfiguration, Producer<?, ?> producer) {
+            Map<String, ?> kafkaConfiguration, Producer<?, ?> producer) {
         super(config.getChannel());
         this.topic = config.getTopic().orElse(config.getChannel());
         this.config = config;
 
         if (config.getHealthReadinessTopicVerification()) {
             // Do not create the client if the readiness health checks are disabled
-            this.admin = KafkaAdminHelper.createAdminClient(vertx, kafkaConfiguration, config.getChannel(), true);
+            Map<String, Object> adminConfiguration = new HashMap<>(kafkaConfiguration);
+            this.admin = KafkaAdminHelper.createAdminClient(vertx, adminConfiguration, config.getChannel(), true);
             this.metric = null;
         } else {
             this.admin = null;

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaExceptions.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaExceptions.java
@@ -56,4 +56,6 @@ public interface KafkaExceptions {
     @Message(id = 18012, value = "Unable to select the DeserializationFailureHandler named `%s` for channel `%s` - too many matches (%d)")
     AmbiguousResolutionException unableToFindDeserializationFailureHandler(String name, String channel, int count);
 
+    @Message(id = 18013, value = "Cannot configure the Kafka producer for channel `%s` - the `mp.messaging.outgoing.%s.value.serializer` property is missing")
+    IllegalArgumentException missingValueSerializer(String channel, String channelAgain);
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -210,4 +210,7 @@ public interface KafkaLogging extends BasicLogger {
     @Message(id = 18247, value = "Resuming Kafka consumption for channel %s")
     void resumingChannel(String channel);
 
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18248, value = "Key serializer omitted, using String as default")
+    void keySerializerOmitted();
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
@@ -75,7 +75,7 @@ public class ConfigurationCleaner {
         return json;
     }
 
-    public static void cleanupProducerConfiguration(Map<String, String> json) {
+    public static void cleanupProducerConfiguration(Map<String, ?> json) {
         for (String key : COMMON) {
             json.remove(key);
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaClientServiceImpl.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaClientServiceImpl.java
@@ -5,12 +5,12 @@ import java.util.Objects;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.apache.kafka.clients.producer.Producer;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
 
 import io.smallrye.reactive.messaging.kafka.KafkaClientService;
 import io.smallrye.reactive.messaging.kafka.KafkaConnector;
 import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
+import io.smallrye.reactive.messaging.kafka.KafkaProducer;
 
 @ApplicationScoped
 public class KafkaClientServiceImpl implements KafkaClientService {
@@ -25,7 +25,7 @@ public class KafkaClientServiceImpl implements KafkaClientService {
     }
 
     @Override
-    public <K, V> Producer<K, V> getProducer(String channel) {
+    public <K, V> KafkaProducer<K, V> getProducer(String channel) {
         return connector.getProducer(Objects.requireNonNull(channel));
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSendingThread.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSendingThread.java
@@ -1,0 +1,12 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class KafkaSendingThread extends Thread {
+
+    private static final AtomicInteger threadCount = new AtomicInteger(0);
+
+    public KafkaSendingThread(Runnable runnable) {
+        super(runnable, "smallrye-kafka-producer-thread-" + threadCount.getAndIncrement());
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaProducer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaProducer.java
@@ -1,0 +1,191 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import static io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions.ex;
+import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Utils;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorOutgoingConfiguration;
+import io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions;
+import io.vertx.core.Context;
+
+public class ReactiveKafkaProducer<K, V> implements io.smallrye.reactive.messaging.kafka.KafkaProducer<K, V> {
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private Producer<K, V> producer;
+    private final KafkaConnectorOutgoingConfiguration configuration;
+
+    private final ExecutorService kafkaWorker;
+    private final Map<String, Object> kafkaConfiguration;
+
+    public ReactiveKafkaProducer(KafkaConnectorOutgoingConfiguration config) {
+        this.configuration = config;
+        kafkaConfiguration = getKafkaProducerConfiguration(configuration);
+
+        String keySerializerCN = (String) kafkaConfiguration.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG);
+        String valueSerializerCN = (String) kafkaConfiguration.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG);
+
+        if (valueSerializerCN == null) {
+            throw ex.missingValueSerializer(config.getChannel(), config.getChannel());
+        }
+
+        Serializer<K> keySerializer = createSerializer(keySerializerCN);
+        Serializer<V> valueSerializer = createSerializer(valueSerializerCN);
+
+        // Configure the underlying serializers
+        configureSerializer(keySerializer, kafkaConfiguration, true);
+        configureSerializer(valueSerializer, kafkaConfiguration, false);
+
+        kafkaWorker = Executors.newSingleThreadExecutor(KafkaSendingThread::new);
+        producer = new KafkaProducer<>(kafkaConfiguration, keySerializer, valueSerializer);
+    }
+
+    private static <T> Serializer<T> createSerializer(String clazz) {
+        try {
+            return (Serializer<T>) Utils.newInstance(clazz, Serializer.class);
+        } catch (ClassNotFoundException e) {
+            throw KafkaExceptions.ex.unableToCreateInstance(clazz, e);
+        }
+    }
+
+    private static void configureSerializer(Serializer<?> serializer, Map<String, Object> config, boolean isKey) {
+        try {
+            serializer.configure(config, isKey);
+        } catch (Exception e) {
+            throw new KafkaException(e);
+        }
+    }
+
+    @Override
+    public <T> Uni<T> runOnSendingThread(Function<Producer<K, V>, T> action) {
+        return Uni.createFrom().item(() -> action.apply(producer))
+                .runSubscriptionOn(kafkaWorker);
+    }
+
+    @Override
+    public Uni<Void> runOnSendingThread(java.util.function.Consumer<Producer<K, V>> action) {
+        return Uni.createFrom().<Void> item(() -> {
+            action.accept(producer);
+            return null;
+        }).runSubscriptionOn(kafkaWorker);
+    }
+
+    @Override
+    public Uni<RecordMetadata> send(ProducerRecord<K, V> record) {
+        return Uni.createFrom().<RecordMetadata> emitter(em -> {
+            producer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    if (record.topic() != null) {
+                        log.unableToWrite(configuration.getChannel(), record.topic(), exception);
+                    } else {
+                        log.unableToWrite(configuration.getChannel(), exception);
+                    }
+                    em.fail(exception);
+                } else {
+                    em.complete(metadata);
+                }
+            });
+        }).runSubscriptionOn(kafkaWorker);
+    }
+
+    @Override
+    public Uni<Void> flush() {
+        return runOnSendingThread(producer -> {
+            producer.flush();
+        });
+    }
+
+    @Override
+    public Uni<List<PartitionInfo>> partitionsFor(String topic) {
+        return runOnSendingThread(producer -> {
+            return producer.partitionsFor(topic);
+        });
+    }
+
+    private Map<String, Object> getKafkaProducerConfiguration(KafkaConnectorOutgoingConfiguration configuration) {
+        Map<String, Object> map = new HashMap<>();
+        JsonHelper.asJsonObject(configuration.config())
+                .forEach(e -> map.put(e.getKey(), e.getValue().toString()));
+
+        // Acks must be a string, even when "1".
+        map.put(ProducerConfig.ACKS_CONFIG, configuration.getAcks());
+
+        if (!map.containsKey(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)) {
+            log.configServers(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, configuration.getBootstrapServers());
+            map.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, configuration.getBootstrapServers());
+        }
+
+        if (!map.containsKey(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)) {
+            log.keySerializerOmitted();
+            map.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, configuration.getKeySerializer());
+        }
+
+        if (!map.containsKey(ProducerConfig.CLIENT_ID_CONFIG)) {
+            String id = "kafka-producer-" + configuration.getChannel();
+            log.setKafkaProducerClientId(id);
+            map.put(ProducerConfig.CLIENT_ID_CONFIG, id);
+        }
+
+        if (!map.containsKey(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG)) {
+            // If no backoff is set, use 10s, it avoids high load on disconnection.
+            map.put(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, "10000");
+        }
+
+        ConfigurationCleaner.cleanupProducerConfiguration(map);
+
+        return map;
+    }
+
+    public String get(String attribute) {
+        return (String) kafkaConfiguration.get(attribute);
+    }
+
+    @Override
+    public Producer<K, V> unwrap() {
+        return producer;
+    }
+
+    public Map<String, ?> configuration() {
+        return kafkaConfiguration;
+    }
+
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            int timeout = configuration.getCloseTimeout();
+            Uni<Void> uni = runOnSendingThread(p -> {
+                p.close(Duration.ofMillis(timeout));
+            }).onItem().invoke(kafkaWorker::shutdown);
+
+            if (Context.isOnEventLoopThread()) {
+                // We can't block, just forget the result
+                uni.subscribeAsCompletionStage();
+            } else {
+                uni.await().atMost(Duration.ofMillis(timeout * 2L));
+            }
+        }
+    }
+
+    boolean isClosed() {
+        return closed.get();
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ClientTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ClientTestBase.java
@@ -36,11 +36,16 @@ public class ClientTestBase extends KafkaTestBase {
 
     public Map<String, Object> producerProps() {
         Map<String, Object> props = new HashMap<>();
+        props.put("tracing-enabled", false);
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
         props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, String.valueOf(requestTimeoutMillis));
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         return props;
+    }
+
+    public MapBasedConfig createProducerConfig() {
+        return new MapBasedConfig(producerProps());
     }
 
     protected MapBasedConfig createConsumerConfig(String groupId) {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaProducerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaProducerTest.java
@@ -1,0 +1,248 @@
+package io.smallrye.reactive.messaging.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.MultiEmitter;
+import io.smallrye.reactive.messaging.kafka.CountKafkaCdiEvents;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorOutgoingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaRecord;
+import io.smallrye.reactive.messaging.kafka.base.TopicHelpers;
+import io.smallrye.reactive.messaging.kafka.impl.KafkaSink;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class ReactiveKafkaProducerTest extends ClientTestBase {
+    private Queue<KafkaSink> sinks;
+
+    @BeforeEach
+    public void init() {
+        sinks = new ConcurrentLinkedQueue<>();
+        topic = TopicHelpers.createNewTopic("test-" + UUID.randomUUID(), partitions);
+        resetMessages();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        for (KafkaSink sink : sinks) {
+            sink.closeQuietly();
+        }
+    }
+
+    @Test
+    public void independentProducerSingleThreadSingleKey() throws InterruptedException {
+        // can pass either `true` or `false` as the last argument, doesn't make a difference
+        independentProducerTest(1, 400, false);
+    }
+
+    @Test
+    public void independentProducerMultipleThreadsSingleKey() throws InterruptedException {
+        independentProducerTest(4, 100, false);
+    }
+
+    @Test
+    public void independentProducerMultipleThreadsMultipleKeys() throws InterruptedException {
+        independentProducerTest(4, 100, true);
+    }
+
+    private void independentProducerTest(int numberOfThreads, int numberOfMessagesPerThread,
+            boolean uniqueKeyPerThread) throws InterruptedException {
+        Queue<String> messages = new ConcurrentLinkedQueue<>();
+
+        CountDownLatch doneLatch = new CountDownLatch(1);
+
+        usage.consumeCount(topic, numberOfThreads * numberOfMessagesPerThread, 1, TimeUnit.MINUTES,
+                doneLatch::countDown, new IntegerDeserializer(), new StringDeserializer(), (k, v) -> {
+                    messages.add(v);
+                });
+
+        Queue<Thread> threads = new ConcurrentLinkedQueue<>();
+        for (int i = 0; i < numberOfThreads; i++) {
+            IndependentProducerThread thread = new IndependentProducerThread("T" + i, uniqueKeyPerThread ? i : 1,
+                    numberOfMessagesPerThread);
+            threads.add(thread);
+            thread.start();
+        }
+
+        boolean done = doneLatch.await(1, TimeUnit.MINUTES);
+        assertThat(done).isTrue();
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            assertThat(messages).containsSubsequence(expectedMessages("T" + i, numberOfMessagesPerThread));
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
+
+    @Test
+    public void sharedProducerSingleThreadSingleKey() throws InterruptedException {
+        // can pass either `true` or `false` as the last argument, doesn't make a difference
+        sharedProducerTest(1, 400, false);
+    }
+
+    @Test
+    public void sharedProducerMultipleThreadsSingleKey() throws InterruptedException {
+        sharedProducerTest(4, 100, false);
+    }
+
+    @Test
+    public void sharedProducerMultipleThreadsMultipleKeys() throws InterruptedException {
+        sharedProducerTest(4, 100, true);
+    }
+
+    private void sharedProducerTest(int numberOfThreads, int numberOfMessagesPerThread,
+            boolean uniqueKeyPerThread) throws InterruptedException {
+        Queue<String> messages = new ConcurrentLinkedQueue<>();
+
+        CountDownLatch doneLatch = new CountDownLatch(1);
+
+        usage.consumeCount(topic, numberOfThreads * numberOfMessagesPerThread, 1, TimeUnit.MINUTES,
+                doneLatch::countDown, new IntegerDeserializer(), new StringDeserializer(), (k, v) -> {
+                    messages.add(v);
+                });
+
+        Queue<Thread> threads = new ConcurrentLinkedQueue<>();
+        Queue<Multi<Message<?>>> multis = new ConcurrentLinkedQueue<>();
+        for (int i = 0; i < numberOfThreads; i++) {
+            int finalI = i;
+            Multi<Message<?>> multi = Multi.createFrom().emitter(em -> {
+                SharedProducerThread thread = new SharedProducerThread("T" + finalI, uniqueKeyPerThread ? finalI : 1,
+                        numberOfMessagesPerThread, (MultiEmitter<Message<?>>) em);
+                threads.add(thread);
+                thread.start();
+            });
+            multis.add(multi);
+        }
+
+        Thread actualProducer = new Thread(() -> {
+            Multi<Message<?>> merge = Multi.createBy().merging().streams(multis);
+            Subscriber<Message<?>> subscriber = (Subscriber<Message<?>>) createSink().getSink().build();
+            merge.subscribe().withSubscriber(subscriber);
+        });
+        threads.add(actualProducer);
+        actualProducer.start();
+
+        boolean done = doneLatch.await(1, TimeUnit.MINUTES);
+        assertThat(done).isTrue();
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            assertThat(messages).containsSubsequence(expectedMessages("T" + i, numberOfMessagesPerThread));
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
+
+    private List<String> expectedMessages(String threadId, int count) {
+        List<String> result = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            result.add(threadId + ":M" + i);
+        }
+        return result;
+    }
+
+    public KafkaSink createSink() {
+        MapBasedConfig config = createProducerConfig()
+                .put("channel-name", "test-" + ThreadLocalRandom.current().nextInt())
+                .put("topic", topic);
+
+        KafkaSink sink = new KafkaSink(vertx, new KafkaConnectorOutgoingConfiguration(config),
+                CountKafkaCdiEvents.noCdiEvents);
+        this.sinks.add(sink);
+        return sink;
+    }
+
+    private class IndependentProducerThread extends Thread {
+        private final String threadId;
+        private final int messageKey; // used for all messages produced by this thread, to guarantee ordering
+        private final int messageCount;
+
+        IndependentProducerThread(String threadId, int messageKey, int messageCount) {
+            this.threadId = threadId;
+            this.messageKey = messageKey;
+            this.messageCount = messageCount;
+            this.setName(ReactiveKafkaProducerTest.class.getSimpleName() + "-" + threadId);
+        }
+
+        @Override
+        public void run() {
+            try {
+                Thread.sleep(ThreadLocalRandom.current().nextInt(20));
+            } catch (InterruptedException e) {
+                return;
+            }
+
+            Multi<Message<?>> stream = Multi.createFrom().emitter(emitter -> {
+                for (int i = 0; i < messageCount; i++) {
+                    emitter.emit(KafkaRecord.of(messageKey, threadId + ":M" + i));
+
+                    try {
+                        Thread.sleep(ThreadLocalRandom.current().nextInt(20));
+                    } catch (InterruptedException e) {
+                        break;
+                    }
+                }
+
+                emitter.complete();
+            });
+
+            Subscriber<Message<?>> subscriber = (Subscriber<Message<?>>) createSink().getSink().build();
+            stream.subscribe().withSubscriber(subscriber);
+        }
+    }
+
+    private static class SharedProducerThread extends Thread {
+        private final String threadId;
+        private final int messageKey; // used for all messages produced by this thread, to guarantee ordering
+        private final int messageCount;
+        private final MultiEmitter<Message<?>> emitter;
+
+        SharedProducerThread(String threadId, int messageKey, int messageCount, MultiEmitter<Message<?>> emitter) {
+            this.threadId = threadId;
+            this.messageKey = messageKey;
+            this.messageCount = messageCount;
+            this.emitter = emitter;
+            this.setName(ReactiveKafkaProducerTest.class.getSimpleName() + "-" + threadId);
+        }
+
+        @Override
+        public void run() {
+            try {
+                Thread.sleep(ThreadLocalRandom.current().nextInt(20));
+            } catch (InterruptedException e) {
+                return;
+            }
+
+            for (int i = 0; i < messageCount; i++) {
+                emitter.emit(KafkaRecord.of(messageKey, threadId + ":M" + i));
+
+                try {
+                    Thread.sleep(ThreadLocalRandom.current().nextInt(20));
+                } catch (InterruptedException e) {
+                    break;
+                }
+            }
+
+            emitter.complete();
+        }
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/PerformanceProducerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/PerformanceProducerTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -27,7 +28,8 @@ import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
 
 public class PerformanceProducerTest extends KafkaTestBase {
 
-    private static final int COUNT = 100000;
+    private static final int COUNT = 100_000;
+    private static final int TIMEOUT_IN_MINUTES = 1;
 
     @Test
     public void testDefault() throws InterruptedException {
@@ -51,12 +53,12 @@ public class PerformanceProducerTest extends KafkaTestBase {
         long begin = System.currentTimeMillis();
         bean.run();
         await()
-                .atMost(Duration.ofMinutes(1))
-                .until(() -> bean.list().size() == COUNT);
+                .atMost(Duration.ofMinutes(TIMEOUT_IN_MINUTES))
+                .until(() -> bean.count() == COUNT);
         long end = System.currentTimeMillis();
 
         // Wait until all the messages are read.
-        receptionDone.await(1, TimeUnit.MINUTES);
+        receptionDone.await(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
 
         long duration = end - begin;
         System.out.println("Time " + duration + " ms");
@@ -70,7 +72,7 @@ public class PerformanceProducerTest extends KafkaTestBase {
         createTopic(topic, 10);
         CountDownLatch receptionDone = new CountDownLatch(1);
         List<Integer> received = Collections.synchronizedList(new ArrayList<>());
-        usage.consumeIntegers(topic, COUNT, 1, TimeUnit.MINUTES, receptionDone::countDown, (s, v) -> {
+        usage.consumeIntegers(topic, COUNT, TIMEOUT_IN_MINUTES, TimeUnit.MINUTES, receptionDone::countDown, (s, v) -> {
             received.add(v);
         });
 
@@ -86,12 +88,12 @@ public class PerformanceProducerTest extends KafkaTestBase {
         long begin = System.currentTimeMillis();
         bean.run();
         await()
-                .atMost(Duration.ofMinutes(1))
-                .until(() -> bean.list().size() == COUNT);
+                .atMost(Duration.ofMinutes(TIMEOUT_IN_MINUTES))
+                .until(() -> bean.count() == COUNT);
         long end = System.currentTimeMillis();
 
         // Wait until all the messages are read.
-        receptionDone.await(1, TimeUnit.MINUTES);
+        receptionDone.await(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
 
         long duration = end - begin;
         System.out.println("Time " + duration + " ms");
@@ -105,7 +107,7 @@ public class PerformanceProducerTest extends KafkaTestBase {
         createTopic(topic, 10);
         CountDownLatch receptionDone = new CountDownLatch(1);
         List<Integer> received = Collections.synchronizedList(new ArrayList<>());
-        usage.consumeIntegers(topic, COUNT, 1, TimeUnit.MINUTES, receptionDone::countDown, (s, v) -> {
+        usage.consumeIntegers(topic, COUNT, TIMEOUT_IN_MINUTES, TimeUnit.MINUTES, receptionDone::countDown, (s, v) -> {
             received.add(v);
         });
 
@@ -122,12 +124,12 @@ public class PerformanceProducerTest extends KafkaTestBase {
         long begin = System.currentTimeMillis();
         bean.run();
         await()
-                .atMost(Duration.ofMinutes(1))
-                .until(() -> bean.list().size() == COUNT);
+                .atMost(Duration.ofMinutes(TIMEOUT_IN_MINUTES))
+                .until(() -> bean.count() == COUNT);
         long end = System.currentTimeMillis();
 
         // Wait until all the messages are read.
-        receptionDone.await(1, TimeUnit.MINUTES);
+        receptionDone.await(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
 
         long duration = end - begin;
         System.out.println("Time " + duration + " ms");
@@ -141,7 +143,7 @@ public class PerformanceProducerTest extends KafkaTestBase {
         createTopic(topic, 10);
         CountDownLatch receptionDone = new CountDownLatch(1);
         List<Integer> received = Collections.synchronizedList(new ArrayList<>());
-        usage.consumeIntegers(topic, COUNT, 1, TimeUnit.MINUTES, receptionDone::countDown, (s, v) -> {
+        usage.consumeIntegers(topic, COUNT, TIMEOUT_IN_MINUTES, TimeUnit.MINUTES, receptionDone::countDown, (s, v) -> {
             received.add(v);
         });
 
@@ -159,12 +161,12 @@ public class PerformanceProducerTest extends KafkaTestBase {
         long begin = System.currentTimeMillis();
         bean.run();
         await()
-                .atMost(Duration.ofMinutes(1))
-                .until(() -> bean.list().size() == COUNT);
+                .atMost(Duration.ofMinutes(TIMEOUT_IN_MINUTES))
+                .until(() -> bean.count() == COUNT);
         long end = System.currentTimeMillis();
 
         // Wait until all the messages are read.
-        receptionDone.await(1, TimeUnit.MINUTES);
+        receptionDone.await(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
 
         long duration = end - begin;
         System.out.println("Time " + duration + " ms");
@@ -178,7 +180,7 @@ public class PerformanceProducerTest extends KafkaTestBase {
         createTopic(topic, 10);
         CountDownLatch receptionDone = new CountDownLatch(1);
         List<Integer> received = Collections.synchronizedList(new ArrayList<>());
-        usage.consumeIntegers(topic, COUNT, 1, TimeUnit.MINUTES, receptionDone::countDown, (s, v) -> {
+        usage.consumeIntegers(topic, COUNT, TIMEOUT_IN_MINUTES, TimeUnit.MINUTES, receptionDone::countDown, (s, v) -> {
             received.add(v);
         });
 
@@ -195,12 +197,12 @@ public class PerformanceProducerTest extends KafkaTestBase {
         long begin = System.currentTimeMillis();
         bean.run();
         await()
-                .atMost(Duration.ofMinutes(1))
-                .until(() -> bean.list().size() == COUNT);
+                .atMost(Duration.ofMinutes(TIMEOUT_IN_MINUTES))
+                .until(() -> bean.count() == COUNT);
         long end = System.currentTimeMillis();
 
         // Wait until all the messages are read.
-        receptionDone.await(1, TimeUnit.MINUTES);
+        receptionDone.await(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
 
         long duration = end - begin;
         System.out.println("Time " + duration + " ms");
@@ -211,7 +213,7 @@ public class PerformanceProducerTest extends KafkaTestBase {
     @ApplicationScoped
     public static class GeneratorBean {
 
-        private final List<Integer> acked = Collections.synchronizedList(new ArrayList<>());
+        private final LongAdder counter = new LongAdder();
 
         @Inject
         @Channel("kafka")
@@ -222,15 +224,15 @@ public class PerformanceProducerTest extends KafkaTestBase {
             for (int i = 0; i < COUNT; i++) {
                 int v = i;
                 Message<Integer> message = Message.of(v, () -> {
-                    acked.add(v);
+                    counter.increment();
                     return CompletableFuture.completedFuture(null);
                 });
                 emitter.send(message);
             }
         }
 
-        public List<Integer> list() {
-            return acked;
+        public long count() {
+            return counter.sum();
         }
 
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/KeyDeserializerConfigurationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/KeyDeserializerConfigurationTest.java
@@ -377,7 +377,9 @@ public class KeyDeserializerConfigurationTest extends KafkaTestBase {
 
         assertThatThrownBy(() -> source = new KafkaSource<>(vertx, "my-group",
                 new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
-                CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1)).isInstanceOf(KafkaException.class)
+                CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1))
+                        .isInstanceOf(KafkaException.class)
+                        .hasCauseInstanceOf(IllegalArgumentException.class)
                         .hasStackTraceContaining("boom");
 
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/ValueDeserializerConfigurationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/ValueDeserializerConfigurationTest.java
@@ -427,7 +427,9 @@ public class ValueDeserializerConfigurationTest extends KafkaTestBase {
 
         assertThatThrownBy(() -> source = new KafkaSource<>(vertx, "my-group",
                 new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
-                CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1)).isInstanceOf(KafkaException.class)
+                CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1))
+                        .isInstanceOf(KafkaException.class)
+                        .hasCauseInstanceOf(IllegalArgumentException.class)
                         .hasStackTraceContaining("boom");
 
     }


### PR DESCRIPTION
When we have moved from using the Vert.x Kafka client for consumers
to using our own managed thread ("polling thread"), we kept using
the Vert.x Kafka client for producers.

With this commit, we no longer use the Vert.x Kafka client even for
producers. Similarly to consumers, we now manage our own thread
("sending thread") and delegate all sending operations to it.

This entails one breaking change: where we previously exposed
Kafka's `Producer`, we now expose our own `KafkaProducer`.