### PR TITLE
Update Vert.x to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
 
   <properties>
-    <vertx.version>4.1.0</vertx.version>
+    <vertx.version>4.1.1</vertx.version>
     <rxjava.version>2.2.21</rxjava.version>
     <cloudevent.version>1.1.0</cloudevent.version>
     <weld.version>3.1.7.SP1</weld.version>
@@ -86,7 +86,8 @@
     <opentelemetry.version>1.3.0</opentelemetry.version>
     <opentelemetry-semver.version>1.3.0-alpha</opentelemetry-semver.version>
 
-    <smallrye-vertx-mutiny-clients.version>2.6.0</smallrye-vertx-mutiny-clients.version>
+    <smallrye-vertx-mutiny-clients.version>2.7.0</smallrye-vertx-mutiny-clients.version>
+    <smallrye-reactive-converters.version>2.6.0</smallrye-reactive-converters.version>
 
     <testcontainers.version>1.15.3</testcontainers.version>
 
@@ -278,7 +279,7 @@
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-reactive-converter-api</artifactId>
-      <version>${smallrye-vertx-mutiny-clients.version}</version>
+      <version>${smallrye-reactive-converters.version}</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
@@ -308,19 +309,19 @@
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-reactive-converter-rxjava2</artifactId>
-      <version>${smallrye-vertx-mutiny-clients.version}</version>
+      <version>${smallrye-reactive-converters.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-reactive-converter-reactor</artifactId>
-      <version>${smallrye-vertx-mutiny-clients.version}</version>
+      <version>${smallrye-reactive-converters.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-reactive-converter-mutiny</artifactId>
-      <version>${smallrye-vertx-mutiny-clients.version}</version>
+      <version>${smallrye-reactive-converters.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Also update the Vert.x Mutiny Client version to 2.7.0 and separate the reactive converter version. They were using the same variable until now.