### PR TITLE
OpenTelemetry fixes:

### DIFF
--- a/api/src/main/java/io/smallrye/reactive/messaging/TracingMetadata.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/TracingMetadata.java
@@ -6,7 +6,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.smallrye.common.annotation.Experimental;
 
@@ -14,14 +13,14 @@ import io.smallrye.common.annotation.Experimental;
 public class TracingMetadata {
     private static final TracingMetadata EMPTY = new TracingMetadata(null);
 
-    private final SpanContext currentSpanContext;
+    private final Context currentSpanContext;
     private final Context previousSpanContext;
 
-    private TracingMetadata(SpanContext spanContext) {
+    private TracingMetadata(Context spanContext) {
         this(spanContext, null);
     }
 
-    private TracingMetadata(SpanContext spanContext, Context previousSpanContext) {
+    private TracingMetadata(Context spanContext, Context previousSpanContext) {
         this.currentSpanContext = spanContext;
         this.previousSpanContext = previousSpanContext;
     }
@@ -55,12 +54,12 @@ public class TracingMetadata {
 
     public TracingMetadata withSpan(Span span) {
         if (span != null) {
-            return new TracingMetadata(span.getSpanContext(), previousSpanContext);
+            return new TracingMetadata(Context.root().with(span), previousSpanContext);
         }
         return this;
     }
 
-    public SpanContext getCurrentSpanContext() {
+    public Context getCurrentContext() {
         return currentSpanContext;
     }
 

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -335,6 +335,9 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
         span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, message.getAddress());
         span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND, "queue");
 
+        // Make available as parent for subsequent spans inside message processing
+        span.makeCurrent();
+
         message.injectTracingMetadata(tracingMetadata.withSpan(span));
 
         span.end();

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpCreditBasedSender.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpCreditBasedSender.java
@@ -18,7 +18,6 @@ import org.reactivestreams.Subscription;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
-import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -265,17 +264,11 @@ public class AmqpCreditBasedSender implements Processor<Message<?>, Message<?>>,
 
             if (tracingMetadata.isPresent()) {
                 // Handle possible parent span
-                final Context parentSpanContext = tracingMetadata.get().getPreviousContext();
+                final Context parentSpanContext = tracingMetadata.get().getCurrentContext();
                 if (parentSpanContext != null) {
                     spanBuilder.setParent(parentSpanContext);
                 } else {
                     spanBuilder.setNoParent();
-                }
-
-                // Handle possible adjacent spans
-                final SpanContext incomingSpan = tracingMetadata.get().getCurrentSpanContext();
-                if (incomingSpan != null && incomingSpan.isValid()) {
-                    spanBuilder.addLink(incomingSpan);
                 }
             } else {
                 spanBuilder.setNoParent();

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
@@ -56,7 +56,7 @@ public class AmqpMessage<T> implements org.eclipse.microprofile.reactive.messagi
             if (msg.applicationProperties() != null) {
                 // Read tracing headers
                 io.opentelemetry.context.Context otelContext = GlobalOpenTelemetry.getPropagators().getTextMapPropagator()
-                        .extract(io.opentelemetry.context.Context.current(), msg.applicationProperties(),
+                        .extract(io.opentelemetry.context.Context.root(), msg.applicationProperties(),
                                 HeaderExtractAdapter.GETTER);
                 tracingMetadata = TracingMetadata.withPrevious(otelContext);
             }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAmqpToAppNoParentTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAmqpToAppNoParentTest.java
@@ -114,7 +114,7 @@ public class TracingAmqpToAppNoParentTest extends AmqpBrokerTestBase {
         List<String> spanIds = new ArrayList<>();
 
         for (TracingMetadata tracing : bean.tracing()) {
-            spanIds.add(tracing.getCurrentSpanContext().getSpanId());
+            spanIds.add(Span.fromContext(tracing.getCurrentContext()).getSpanContext().getSpanId());
             assertThat(Span.fromContextOrNull(tracing.getPreviousContext())).isNull();
         }
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAmqpToAppWithParentTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAmqpToAppWithParentTest.java
@@ -132,7 +132,7 @@ public class TracingAmqpToAppWithParentTest extends AmqpBrokerTestBase {
         assertThat(bean.tracing()).doesNotContainNull().doesNotHaveDuplicates();
 
         List<String> receivedTraceIds = bean.tracing().stream()
-                .map(tracingMetadata -> tracingMetadata.getCurrentSpanContext().getTraceId())
+                .map(tracingMetadata -> Span.fromContext(tracingMetadata.getCurrentContext()).getSpanContext().getTraceId())
                 .collect(Collectors.toList());
         assertThat(receivedTraceIds).doesNotContainNull().doesNotHaveDuplicates().hasSize(10);
         assertThat(receivedTraceIds).containsExactlyInAnyOrderElementsOf(producedTraceIds);
@@ -140,15 +140,15 @@ public class TracingAmqpToAppWithParentTest extends AmqpBrokerTestBase {
         List<String> spanIds = new ArrayList<>();
 
         for (TracingMetadata tracing : bean.tracing()) {
-            spanIds.add(tracing.getCurrentSpanContext().getSpanId());
+            spanIds.add(Span.fromContext(tracing.getCurrentContext()).getSpanContext().getSpanId());
 
             assertThat(tracing.getPreviousContext()).isNotNull();
             Span previousSpan = Span.fromContextOrNull(tracing.getPreviousContext());
             assertThat(previousSpan).isNotNull();
             assertThat(previousSpan.getSpanContext().getTraceId())
-                    .isEqualTo(tracing.getCurrentSpanContext().getTraceId());
+                    .isEqualTo(Span.fromContext(tracing.getCurrentContext()).getSpanContext().getTraceId());
             assertThat(previousSpan.getSpanContext().getSpanId())
-                    .isNotEqualTo(tracing.getCurrentSpanContext().getSpanId());
+                    .isNotEqualTo(Span.fromContext(tracing.getCurrentContext()).getSpanContext().getSpanId());
         }
 
         assertThat(spanIds).doesNotContainNull().doesNotHaveDuplicates().hasSizeGreaterThanOrEqualTo(10);

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecord.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecord.java
@@ -69,7 +69,7 @@ public class IncomingKafkaRecord<K, T> implements KafkaRecord<K, T> {
             if (record.headers() != null) {
                 // Read tracing headers
                 Context context = GlobalOpenTelemetry.getPropagators().getTextMapPropagator()
-                        .extract(Context.current(), kafkaMetadata.getHeaders(), HeaderExtractAdapter.GETTER);
+                        .extract(Context.root(), kafkaMetadata.getHeaders(), HeaderExtractAdapter.GETTER);
                 tracingMetadata = TracingMetadata.withPrevious(context);
             }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
@@ -32,7 +32,6 @@ import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
-import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -281,17 +280,11 @@ public class KafkaSink {
 
             if (tracingMetadata.isPresent()) {
                 // Handle possible parent span
-                final Context parentSpanContext = tracingMetadata.get().getPreviousContext();
+                final Context parentSpanContext = tracingMetadata.get().getCurrentContext();
                 if (parentSpanContext != null) {
                     spanBuilder.setParent(parentSpanContext);
                 } else {
                     spanBuilder.setNoParent();
-                }
-
-                // Handle possible adjacent spans
-                final SpanContext incomingSpan = tracingMetadata.get().getCurrentSpanContext();
-                if (incomingSpan != null && incomingSpan.isValid()) {
-                    spanBuilder.addLink(incomingSpan);
                 }
             } else {
                 spanBuilder.setNoParent();

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -209,6 +209,9 @@ public class KafkaSource<K, V> {
             span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, kafkaRecord.getTopic());
             span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND, "topic");
 
+            // Make available as parent for subsequent spans inside message processing
+            span.makeCurrent();
+
             kafkaRecord.injectTracingMetadata(tracingMetadata.withSpan(span));
 
             span.end();


### PR DESCRIPTION
- Ensure extracting an OpenTelemetry Context from incoming headers uses `Context.root()` as the starting point, as `current()` doesn't apply because there is nothing before the incoming processing
- Call `makeCurrent()` on the CONSUMER span created for incoming. This enables any spans created within message processing to have this span as the correct parent
- Remove previous linking of spans, as it made the visualization complex to understand
- Update APIs in `TracingMetadata` as we're no longer tracking the `SpanContext`, but `Context` on the current span