### PR TITLE
Provide a minimal wrapper around KafkaAdminClient for health check

### DIFF
--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -15,11 +15,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.smallrye.reactive</groupId>
-      <artifactId>smallrye-mutiny-vertx-kafka-client</artifactId>
-      <version>${smallrye-vertx-mutiny-clients.version}</version>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>smallrye-reactive-messaging-provider</artifactId>
       <version>${project.version}</version>
@@ -45,6 +40,12 @@
       <artifactId>opentelemetry-semconv</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-mutiny-vertx-kafka-client</artifactId>
+      <version>${smallrye-vertx-mutiny-clients.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config</artifactId>

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaAdmin.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaAdmin.java
@@ -1,0 +1,20 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.Set;
+
+import org.apache.kafka.clients.admin.Admin;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Internal interface for Kafka admin client.
+ * To complete with remaining {@link org.apache.kafka.clients.admin.Admin} method wrappers, if decided to expose it externally.
+ */
+public interface KafkaAdmin {
+
+    Uni<Set<String>> listTopics();
+
+    Admin unwrap();
+
+    void closeAndAwait();
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -224,7 +224,7 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
             c = merge(config, matching.get());
         }
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(c);
-        KafkaSink sink = new KafkaSink(vertx, oc, kafkaCDIEvents);
+        KafkaSink sink = new KafkaSink(oc, kafkaCDIEvents);
         sinks.add(sink);
         return sink.getSink();
     }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/BaseHealth.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/BaseHealth.java
@@ -8,7 +8,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 
 import io.smallrye.reactive.messaging.health.HealthReport;
