### PR TITLE
added support for headers on camel's OutgoingExchangeMetadata

### DIFF
--- a/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/CamelConnector.java
+++ b/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/CamelConnector.java
@@ -135,6 +135,8 @@ public class CamelConnector implements IncomingConnectorFactory, OutgoingConnect
             if (metadata.getExchangePattern() != null) {
                 exchange.setPattern(metadata.getExchangePattern());
             }
+
+            metadata.getHeaders().forEach(exchange.getIn()::setHeader);
         }
 
         exchange.getIn().setBody(message.getPayload());

--- a/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/OutgoingExchangeMetadata.java
+++ b/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/OutgoingExchangeMetadata.java
@@ -8,6 +8,7 @@ import org.apache.camel.ExchangePattern;
 public class OutgoingExchangeMetadata {
 
     private Map<String, Object> properties = new ConcurrentHashMap<>();
+    private Map<String, Object> headers = new ConcurrentHashMap<>();
     private ExchangePattern pattern;
 
     public OutgoingExchangeMetadata putProperty(String name, Object value) {
@@ -22,6 +23,20 @@ public class OutgoingExchangeMetadata {
 
     public Map<String, Object> getProperties() {
         return properties;
+    }
+
+    public OutgoingExchangeMetadata putHeader(String name, Object value) {
+        headers.put(name, value);
+        return this;
+    }
+
+    public OutgoingExchangeMetadata removeHeader(String name) {
+        headers.remove(name);
+        return this;
+    }
+
+    public Map<String, Object> getHeaders() {
+        return headers;
     }
 
     public OutgoingExchangeMetadata setExchangePattern(ExchangePattern pattern) {

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/BeanWithCamelSinkUsingRegularEndpoint.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/BeanWithCamelSinkUsingRegularEndpoint.java
@@ -16,7 +16,8 @@ public class BeanWithCamelSinkUsingRegularEndpoint {
     public Publisher<Message<String>> source() {
         return ReactiveStreams.of("a", "b", "c", "d")
                 .map(String::toUpperCase)
-                .map(m -> Message.of(m).addMetadata(new OutgoingExchangeMetadata().putProperty("key", "value")))
+                .map(m -> Message.of(m).addMetadata(
+                        new OutgoingExchangeMetadata().putProperty("key", "value").putHeader("headerKey", "headerValue")))
                 .buildRs();
     }
 

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/CamelSinkTest.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/CamelSinkTest.java
@@ -70,6 +70,7 @@ public class CamelSinkTest extends CamelTestBase {
         BeanWithCamelSinkUsingRegularRoute bean = container.getBeanManager()
                 .createInstance().select(BeanWithCamelSinkUsingRegularRoute.class).get();
         assertThat(bean.getList()).hasSize(4).allSatisfy(map -> assertThat(map).contains(entry("key", "value")));
+        assertThat(bean.getHeaders()).hasSize(4).allSatisfy(map -> assertThat(map).contains(entry("headerKey", "headerValue")));
     }
 
     private MapBasedConfig getConfigUsingRoute() {

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/source/BeanWithCamelSourceUsingRSEndpoint.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/source/BeanWithCamelSourceUsingRSEndpoint.java
@@ -18,18 +18,24 @@ public class BeanWithCamelSourceUsingRSEndpoint extends RouteBuilder {
 
     private final List<String> list = new ArrayList<>();
     private final List<String> props = new ArrayList<>();
+    private final List<String> headers = new ArrayList<>();
 
     @Incoming("data")
     public CompletionStage<Void> sink(CamelMessage<String> msg) {
         IncomingExchangeMetadata metadata = msg.getMetadata(IncomingExchangeMetadata.class).orElse(null);
         Assertions.assertThat(metadata).isNotNull();
         props.add(metadata.getExchange().getProperty("key", String.class));
+        headers.add(metadata.getExchange().getIn().getHeader("headerKey", String.class));
         list.add(msg.getPayload());
         return msg.ack();
     }
 
     public List<String> list() {
         return list;
+    }
+
+    public List<String> headers() {
+        return headers;
     }
 
     public List<String> props() {
@@ -42,6 +48,7 @@ public class BeanWithCamelSourceUsingRSEndpoint extends RouteBuilder {
             exchange.getMessage()
                     .setBody(exchange.getIn().getBody(String.class).toUpperCase());
             exchange.setProperty("key", "value");
+            exchange.getIn().setHeader("headerKey", "headerValue");
         })
                 .to("reactive-streams:out");
     }

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/source/CamelSourceTest.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/source/CamelSourceTest.java
@@ -81,6 +81,7 @@ public class CamelSourceTest extends CamelTestBase {
         await().until(() -> bean.list().size() == 3);
         assertThat(bean.list()).contains("A", "B", "C");
         assertThat(bean.props()).containsExactly("value", "value", "value");
+        assertThat(bean.headers()).containsExactly("headerValue", "headerValue", "headerValue");
     }
 
     private MapBasedConfig getConfigUsingRS() {


### PR DESCRIPTION
A very common need when working with camel is to set header that actually drive how given component is used. For example when using camel drops component to upload files there is a need to set the header `CamelDropboxPutFileName` that will configure the name of the file at the remote drive. 

This pull request adds support for setting headers on Camel's in message via camel's `OutgoingExchangeMetadata`.

It is implemented pretty much the same way as the properties are that are put on the exchange level.