### PR TITLE
Kafka processor consuming parameter type can be message or payload

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+ij_continuation_indent_size = 8
 trim_trailing_whitespace = true
 end_of_line = lf
 insert_final_newline = true

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ProcessorShapeReturningCompletionStagesTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ProcessorShapeReturningCompletionStagesTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.beans.BeanConsumingItemAndProducingCompletionStageOfMessage;
+import io.smallrye.reactive.messaging.beans.BeanConsumingMessagesAndProducingCompletionStageOfSomething;
 import io.smallrye.reactive.messaging.beans.BeanProducingACompletableFuture;
 import io.smallrye.reactive.messaging.beans.BeanProducingACompletableFutureOfMessage;
 import io.smallrye.reactive.messaging.beans.BeanProducingACompletionStage;
@@ -29,8 +31,26 @@ public class ProcessorShapeReturningCompletionStagesTest extends WeldTestBase {
     }
 
     @Test
+    public void testBeanConsumingItemAndProducingACompletionStageOfMessage() {
+        addBeanClass(BeanConsumingItemAndProducingCompletionStageOfMessage.class);
+        initialize();
+        MyCollector collector = container.select(MyCollector.class).get();
+        await().until(() -> collector.payloads().size() == LIST.size());
+        assertThat(collector.payloads()).isEqualTo(LIST);
+    }
+
+    @Test
     public void testBeanProducingACompletionStageOfPayloads() {
         addBeanClass(BeanProducingACompletionStage.class);
+        initialize();
+        MyCollector collector = container.select(MyCollector.class).get();
+        await().until(() -> collector.payloads().size() == LIST.size());
+        assertThat(collector.payloads()).isEqualTo(LIST);
+    }
+
+    @Test
+    public void testBeanConsumingMessageAndProducingACompletionStageOfPayloads() {
+        addBeanClass(BeanConsumingMessagesAndProducingCompletionStageOfSomething.class);
         initialize();
         MyCollector collector = container.select(MyCollector.class).get();
         await().until(() -> collector.payloads().size() == LIST.size());

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAndProducingCompletionStageOfMessage.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAndProducingCompletionStageOfMessage.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.beans;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -9,12 +10,12 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 @ApplicationScoped
-public class BeanProducingACompletableFutureOfMessage {
+public class BeanConsumingItemAndProducingCompletionStageOfMessage {
 
     @Incoming("count")
     @Outgoing("sink")
-    public CompletableFuture<Message<String>> process(Message<Integer> value) {
-        return CompletableFuture.supplyAsync(() -> Integer.toString(value.getPayload() + 1))
+    public CompletionStage<Message<String>> process(int value) {
+        return CompletableFuture.supplyAsync(() -> Integer.toString(value + 1))
                 .thenApply(Message::of);
     }
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMessagesAndProducingCompletionStageOfSomething.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMessagesAndProducingCompletionStageOfSomething.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.beans;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -9,12 +10,12 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 @ApplicationScoped
-public class BeanProducingACompletableFutureOfMessage {
+public class BeanConsumingMessagesAndProducingCompletionStageOfSomething {
 
     @Incoming("count")
     @Outgoing("sink")
-    public CompletableFuture<Message<String>> process(Message<Integer> value) {
-        return CompletableFuture.supplyAsync(() -> Integer.toString(value.getPayload() + 1))
-                .thenApply(Message::of);
+    CompletionStage<String> process(Message<Integer> value) {
+        return CompletableFuture.supplyAsync(() -> Integer.toString(value.getPayload() + 1));
     }
+
 }


### PR DESCRIPTION
Currently supported processor signatures for single items are : 
- `Message<O> method(Message<I> msg)`
- `O method(I payload)`
- `CompletionStage<O> method(I payload)`
- `CompletionStage<Message<O>> method(Message<I> msg)`
(And `Uni<O>` variants)

A processor can support `Message` or payload object in consumption parameter type such as :
- `Message<O> method(I payload)`
- `CompletionStage<O> method(<Message<O> msg)`

Whereas currently these signatures result in ClassCastExceptionn: class [PAYLOAD] cannot be cast to class org.eclipse.microprofile.reactive.messaging.Message