-import io.vertx.mutiny.kafka.admin.KafkaAdminClient;
+import io.smallrye.reactive.messaging.kafka.KafkaAdmin;
 
 public abstract class BaseHealth {
 
@@ -21,7 +21,7 @@ public abstract class BaseHealth {
     }
 
     public void close() {
-        KafkaAdminClient admin = getAdmin();
+        KafkaAdmin admin = getAdmin();
         if (admin != null) {
             try {
                 admin.closeAndAwait();
@@ -32,7 +32,7 @@ public abstract class BaseHealth {
     }
 
     public void isReady(HealthReport.HealthReportBuilder builder) {
-        KafkaAdminClient admin = getAdmin();
+        KafkaAdmin admin = getAdmin();
         if (admin != null) {
             adminBasedHealthCheck(builder);
         } else {
@@ -55,5 +55,5 @@ public abstract class BaseHealth {
 
     protected abstract void adminBasedHealthCheck(HealthReport.HealthReportBuilder builder);
 
-    public abstract KafkaAdminClient getAdmin();
+    public abstract KafkaAdmin getAdmin();
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSinkReadinessHealth.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSinkReadinessHealth.java
@@ -10,19 +10,18 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 
 import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.kafka.KafkaAdmin;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorOutgoingConfiguration;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaAdminHelper;
-import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.kafka.admin.KafkaAdminClient;
 
 public class KafkaSinkReadinessHealth extends BaseHealth {
 
     private final KafkaConnectorOutgoingConfiguration config;
-    private final KafkaAdminClient admin;
+    private final KafkaAdmin admin;
     private final Metric metric;
     private final String topic;
 
-    public KafkaSinkReadinessHealth(Vertx vertx, KafkaConnectorOutgoingConfiguration config,
+    public KafkaSinkReadinessHealth(KafkaConnectorOutgoingConfiguration config,
             Map<String, ?> kafkaConfiguration, Producer<?, ?> producer) {
         super(config.getChannel());
         this.topic = config.getTopic().orElse(config.getChannel());
@@ -31,7 +30,7 @@ public class KafkaSinkReadinessHealth extends BaseHealth {
         if (config.getHealthReadinessTopicVerification()) {
             // Do not create the client if the readiness health checks are disabled
             Map<String, Object> adminConfiguration = new HashMap<>(kafkaConfiguration);
-            this.admin = KafkaAdminHelper.createAdminClient(vertx, adminConfiguration, config.getChannel(), true);
+            this.admin = KafkaAdminHelper.createAdminClient(adminConfiguration, config.getChannel(), true);
             this.metric = null;
         } else {
             this.admin = null;
@@ -41,7 +40,7 @@ public class KafkaSinkReadinessHealth extends BaseHealth {
     }
 
     @Override
-    public KafkaAdminClient getAdmin() {
+    public KafkaAdmin getAdmin() {
         return admin;
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSourceReadinessHealth.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSourceReadinessHealth.java
@@ -12,15 +12,14 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 
 import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.kafka.KafkaAdmin;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaAdminHelper;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
-import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.kafka.admin.KafkaAdminClient;
 
 public class KafkaSourceReadinessHealth extends BaseHealth {
 
-    private final KafkaAdminClient admin;
+    private final KafkaAdmin admin;
     private final KafkaConnectorIncomingConfiguration config;
     private final Pattern pattern;
     private final String channel;
@@ -28,7 +27,7 @@ public class KafkaSourceReadinessHealth extends BaseHealth {
     private final Metric metric;
     private final KafkaSource<?, ?> source;
 
-    public KafkaSourceReadinessHealth(KafkaSource<?, ?> source, Vertx vertx, KafkaConnectorIncomingConfiguration config,
+    public KafkaSourceReadinessHealth(KafkaSource<?, ?> source, KafkaConnectorIncomingConfiguration config,
             Map<String, ?> kafkaConfiguration, Consumer<?, ?> consumer, Set<String> topics, Pattern pattern) {
         super(config.getChannel());
         this.config = config;
@@ -39,7 +38,7 @@ public class KafkaSourceReadinessHealth extends BaseHealth {
         if (config.getHealthReadinessTopicVerification()) {
             // Do not create the client if the readiness health checks are disabled
             Map<String, Object> adminConfiguration = new HashMap<>(kafkaConfiguration);
-            this.admin = KafkaAdminHelper.createAdminClient(vertx, adminConfiguration, config.getChannel(), true);
+            this.admin = KafkaAdminHelper.createAdminClient(adminConfiguration, config.getChannel(), true);
             this.metric = null;
 
         } else {
@@ -94,7 +93,7 @@ public class KafkaSourceReadinessHealth extends BaseHealth {
     }
 
     @Override
-    public KafkaAdminClient getAdmin() {
+    public KafkaAdmin getAdmin() {
         return admin;
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaAdminHelper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaAdminHelper.java
@@ -6,8 +6,7 @@ import java.util.Map;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
-import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.kafka.admin.KafkaAdminClient;
+import io.smallrye.reactive.messaging.kafka.KafkaAdmin;
 
 public class KafkaAdminHelper {
 
@@ -15,8 +14,8 @@ public class KafkaAdminHelper {
         // avoid direct instantiation
     }
 
-    public static KafkaAdminClient createAdminClient(Vertx vertx,
-            Map<String, Object> kafkaConfigurationMap, String channel, boolean incoming) {
+    public static KafkaAdmin createAdminClient(Map<String, Object> kafkaConfigurationMap, String channel,
+            boolean incoming) {
         Map<String, String> copy = new HashMap<>();
         for (Map.Entry<String, Object> entry : kafkaConfigurationMap.entrySet()) {
             if (AdminClientConfig.configNames().contains(entry.getKey())) {
@@ -40,6 +39,6 @@ public class KafkaAdminHelper {
         }
         copy.put(AdminClientConfig.CLIENT_ID_CONFIG, name);
 
-        return KafkaAdminClient.create(vertx, copy);
+        return new ReactiveKafkaAdminClient(copy);
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
@@ -48,7 +48,6 @@ import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import io.smallrye.reactive.messaging.kafka.health.KafkaSinkReadinessHealth;
 import io.smallrye.reactive.messaging.kafka.impl.ce.KafkaCloudEventHelper;
 import io.smallrye.reactive.messaging.kafka.tracing.HeaderInjectAdapter;
-import io.vertx.mutiny.core.Vertx;
 
 public class KafkaSink {
 
@@ -71,7 +70,7 @@ public class KafkaSink {
     private final KafkaSinkReadinessHealth health;
     private final boolean isHealthEnabled;
 
-    public KafkaSink(Vertx vertx, KafkaConnectorOutgoingConfiguration config, KafkaCDIEvents kafkaCDIEvents) {
+    public KafkaSink(KafkaConnectorOutgoingConfiguration config, KafkaCDIEvents kafkaCDIEvents) {
         isTracingEnabled = config.getTracingEnabled();
 
         this.client = new ReactiveKafkaProducer<>(config);
@@ -106,7 +105,7 @@ public class KafkaSink {
 
         this.isHealthEnabled = configuration.getHealthEnabled();
         if (isHealthEnabled && this.configuration.getHealthReadinessEnabled()) {
-            this.health = new KafkaSinkReadinessHealth(vertx, config, client.configuration(), client.unwrap());
+            this.health = new KafkaSinkReadinessHealth(config, client.configuration(), client.unwrap());
         } else {
             this.health = null;
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -91,9 +91,9 @@ public class KafkaSource<K, V> {
                         : KafkaCommitHandler.Strategy.THROTTLED.name());
 
         commitHandler = createCommitHandler(vertx, client, consumerGroup, config, commitStrategy);
-        failureHandler = createFailureHandler(config, vertx, client.configuration(), kafkaCDIEvents);
+        failureHandler = createFailureHandler(config, client.configuration(), kafkaCDIEvents);
         if (configuration.getHealthEnabled() && configuration.getHealthReadinessEnabled()) {
-            health = new KafkaSourceReadinessHealth(this, vertx, configuration, client.configuration(),
+            health = new KafkaSourceReadinessHealth(this, configuration, client.configuration(),
                     client.unwrap(), topics, pattern);
         } else {
             health = null;
@@ -218,7 +218,7 @@ public class KafkaSource<K, V> {
         }
     }
 
-    private KafkaFailureHandler createFailureHandler(KafkaConnectorIncomingConfiguration config, Vertx vertx,
+    private KafkaFailureHandler createFailureHandler(KafkaConnectorIncomingConfiguration config,
             Map<String, ?> kafkaConfiguration, KafkaCDIEvents kafkaCDIEvents) {
         String strategy = config.getFailureStrategy();
         KafkaFailureHandler.Strategy actualStrategy = KafkaFailureHandler.Strategy.from(strategy);
@@ -228,7 +228,7 @@ public class KafkaSource<K, V> {
             case IGNORE:
                 return new KafkaIgnoreFailure(config.getChannel());
             case DEAD_LETTER_QUEUE:
-                return KafkaDeadLetterQueue.create(vertx, kafkaConfiguration, config, this, kafkaCDIEvents);
+                return KafkaDeadLetterQueue.create(kafkaConfiguration, config, this, kafkaCDIEvents);
             default:
                 throw ex.illegalArgumentInvalidFailureStrategy(strategy);
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaAdminClient.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaAdminClient.java
@@ -1,0 +1,35 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.KafkaAdmin;
+
+public class ReactiveKafkaAdminClient implements KafkaAdmin {
+
+    private final AdminClient adminClient;
+
+    public ReactiveKafkaAdminClient(Map<String, String> config) {
+        adminClient = AdminClient.create(new HashMap<>(config));
+    }
+
+    @Override
+    public Uni<Set<String>> listTopics() {
+        return Uni.createFrom().future(adminClient.listTopics().names());
+    }
+
+    @Override
+    public Admin unwrap() {
+        return adminClient;
+    }
+
+    @Override
+    public void closeAndAwait() {
+        adminClient.close();
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
@@ -65,7 +65,7 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("partition", 0)
                 .with("channel-name", "testSinkUsingInteger");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 10)
@@ -90,7 +90,7 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("value.serializer", IntegerSerializer.class.getName())
                 .with("partition", 0);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 10)
@@ -116,7 +116,7 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("partition", 0)
                 .with("channel-name", "testSinkUsingString");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 10)
@@ -275,7 +275,7 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("retries", 0L); // disable retry.
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
         CountKafkaCdiEvents testCdiEvents = new CountKafkaCdiEvents();
-        sink = new KafkaSink(vertx, oc, testCdiEvents);
+        sink = new KafkaSink(oc, testCdiEvents);
 
         await().until(() -> {
             HealthReport.HealthReportBuilder builder = HealthReport.builder();
@@ -329,7 +329,7 @@ public class KafkaSinkTest extends KafkaTestBase {
                 .with("retries", 0L)
                 .with("channel-name", "testInvalidTypeWithDefaultInflightMessages");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 5)

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkWithLegacyMetadataTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkWithLegacyMetadataTest.java
@@ -70,7 +70,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaTestBase {
                 .with("partition", 0)
                 .with("channel-name", "testSinkUsingInteger");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 10)
@@ -95,7 +95,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaTestBase {
                 .with("value.serializer", IntegerSerializer.class.getName())
                 .with("partition", 0);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 10)
@@ -121,7 +121,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaTestBase {
                 .with("partition", 0)
                 .with("channel-name", "testSinkUsingString");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 10)
@@ -281,7 +281,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaTestBase {
                 .with("retries", 0L); // disable retry.
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
         CountKafkaCdiEvents testCdiEvents = new CountKafkaCdiEvents();
-        sink = new KafkaSink(vertx, oc, testCdiEvents);
+        sink = new KafkaSink(oc, testCdiEvents);
 
         await().until(() -> {
             HealthReport.HealthReportBuilder builder = HealthReport.builder();
@@ -335,7 +335,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaTestBase {
                 .with("retries", 0L)
                 .with("channel-name", "testInvalidTypeWithDefaultInflightMessages");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Subscriber subscriber = sink.getSink().build();
         Multi.createFrom().range(0, 5)

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSinkWithCloudEventsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSinkWithCloudEventsTest.java
@@ -54,7 +54,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -101,7 +101,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -147,7 +147,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -195,7 +195,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Message<?> message = Message.of("hello").addMetadata(OutgoingCloudEventMetadata.builder()
                 .withSource(URI.create("test://test"))
@@ -228,7 +228,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
 
-        assertThatThrownBy(() -> new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents))
+        assertThatThrownBy(() -> new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents))
                 .isInstanceOf(IllegalStateException.class);
     }
 
@@ -241,7 +241,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -287,7 +287,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-type", "my type");
         config.put("cloud-events-source", "http://acme.org");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -329,7 +329,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-type", "my type");
         config.put("cloud-events-source", "http://acme.org");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -367,7 +367,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events-mode", "structured");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -412,7 +412,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -452,7 +452,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -496,7 +496,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -541,7 +541,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-type", "my type");
         config.put("cloud-events-source", "http://acme.org");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -582,7 +582,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("cloud-events-type", "my type");
         config.put("cloud-events-source", "http://acme.org");
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -618,7 +618,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Message<?> message = Message.of("hello").addMetadata(OutgoingCloudEventMetadata.builder()
                 .withSource(URI.create("test://test"))
@@ -652,7 +652,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("key", "my-key");
         config.put("cloud-events", false);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();
@@ -686,7 +686,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaTestBase {
         config.put("value.serializer", StringSerializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(config);
-        sink = new KafkaSink(vertx, oc, CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents);
 
         Deserializer<String> keyDes = new StringDeserializer();
         String randomId = UUID.randomUUID().toString();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaProducerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaProducerTest.java
@@ -165,7 +165,7 @@ public class ReactiveKafkaProducerTest extends ClientTestBase {
                 .put("channel-name", "test-" + ThreadLocalRandom.current().nextInt())
                 .put("topic", topic);
 
-        KafkaSink sink = new KafkaSink(vertx, new KafkaConnectorOutgoingConfiguration(config),
+        KafkaSink sink = new KafkaSink(new KafkaConnectorOutgoingConfiguration(config),
                 CountKafkaCdiEvents.noCdiEvents);
         this.sinks.add(sink);
         return sink;

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/SerializerConfigurationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/SerializerConfigurationTest.java
@@ -40,7 +40,7 @@ public class SerializerConfigurationTest extends KafkaTestBase {
     @Test
     public void testThatWhenNotSetKeySerializerIsString() {
         MapBasedConfig config = commonConsumerConfiguration();
-        sink = new KafkaSink(vertx, new KafkaConnectorOutgoingConfiguration(config), CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(new KafkaConnectorOutgoingConfiguration(config), CountKafkaCdiEvents.noCdiEvents);
 
         List<Tuple2<String, String>> list = new ArrayList<>();
         usage.consumeStrings(topic, 4, 10, TimeUnit.SECONDS, () -> {
@@ -75,7 +75,7 @@ public class SerializerConfigurationTest extends KafkaTestBase {
                 .with("value.serializer", JsonObjectSerializer.class.getName())
                 .with("key.serializer", JsonObjectSerializer.class.getName())
                 .with("retries", 0L);
-        sink = new KafkaSink(vertx, new KafkaConnectorOutgoingConfiguration(config), CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(new KafkaConnectorOutgoingConfiguration(config), CountKafkaCdiEvents.noCdiEvents);
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         AtomicBoolean nacked = new AtomicBoolean();
         Multi.createFrom().items(
@@ -93,7 +93,7 @@ public class SerializerConfigurationTest extends KafkaTestBase {
                 .with("value.serializer", JsonObjectSerializer.class.getName())
                 .with("key.serializer", JsonObjectSerializer.class.getName())
                 .with("retries", 0L);
-        sink = new KafkaSink(vertx, new KafkaConnectorOutgoingConfiguration(config), CountKafkaCdiEvents.noCdiEvents);
+        sink = new KafkaSink(new KafkaConnectorOutgoingConfiguration(config), CountKafkaCdiEvents.noCdiEvents);
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
         AtomicBoolean nacked = new AtomicBoolean();
         Multi.createFrom().items(
@@ -111,8 +111,7 @@ public class SerializerConfigurationTest extends KafkaTestBase {
                 .without("value.serializer");
 
         assertThatThrownBy(() -> {
-            sink = new KafkaSink(vertx, new KafkaConnectorOutgoingConfiguration(config),
-                    CountKafkaCdiEvents.noCdiEvents);
+            sink = new KafkaSink(new KafkaConnectorOutgoingConfiguration(config), CountKafkaCdiEvents.noCdiEvents);
         }).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("value.serializer");
 
     }
@@ -123,8 +122,7 @@ public class SerializerConfigurationTest extends KafkaTestBase {
                 .with("value.serializer", BrokenSerializerFailingDuringConfig.class.getName());
 
         assertThatThrownBy(() -> {
-            sink = new KafkaSink(vertx, new KafkaConnectorOutgoingConfiguration(config),
-                    CountKafkaCdiEvents.noCdiEvents);
+            sink = new KafkaSink(new KafkaConnectorOutgoingConfiguration(config), CountKafkaCdiEvents.noCdiEvents);
         }).isInstanceOf(KafkaException.class)
                 .hasCauseInstanceOf(IllegalStateException.class)
                 .hasStackTraceContaining("boom");


### PR DESCRIPTION
Remove usages of vertx-kafka-client, change dependency to test scope.
Use an internal ReactiveKafkaProducer for sending messages in dead letter queue.

Because the vertx-kafka-client is no longer brought as a dependency, JsonObject serde won't be available by default in applications. This is a possible breaking change.