### PR TITLE
First commit of rabbitmq connector

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -57,6 +57,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-rabbitmq</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>jakarta.jms</groupId>
       <artifactId>jakarta.jms-api</artifactId>
     </dependency>
@@ -116,6 +121,7 @@
                 <source>src/main/doc/modules/camel/examples</source>
                 <source>src/main/doc/modules/jms/examples</source>
                 <source>src/main/doc/modules/mqtt/examples</source>
+                <source>src/main/doc/modules/rabbitmq/examples</source>
                 <source>src/main/doc/modules/mqtt-server/examples</source>
                 <source>src/main/doc/modules/http/examples</source>
                 <source>src/main/doc/modules/vertx-event-bus/examples</source>

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-incoming.adoc
@@ -1,0 +1,186 @@
+.Incoming Attributes of the 'smallrye-rabbitmq' connector
+[cols="25, 30, 15, 20",options="header"]
+|===
+|Attribute (_alias_) | Description | Mandatory | Default
+
+| *username*
+
+_(rabbitmq-username)_ | The username used to authenticate to the broker
+
+Type: _string_ | false | 
+
+| *password*
+
+_(rabbitmq-password)_ | The password used to authenticate to the broker
+
+Type: _string_ | false | 
+
+| *host*
+
+_(rabbitmq-host)_ | The broker hostname
+
+Type: _string_ | false | `localhost`
+
+| *port*
+
+_(rabbitmq-port)_ | The broker port
+
+Type: _int_ | false | `5672`
+
+| *connection-timeout* | The TCP connection timeout (ms); 0 is interpreted as no timeout
+
+Type: _int_ | false | `60000`
+
+| *handshake-timeout* | The AMQP 0-9-1 protocol handshake timeout (ms)
+
+Type: _int_ | false | `10000`
+
+| *automatic-recovery-enabled* | Whether automatic connection recovery is enabled
+
+Type: _boolean_ | false | `false`
+
+| *automatic-recovery-on-initial-connection* | Whether automatic recovery on initial connections is enabled
+
+Type: _boolean_ | false | `true`
+
+| *reconnect-attempts*
+
+_(rabbitmq-reconnect-attempts)_ | The number of reconnection attempts
+
+Type: _int_ | false | `100`
+
+| *reconnect-interval*
+
+_(rabbitmq-reconnect-interval)_ | The interval (in seconds) between two reconnection attempts
+
+Type: _int_ | false | `10`
+
+| *network-recovery-interval* | How long (ms) will automatic recovery wait before attempting to reconnect
+
+Type: _int_ | false | `5000`
+
+| *user* | The AMQP user name to use when connecting to the broker
+
+Type: _string_ | false | `guest`
+
+| *include-properties* | Whether to include properties when a broker message is passed on the event bus
+
+Type: _boolean_ | false | `false`
+
+| *requested-channel-max* | The initially requested maximum channel number
+
+Type: _int_ | false | `2047`
+
+| *requested-heartbeat* | The initially requested heartbeat interval (seconds), zero for none
+
+Type: _int_ | false | `60`
+
+| *use-nio* | Whether usage of NIO Sockets is enabled
+
+Type: _boolean_ | false | `false`
+
+| *virtual-host* | The virtual host to use when connecting to the broker
+
+Type: _string_ | false | `/`
+
+| *exchange.name* | The exchange that messages are published to or consumed from. If not set, the channel name is used
+
+Type: _string_ | false | 
+
+| *exchange.durable* | Whether the exchange is durable
+
+Type: _boolean_ | false | `true`
+
+| *exchange.auto-delete* | Whether the exchange should be deleted after use
+
+Type: _boolean_ | false | `false`
+
+| *exchange.type* | The exchange type: direct, fanout, headers or topic (default)
+
+Type: _string_ | false | `topic`
+
+| *exchange.declare* | Whether to declare the exchange; set to false if the exchange is expected to be set up independently
+
+Type: _boolean_ | false | `true`
+
+| *tracing.enabled* | Whether tracing is enabled (default) or disabled
+
+Type: _boolean_ | false | `true`
+
+| *tracing.attribute-headers* | A comma-separated list of headers that should be recorded as span attributes. Relevant only if tracing.enabled=true
+
+Type: _string_ | false | ``
+
+| *queue.name* | The queue from which messages are consumed.
+
+Type: _string_ | true | 
+
+| *queue.durable* | Whether the queue is durable
+
+Type: _boolean_ | false | `true`
+
+| *queue.exclusive* | Whether the queue is for exclusive use
+
+Type: _boolean_ | false | `false`
+
+| *queue.auto-delete* | Whether the queue should be deleted after use
+
+Type: _boolean_ | false | `false`
+
+| *queue.declare* | Whether to declare the queue and binding; set to false if these are expected to be set up independently
+
+Type: _boolean_ | false | `true`
+
+| *queue.ttl* | If specified, the time (ms) for which a message can remain in the queue undelivered before it is dead
+
+Type: _long_ | false | 
+
+| *max-incoming-internal-queue-size* | The maximum size of the incoming internal queue
+
+Type: _int_ | false | 
+
+| *auto-bind-dlq* | Whether to automatically declare the DLQ and bind it to the binder DLX
+
+Type: _boolean_ | false | `false`
+
+| *dead-letter-queue-name* | The name of the DLQ; if not supplied will default to the queue name with '.dlq' appended
+
+Type: _string_ | false | 
+
+| *dead-letter-exchange* | A DLX to assign to the queue. Relevant only if auto-bind-dlq is true
+
+Type: _string_ | false | `DLX`
+
+| *dead-letter-exchange-type* | The type of the DLX to assign to the queue. Relevant only if auto-bind-dlq is true
+
+Type: _string_ | false | `direct`
+
+| *dead-letter-routing-key* | A dead letter routing key to assign to the queue; if not supplied will default to the queue name
+
+Type: _string_ | false | 
+
+| *dlx.declare* | Whether to declare the dead letter exchange binding. Relevant only if auto-bind-dlq is true; set to false if these are expected to be set up independently
+
+Type: _boolean_ | false | `false`
+
+| *failure-strategy* | The failure strategy to apply when a RabbitMQ message is nacked. Accepted values are `fail`, `accept`, `reject` (default)
+
+Type: _string_ | false | `reject`
+
+| *broadcast* | Whether the received RabbitMQ messages must be dispatched to multiple _subscribers_
+
+Type: _boolean_ | false | `false`
+
+| *auto-acknowledgement* | Whether the received RabbitMQ messages must be acknowledged when received; if true then delivery constitutes acknowledgement
+
+Type: _boolean_ | false | `false`
+
+| *keep-most-recent* | Whether to discard old messages instead of recent ones
+
+Type: _boolean_ | false | `false`
+
+| *routing-keys* | A comma-separated list of routing keys to bind the queue to the exchange
+
+Type: _string_ | false | `#`
+
+|===

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-outgoing.adoc
@@ -1,0 +1,130 @@
+.Outgoing Attributes of the 'smallrye-rabbitmq' connector
+[cols="25, 30, 15, 20",options="header"]
+|===
+|Attribute (_alias_) | Description | Mandatory | Default
+
+| *automatic-recovery-enabled* | Whether automatic connection recovery is enabled
+
+Type: _boolean_ | false | `false`
+
+| *automatic-recovery-on-initial-connection* | Whether automatic recovery on initial connections is enabled
+
+Type: _boolean_ | false | `true`
+
+| *connection-timeout* | The TCP connection timeout (ms); 0 is interpreted as no timeout
+
+Type: _int_ | false | `60000`
+
+| *default-routing-key* | The default routing key to use when sending messages to the exchange
+
+Type: _string_ | false | ``
+
+| *default-ttl* | If specified, the time (ms) sent messages can remain in queues undelivered before they are dead
+
+Type: _long_ | false | 
+
+| *exchange.auto-delete* | Whether the exchange should be deleted after use
+
+Type: _boolean_ | false | `false`
+
+| *exchange.declare* | Whether to declare the exchange; set to false if the exchange is expected to be set up independently
+
+Type: _boolean_ | false | `true`
+
+| *exchange.durable* | Whether the exchange is durable
+
+Type: _boolean_ | false | `true`
+
+| *exchange.name* | The exchange that messages are published to or consumed from. If not set, the channel name is used
+
+Type: _string_ | false | 
+
+| *exchange.type* | The exchange type: direct, fanout, headers or topic (default)
+
+Type: _string_ | false | `topic`
+
+| *handshake-timeout* | The AMQP 0-9-1 protocol handshake timeout (ms)
+
+Type: _int_ | false | `10000`
+
+| *host*
+
+_(rabbitmq-host)_ | The broker hostname
+
+Type: _string_ | false | `localhost`
+
+| *include-properties* | Whether to include properties when a broker message is passed on the event bus
+
+Type: _boolean_ | false | `false`
+
+| *max-inflight-messages* | The maximum number of messages to be written to RabbitMQ concurrently; must be a positive number
+
+Type: _long_ | false | `1024`
+
+| *max-outgoing-internal-queue-size* | The maximum size of the outgoing internal queue
+
+Type: _int_ | false | 
+
+| *network-recovery-interval* | How long (ms) will automatic recovery wait before attempting to reconnect
+
+Type: _int_ | false | `5000`
+
+| *password*
+
+_(rabbitmq-password)_ | The password used to authenticate to the broker
+
+Type: _string_ | false | 
+
+| *port*
+
+_(rabbitmq-port)_ | The broker port
+
+Type: _int_ | false | `5672`
+
+| *reconnect-attempts*
+
+_(rabbitmq-reconnect-attempts)_ | The number of reconnection attempts
+
+Type: _int_ | false | `100`
+
+| *reconnect-interval*
+
+_(rabbitmq-reconnect-interval)_ | The interval (in seconds) between two reconnection attempts
+
+Type: _int_ | false | `10`
+
+| *requested-channel-max* | The initially requested maximum channel number
+
+Type: _int_ | false | `2047`
+
+| *requested-heartbeat* | The initially requested heartbeat interval (seconds), zero for none
+
+Type: _int_ | false | `60`
+
+| *tracing.attribute-headers* | A comma-separated list of headers that should be recorded as span attributes. Relevant only if tracing.enabled=true
+
+Type: _string_ | false | ``
+
+| *tracing.enabled* | Whether tracing is enabled (default) or disabled
+
+Type: _boolean_ | false | `true`
+
+| *use-nio* | Whether usage of NIO Sockets is enabled
+
+Type: _boolean_ | false | `false`
+
+| *user* | The AMQP user name to use when connecting to the broker
+
+Type: _string_ | false | `guest`
+
+| *username*
+
+_(rabbitmq-username)_ | The username used to authenticate to the broker
+
+Type: _string_ | false | 
+
+| *virtual-host* | The virtual host to use when connecting to the broker
+
+Type: _string_ | false | `/`
+
+|===

--- a/documentation/src/main/doc/modules/rabbitmq/examples/inbound/RabbitMQMetadataExample.java
+++ b/documentation/src/main/doc/modules/rabbitmq/examples/inbound/RabbitMQMetadataExample.java
@@ -1,0 +1,36 @@
+package inbound;
+
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMetadata;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.Optional;
+
+public class RabbitMQMetadataExample {
+
+    public void metadata(final Message<String> incomingMessage) {
+        // tag::code[]
+        final Optional<IncomingRabbitMQMetadata> metadata = incomingMessage.getMetadata(IncomingRabbitMQMetadata.class);
+        metadata.ifPresent(meta -> {
+            final Optional<String> contentEncoding = meta.getContentEncoding();
+            final Optional<String> contentType = meta.getContentType();
+            final Optional<String> correlationId = meta.getCorrelationId();
+            final Optional<ZonedDateTime> creationTime = meta.getCreationTime(ZoneId.systemDefault());
+            final Optional<Integer> priority = meta.getPriority();
+            final Optional<String> replyTo = meta.getReplyTo();
+            final Optional<String> userId = meta.getUserId();
+
+            // Access a single String-valued header
+            final Optional<String> stringHeader = meta.getHeader("my-header", String.class);
+
+            // Access all headers
+            final Map<String,Object> headers = meta.getHeaders();
+            // ...
+        });
+        // end::code[]
+    }
+
+}

--- a/documentation/src/main/doc/modules/rabbitmq/examples/inbound/RabbitMQPriceConsumer.java
+++ b/documentation/src/main/doc/modules/rabbitmq/examples/inbound/RabbitMQPriceConsumer.java
@@ -1,0 +1,15 @@
+package inbound;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class RabbitMQPriceConsumer {
+
+    @Incoming("prices")
+    public void consume(String price) {
+        // process your price.
+    }
+
+}

--- a/documentation/src/main/doc/modules/rabbitmq/examples/inbound/RabbitMQPriceMessageConsumer.java
+++ b/documentation/src/main/doc/modules/rabbitmq/examples/inbound/RabbitMQPriceMessageConsumer.java
@@ -1,0 +1,20 @@
+package inbound;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.concurrent.CompletionStage;
+
+@ApplicationScoped
+public class RabbitMQPriceMessageConsumer {
+
+    @Incoming("prices")
+    public CompletionStage<Void> consume(Message<String> price) {
+        // process your price.
+
+        // Acknowledge the incoming message, marking the RabbitMQ message as `accepted`.
+        return price.ack();
+    }
+
+}

--- a/documentation/src/main/doc/modules/rabbitmq/examples/outbound/RabbitMQOutboundMetadataExample.java
+++ b/documentation/src/main/doc/modules/rabbitmq/examples/outbound/RabbitMQOutboundMetadataExample.java
@@ -1,0 +1,26 @@
+package outbound;
+
+import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
+import java.time.ZonedDateTime;
+
+public class RabbitMQOutboundMetadataExample {
+
+    public Message<String> metadata(Message<String> incoming) {
+
+        // tag::code[]
+        final OutgoingRabbitMQMetadata metadata = new OutgoingRabbitMQMetadata.Builder()
+                .withHeader("my-header", "xyzzy")
+                .withRoutingKey("urgent")
+                .withTimestamp(ZonedDateTime.now())
+                .build();
+
+        // Add `metadata` to the metadata of the outgoing message.
+        return Message.of("Hello", Metadata.of(metadata));
+        // end::code[]
+    }
+
+}

--- a/documentation/src/main/doc/modules/rabbitmq/examples/outbound/RabbitMQPriceMessageProducer.java
+++ b/documentation/src/main/doc/modules/rabbitmq/examples/outbound/RabbitMQPriceMessageProducer.java
@@ -1,0 +1,32 @@
+package outbound;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Random;
+
+@ApplicationScoped
+public class RabbitMQPriceMessageProducer {
+
+    private Random random = new Random();
+
+    @Outgoing("prices")
+    public Multi<Message<Double>> generate() {
+        // Build an infinite stream of random prices
+        // It emits a price every second
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
+                .map(x -> Message.of(random.nextDouble(),
+                        Metadata.of(new OutgoingRabbitMQMetadata.Builder()
+                                .withRoutingKey("normal")
+                                .withTimestamp(ZonedDateTime.now())
+                                .build())
+                ));
+    }
+
+}

--- a/documentation/src/main/doc/modules/rabbitmq/examples/outbound/RabbitMQPriceProducer.java
+++ b/documentation/src/main/doc/modules/rabbitmq/examples/outbound/RabbitMQPriceProducer.java
@@ -1,0 +1,23 @@
+package outbound;
+
+import io.smallrye.mutiny.Multi;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.time.Duration;
+import java.util.Random;
+
+@ApplicationScoped
+public class RabbitMQPriceProducer {
+
+    private Random random = new Random();
+
+    @Outgoing("prices")
+    public Multi<Double> generate() {
+        // Build an infinite stream of random prices
+        // It emits a price every second
+        return Multi.createFrom().ticks().every(Duration.ofSeconds(1))
+                .map(x -> random.nextDouble());
+    }
+
+}

--- a/documentation/src/main/doc/modules/rabbitmq/pages/health.adoc
+++ b/documentation/src/main/doc/modules/rabbitmq/pages/health.adoc
@@ -1,0 +1,9 @@
+[#rabbitmq-health]
+== Health reporting
+
+The RabbitMQ connector reports the readiness and liveness of each channel managed by the connector.
+
+On the inbound side (receiving messages from RabbitMQ), the check verifies that the receiver is connected to the broker.
+
+On the outbound side (sending records to RabbitMQ), the check verifies that the sender is not disconnected from the broker; the sender _may_ still be in an initiliased state (connection not yet attempted), but this is regarded as live/ready.
+

--- a/documentation/src/main/doc/modules/rabbitmq/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/rabbitmq/pages/inbound.adoc
@@ -1,0 +1,185 @@
+[#rabbitmq-inbound]
+== Receiving messages from RabbitMQ
+
+The RabbitMQ connector lets you retrieve messages from a https://www.rabbitmq.com/[RabbitMQ broker]. The RabbitMQ connector retrieves _RabbitMQ Messages_ and maps each of them into Reactive Messaging `Messages`.
+
+[NOTE]
+====
+In this context, the reactive messaging concept of a _Channel_ is realised as a https://www.rabbitmq.com/queues.html[RabbitMQ Queue].
+====
+
+=== Example
+
+Let’s imagine you have a RabbitMQ broker running, and accessible using the `rabbitmq:5672` address (by default it would use `localhost:5672`). Configure your application to receive RabbitMQ Messages on the `prices` channel as follows:
+
+[source, properties]
+----
+rabbitmq-host=rabbitmq           # <1>
+rabbitmq-port=5672               # <2>
+rabbitmq-username=my-username    # <3>
+rabbitmq-password=my-password    # <4>
+
+mp.messaging.incoming.prices.connector=smallrye-rabbitmq  # <5>
+mp.messaging.incoming.prices.queue.name=my-queue          # <6>
+mp.messaging.incoming.prices.routing-keys=urgent          # <7>
+----
+1. Configures the broker/router host name. You can do it per channel (using the `host` attribute) or globally using `rabbitmq-host`.
+
+2. Configures the broker/router port. You can do it per channel (using the `port` attribute) or globally using `rabbitmq-port`. The default is 5672.
+
+3. Configures the broker/router username if required. You can do it per channel (using the `username` attribute) or globally using `rabbitmq-username`.
+
+4. Configures the broker/router password if required. You can do it per channel (using the `password` attribute) or globally using `rabbitmq-password`.
+
+5. Instructs the `prices` channel to be managed by the RabbitMQ connector.
+
+6. Configures the RabbitMQ queue to read messages from.
+
+7. Configures the binding between the RabbitMQ exchange and the RabbitMQ queue using a routing key. The default is `#` (all messages will be forwarded from the exchange to the queue) but in general this can be a comma-separated list of one or more keys.
+
+Then, your application receives `Message<String>`. You can consume the payload directly:
+
+[source, java]
+----
+include::example$inbound/RabbitMQPriceConsumer.java[]
+----
+
+Or, you can retrieve the `Message<String>`:
+
+[source, java]
+----
+include::example$inbound/RabbitMQPriceMessageConsumer.java[]
+----
+
+[NOTE]
+Whether you need to explicitly acknowledge the message depends on the `auto-acknowledgement` channel setting; if that is set to `true` then your message will be automatically acknowledged on receipt.
+
+=== Deserialization
+
+The connector converts incoming RabbitMQ Messages into Reactive Messaging `Message<T>` instances. The payload type `T` depends on the value of the RabbitMQ received message Envelope `content_type` and `content_encoding` properties.
+
+[options="header"]
+|===
+| content_encoding | content_type      | T
+| _Value present_ | _n/a_ | `byte[]`
+| _No value_ | `text/plain`      | `String`
+| _No value_ | `application/json`   | a JSON element which can be a https://vertx.io/docs/apidocs/io/vertx/core/json/JsonArray.html[`JsonArray`], https://vertx.io/docs/apidocs/io/vertx/core/json/JsonObject.html[`JsonObject`], `String`, ...etc if the buffer contains an array, object, string, ...etc
+| _No value_ | _Anything else_  | `byte[]`
+|===
+
+If you send objects with this RabbitMQ connector (outbound connector), they are encoded as JSON and sent with `content_type` set to `application/json`. You can receive this payload using (Vert.x) JSON Objects, and then map it to the object class you want:
+
+[source, java]
+----
+@ApplicationScoped
+public static class Generator {
+
+    @Outgoing("to-rabbitmq")
+    public Multi<Price> prices() { // <1>
+        AtomicInteger count = new AtomicInteger();
+        return Multi.createFrom().ticks().every(Duration.ofMillis(1000))
+                .map(l -> new Price().setPrice(count.incrementAndGet()))
+                .onOverflow().drop();
+    }
+
+}
+
+@ApplicationScoped
+public static class Consumer {
+
+    List<Price> prices = new CopyOnWriteArrayList<>();
+
+    @Incoming("from-rabbitmq")
+    public void consume(JsonObject p) { // <2>
+        Price price = p.mapTo(Price.class); // <3>
+        prices.add(price);
+    }
+
+    public List<Price> list() {
+        return prices;
+    }
+}
+----
+1. The `Price` instances are automatically encoded to JSON by the connector
+2. You can receive it using a `JsonObject`
+3. Then, you can reconstruct the instance using the `mapTo` method
+
+=== Inbound Metadata
+
+Messages coming from RabbitMQ contain an instance of {javadoc-base}/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.html[`IncomingRabbitMQMetadata`] in the metadata.
+
+RabbitMQ message headers can be accessed from the metadata either by calling `getHeader(String header, Class<T> type)` to retrieve a single header value. or `getHeaders()` to get a map of all header values.
+
+[source,java,indent=0]
+----
+include::example$inbound/RabbitMQMetadataExample.java[tag=code]
+----
+
+The type `<T>` of the header value depends on the RabbitMQ type used for the header:
+
+[options="header"]
+|===
+| RabbitMQ Header Type      | T
+| String      | `String`
+| Boolean   | `Boolean`
+| Number    | `Number`
+| List  | `java.util.List`
+|===
+
+=== Acknowledgement
+
+When a Reactive Messaging Message associated with a RabbitMQ Message is acknowledged, it informs the broker that the message has been _accepted_.
+
+Whether you need to explicitly acknowledge the message depends on the `auto-acknowledgement` setting for the channel; if that is set to `true` then your message will be automatically acknowledged on receipt.
+
+=== Failure Management
+
+If a message produced from a RabbitMQ message is _nacked_, a failure strategy is applied. The RabbitMQ connector supports three strategies, controlled by the `failure-strategy` channel setting:
+
+* `fail` - fail the application; no more RabbitMQ messages will be processed. The RabbitMQ message is marked as rejected.
+
+* `accept` - this strategy marks the RabbitMQ message as accepted. The processing continues ignoring the failure.
+
+* `reject` - this strategy marks the RabbitMQ message as rejected (default). The processing continues with the next message.
+
+=== Configuration Reference
+
+include::connectors:partial$META-INF/connector/smallrye-rabbitmq-incoming.adoc[]
+
+To use an existing _queue_, you need to configure the `queue.name` attribute.
+
+For example, if you have a RabbitMQ broker already configured with a queue called `peopleQueue` that you wish to read messages from, you need the following configuration:
+
+[source, properties]
+----
+mp.messaging.incoming.people.connector=smallrye-rabbitmq
+mp.messaging.incoming.people.queue.name=peopleQueue
+----
+
+If you want RabbitMQ to create the queue for you but bind it to an existing topic exchange `people`, you need the following configuration:
+
+[source, properties]
+----
+mp.messaging.incoming.people.connector=smallrye-rabbitmq
+mp.messaging.incoming.people.queue.name=peopleQueue
+mp.messaging.incoming.people.queue.declare=true
+----
+
+[NOTE]
+In the above the channel name `people` is implicitly assumed to be the name of the exchange; if this is not the case you would need to name the exchange explicitly using the `exchange.name` property.
+
+If you want RabbitMQ to create the `people` exchange, queue and binding, you need the following configuration:
+
+[source, properties]
+----
+mp.messaging.incoming.people.connector=smallrye-rabbitmq
+mp.messaging.incoming.people.exchange.declare=true
+mp.messaging.incoming.people.queue.name=peopleQueue
+mp.messaging.incoming.people.queue.declare=true
+mp.messaging.incoming.people.queue.routing-keys=tall,short
+----
+
+In the above we have used an explicit list of routing keys rather than the default (`#`). Each component of the list creates a separate binding between the queue and the exchange, so in the case above we would have two bindings; one based on a routing key of `tall`, the other based on one of `short`.
+
+[NOTE]
+The default value of `routing-keys` is `#` (indicating a match against all possible routing keys) which is only appropriate for _topic_ Exchanges. If you are using other types of exchange and/or need to declare queue bindings, you'll need to supply a valid value for the exchange in question.

--- a/documentation/src/main/doc/modules/rabbitmq/pages/installation.adoc
+++ b/documentation/src/main/doc/modules/rabbitmq/pages/installation.adoc
@@ -1,0 +1,26 @@
+[#rabbitmq-installation]
+== Using the RabbitMQ connector
+
+To use the RabbitMQ Connector, add the following dependency to your project:
+
+[source,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>io.smallrye.reactive</groupId>
+  <artifactId>smallrye-reactive-messaging-rabbitmq</artifactId>
+  <version>{project-version}</version>
+</dependency>
+----
+
+The connector name is: `smallrye-rabbitmq`.
+
+So, to indicate that a channel is managed by this connector you need:
+
+[source]
+----
+# Inbound
+mp.messaging.incoming.[channel-name].connector=smallrye-rabbitmq
+
+# Outbound
+mp.messaging.outgoing.[channel-name].connector=smallrye-rabbitmq
+----

--- a/documentation/src/main/doc/modules/rabbitmq/pages/outbound.adoc
+++ b/documentation/src/main/doc/modules/rabbitmq/pages/outbound.adoc
@@ -1,0 +1,110 @@
+[#rabbitmq-outbound]
+== Sending messages to RabbitMQ
+
+The RabbitMQ connector can write Reactive Messaging `Messages` as RabbitMQ Messages.
+
+[NOTE]
+====
+In this context, the reactive messaging concept of a _Channel_ is realised as a https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchanges[RabbitMQ Exchange].
+====
+
+=== Example
+
+Let’s imagine you have a RabbitMQ broker running, and accessible using the `rabbitmq:5672` address (by default it would use `localhost:5672`). Configure your application to send the messages from the `prices` channel as a RabbitMQ Message as follows:
+
+[source]
+----
+rabbitmq-host=rabbitmq         # <1>
+rabbitmq-port=5672             # <2>
+rabbitmq-username=my-username  # <3>
+rabbitmq-password=my-password  # <4>
+
+mp.messaging.outgoing.prices.connector=smallrye-rabbitmq  # <5>
+mp.messaging.outgoing.prices.default-routing-key=normal   # <6>
+----
+1. Configures the broker/router host name. You can do it per channel (using the `host` attribute) or globally using `rabbitmq-host`
+2. Configures the broker/router port. You can do it per channel (using the `port` attribute) or globally using `rabbitmq-port`. The default is `5672`.
+3. Configures the broker/router username if required. You can do it per channel (using the `username` attribute) or globally using `rabbitmq-username`.
+4. Configures the broker/router password if required. You can do it per channel (using the `password` attribute) or globally using `rabbitmq-password`.
+5. Instructs the `prices` channel to be managed by the RabbitMQ connector
+6. Supplies the default routing key to be included in outbound messages; this will be if the "raw payload" form of message sending is used (see below).
+
+NOTE: You don’t need to set the RabbitMQ exchange name. By default, it uses the channel name (`prices`) as the name of the exchange to send messages to. You can configure the `exchange.name` attribute to override it.
+
+Then, your application can send `Message<Double>` to the prices channel. It can use `double` payloads as in the following snippet:
+
+[source, java]
+----
+include::example$outbound/RabbitMQPriceProducer.java[]
+----
+
+Or, you can send `Message<Double>`, which affords the opportunity to explicitly specify metadata on the outgoing message:
+
+[source, java]
+----
+include::example$outbound/RabbitMQPriceMessageProducer.java[]
+----
+
+=== Serialization
+
+When sending a `Message<T>`, the connector converts the message into a RabbitMQ Message. The payload is converted to the RabbitMQ Message body.
+
+[options=header]
+|===
+| T	| RabbitMQ Message Body
+| primitive types or `UUID`/`String` | String value with `content_type` set to `text/plain`
+| https://vertx.io/docs/apidocs/io/vertx/core/json/JsonObject.html[`JsonObject`] or https://vertx.io/docs/apidocs/io/vertx/core/json/JsonArray.html[`JsonArray`] | Serialized String payload with `content_type` set to `application/json`
+| `io.vertx.mutiny.core.buffer.Buffer` | Binary content, with `content_type` set to `application/octet-stream`
+| `byte[]`| Binary content, with content_type set to `application/octet-stream`
+| Any other class | The payload is converted to JSON (using a Json Mapper) then serialized with `content_type` set to `application/json`
+|===
+
+If the message payload cannot be serialized to JSON, the message is _nacked_.
+
+=== Outbound Metadata
+
+When sending `Messages`, you can add an instance of {javadoc-base}/apidocs/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.html[`OutgoingRabbitMQMetadata`] to influence how the message is handled by RabbitMQ. For example, you can configure the routing key, timestamp and headers:
+
+[source, java]
+----
+include::example$outbound/RabbitMQOutboundMetadataExample.java[tag=code]
+----
+
+=== Acknowledgement
+
+By default, the Reactive Messaging `Message` is acknowledged when the broker acknowledges the message.
+
+=== Configuration Reference
+
+include::connectors:partial$META-INF/connector/smallrye-rabbitmq-outgoing.adoc[]
+
+=== Using existing destinations
+
+To use an existing _exchange_, you may need to configure the `exchange.name` attribute.
+
+For example, if you have a RabbitMQ broker already configured with an exchange called `people` that you wish to send messages to, you need the following configuration:
+
+[source, properties]
+----
+mp.messaging.outgoing.people.connector=smallrye-rabbitmq
+----
+
+You would need to configure the `exchange.name` attribute, if the exchange name were not the channel name:
+
+[source, properties]
+----
+mp.messaging.outgoing.people-out.connector=smallrye-rabbitmq
+mp.messaging.outgoing.people-out.exchange.name=people
+----
+
+If you want RabbitMQ to create the `people` exchange, you need the following configuration:
+
+[source, properties]
+----
+mp.messaging.outgoing.people-out.connector=smallrye-amqp
+mp.messaging.outgoing.people-out.exchange.name=people
+mp.messaging.outgoing.people-out.exchange.declare=true
+----
+
+[NOTE]
+The above example will create a `topic` exchange and use an empty default `routing-key` (unless overridden programatically using outgoing metadata for the message). If you want to create a different type of exchange or have a different default routing key, then the `exchange.type` and `default-routing-key` properties need to be explicitly specified.

--- a/documentation/src/main/doc/modules/rabbitmq/pages/rabbitmq.adoc
+++ b/documentation/src/main/doc/modules/rabbitmq/pages/rabbitmq.adoc
@@ -1,0 +1,25 @@
+= RabbitMQ
+
+The RabbitMQ Connector adds support for RabbitMQ to Reactive Messaging, based on the AMQP 0-9-1 Protocol Specification.
+
+Advanced Message Queuing Protocol 0-9-1 (https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf[AMQP 0-9-1]) is an open standard for passing business messages between applications or organizations.
+
+With this connector, your application can:
+
+* receive messages from a RabbitMQ queue
+* send messages to a RabbitMQ exchange
+
+The RabbitMQ connector is based on the https://vertx.io/docs/vertx-rabbitmq-client/java/[Vert.x RabbitMQ Client].
+
+[IMPORTANT]
+====
+The *AMQP connector* supports the AMQP 1.0 protocol, which is very different from AMQP 0-9-1. You _can_ use the AMQP connector with RabbitMQ provided that the latter has the https://github.com/rabbitmq/rabbitmq-amqp1.0/blob/v3.7.x/README.md[AMQP 1.0 Plugin] installed, albeit with reduced functionality.
+====
+
+include::installation.adoc[]
+include::inbound.adoc[]
+include::outbound.adoc[]
+include::health.adoc[]
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
     <module>smallrye-reactive-messaging-amqp</module>
     <module>smallrye-reactive-messaging-jms</module>
     <module>smallrye-reactive-messaging-health</module>
+    <module>smallrye-reactive-messaging-rabbitmq</module>
     <module>examples/quickstart</module>
     <module>examples/kafka-quickstart</module>
     <module>examples/kafka-quickstart-kotlin</module>

--- a/smallrye-reactive-messaging-rabbitmq/pom.xml
+++ b/smallrye-reactive-messaging-rabbitmq/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.smallrye.reactive</groupId>
+    <artifactId>smallrye-reactive-messaging</artifactId>
+    <version>3.6.0</version>
+  </parent>
+
+  <artifactId>smallrye-reactive-messaging-rabbitmq</artifactId>
+
+  <name>SmallRye Reactive Messaging : Connector :: RabbitMQ</name>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-reactive-messaging-provider</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-mutiny-vertx-rabbitmq-client</artifactId>
+      <version>${smallrye-vertx-mutiny-clients.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rabbitmq-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>test-common</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-connector-attribute-processor</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-semconv</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <generatedSourcesDirectory>${project.build.directory}/generated-sources/</generatedSourcesDirectory>
+          <annotationProcessors>
+            <annotationProcessor>
+              io.smallrye.reactive.messaging.connector.ConnectorAttributeProcessor
+            </annotationProcessor>
+            <annotationProcessor>
+              org.jboss.logging.processor.apt.LoggingToolsProcessor
+            </annotationProcessor>
+          </annotationProcessors>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <!-- Tests that require test-containers
+                 Enable with -Dtest-containers or -Ptest-containers -->
+            <exclude>**/RabbitMQTest.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+
+  <profiles>
+    <profile>
+      <id>coverage</id>
+      <properties>
+        <argLine>@{jacocoArgLine}</argLine>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>test-containers</id>
+      <activation>
+        <property>
+          <name>test-containers</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <excludes combine.self="override">
+               </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/smallrye-reactive-messaging-rabbitmq/pom.xml
+++ b/smallrye-reactive-messaging-rabbitmq/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.smallrye.reactive</groupId>
     <artifactId>smallrye-reactive-messaging</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-reactive-messaging-rabbitmq</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-reactive-messaging-provider</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
@@ -37,14 +37,14 @@
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>test-common</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-connector-attribute-processor</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ConnectionHolder.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ConnectionHolder.java
@@ -1,0 +1,137 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions.ex;
+import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.rabbitmq.RabbitMQClient;
+
+public class ConnectionHolder {
+    private final RabbitMQClient client;
+    private final RabbitMQConnectorCommonConfiguration configuration;
+    private final AtomicReference<CurrentConnection> holder = new AtomicReference<>();
+
+    private final Vertx vertx;
+
+    public ConnectionHolder(RabbitMQClient client,
+            RabbitMQConnectorCommonConfiguration configuration,
+            Vertx vertx) {
+        this.client = client;
+        this.configuration = configuration;
+        this.vertx = vertx;
+    }
+
+    public static CompletionStage<Void> runOnContext(Context context, Runnable runnable) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        if (Vertx.currentContext() == context) {
+            runnable.run();
+            future.complete(null);
+        } else {
+            context.runOnContext(() -> {
+                runnable.run();
+                future.complete(null);
+            });
+        }
+        return future;
+    }
+
+    public static CompletionStage<Void> runOnContextAndReportFailure(Context context, Throwable reason, Runnable runnable) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        if (Vertx.currentContext() == context) {
+            runnable.run();
+            future.completeExceptionally(reason);
+        } else {
+            context.runOnContext(() -> {
+                runnable.run();
+                future.completeExceptionally(reason);
+            });
+        }
+        return future;
+    }
+
+    public Context getContext() {
+        CurrentConnection connection = holder.get();
+        if (connection != null) {
+            return connection.context;
+        } else {
+            return null;
+        }
+    }
+
+    public Uni<Void> getAck(final long deliveryTag) {
+        return client.basicAck(deliveryTag, false);
+    }
+
+    public Function<Throwable, CompletionStage<Void>> getNack(final long deliveryTag, final boolean requeue) {
+        return t -> client.basicNack(deliveryTag, false, requeue).subscribeAsCompletionStage();
+    }
+
+    public Vertx getVertx() {
+        return vertx;
+    }
+
+    @SuppressWarnings("unused")
+    public synchronized void onFailure(Consumer<Throwable> callback) {
+        // As RabbitMQClient doesn't have a failure callback mechanism, there isn't much we can do here
+    }
+
+    public Uni<RabbitMQClient> getOrEstablishConnection() {
+        return Uni.createFrom().item(() -> {
+            final CurrentConnection connection = holder.get();
+            if (connection != null && connection.connection != null && connection.connection.isConnected()) {
+                return connection.connection;
+            } else {
+                return null;
+            }
+        })
+                .onItem().ifNull().switchTo(() -> {
+                    // we don't have a connection, try to connect.
+                    CurrentConnection reference = holder.get();
+
+                    if (reference != null && reference.connection != null && reference.connection.isConnected()) {
+                        RabbitMQClient connection = reference.connection;
+                        return Uni.createFrom().item(connection);
+                    }
+
+                    log.establishingConnection(configuration.getChannel());
+                    return client.start()
+                            .onSubscribe().invoke(() -> log.connectionEstablished(configuration.getChannel()))
+                            .onItem().transform(ignored -> {
+                                holder.set(new CurrentConnection(client, Vertx.currentContext()));
+
+                                // handle the case we are already disconnected.
+                                if (!client.isConnected() || holder.get() == null) {
+                                    // Throwing the exception would trigger a retry.
+                                    holder.set(null);
+                                    throw ex.illegalStateConnectionDisconnected();
+                                }
+
+                                return client;
+                            })
+                            .onFailure().invoke(ex -> log.unableToConnectToBroker(ex))
+                            .onFailure().invoke(t -> {
+                                holder.set(null);
+                                log.unableToRecoverFromConnectionDisruption(t);
+                            });
+                });
+    }
+
+    private static class CurrentConnection {
+        final RabbitMQClient connection;
+        final Context context;
+
+        private CurrentConnection(RabbitMQClient connection, Context context) {
+            this.connection = connection;
+            this.context = context;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessage.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessage.java
@@ -1,0 +1,183 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.smallrye.reactive.messaging.TracingMetadata;
+import io.smallrye.reactive.messaging.rabbitmq.ack.RabbitMQAckHandler;
+import io.smallrye.reactive.messaging.rabbitmq.fault.RabbitMQFailureHandler;
+import io.smallrye.reactive.messaging.rabbitmq.tracing.TracingUtils;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.mutiny.core.Context;
+
+/**
+ * An implementation of {@link Message} suitable for incoming RabbitMQ messages.
+ *
+ * @param <T> the message body type
+ */
+public class IncomingRabbitMQMessage<T> implements Message<T> {
+
+    protected final io.vertx.rabbitmq.RabbitMQMessage message;
+    protected Metadata metadata;
+    protected final IncomingRabbitMQMetadata rabbitMQMetadata;
+    private final ConnectionHolder holder;
+    private final Context context;
+    private final long deliveryTag;
+    protected final RabbitMQFailureHandler onNack;
+    protected final RabbitMQAckHandler onAck;
+
+    IncomingRabbitMQMessage(io.vertx.mutiny.rabbitmq.RabbitMQMessage delegate, ConnectionHolder holder,
+            boolean isTracingEnabled, RabbitMQFailureHandler onNack,
+            RabbitMQAckHandler onAck) {
+        this(delegate.getDelegate(), holder, isTracingEnabled, onNack, onAck);
+    }
+
+    IncomingRabbitMQMessage(io.vertx.rabbitmq.RabbitMQMessage msg, ConnectionHolder holder, boolean isTracingEnabled,
+            RabbitMQFailureHandler onNack, RabbitMQAckHandler onAck) {
+        this.message = msg;
+        this.deliveryTag = msg.envelope().getDeliveryTag();
+        this.holder = holder;
+        this.context = holder.getContext();
+        this.rabbitMQMetadata = new IncomingRabbitMQMetadata(this.message);
+        this.onNack = onNack;
+        this.onAck = onAck;
+        this.metadata = Metadata.of(rabbitMQMetadata);
+
+        // If tracing is enabled, ensure any tracing metadata in the received msg headers is transferred as metadata.
+        if (isTracingEnabled) {
+            this.metadata = this.metadata.with(TracingUtils.getTracingMetaData(msg));
+        }
+    }
+
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
+        //return () -> onAck.handle(this, context);
+    }
+
+    @Override
+    public Function<Throwable, CompletionStage<Void>> getNack() {
+        return this::nack;
+    }
+
+    @Override
+    public CompletionStage<Void> ack() {
+        // We must switch to the context having created the message.
+        // This context is passed when this instance of message is created.
+        // It's more a Vert.x RabbitMQ client issue which should ensure calling `accepted` on the right context.
+        return onAck.handle(this, context);
+    }
+
+    @Override
+    public CompletionStage<Void> nack(Throwable reason, Metadata metadata) {
+        // We must switch to the context having created the message.
+        // This context is passed when this instance of message is created.
+        // It's more a Vert.x RabbitMQ client issue which should ensure calling `not accepted` on the right context.
+        return onNack.handle(this, context, reason);
+    }
+
+    /**
+     * Acknowledges the message.
+     *
+     */
+    public void acknowledgeMessage() {
+        holder.getAck(this.deliveryTag).subscribeAsCompletionStage();
+    }
+
+    /**
+     * Rejects the message by nack'ing with requeue=false; this will either discard the message for good or
+     * (if a DLQ has been set up) send it to the DLQ.
+     * 
+     * @param reason the cause of the rejection, which must not be null
+     */
+    public void rejectMessage(Throwable reason) {
+        holder.getNack(this.deliveryTag, false).apply(reason);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T getPayload() {
+        // Throw a class cast exception if it cannot be converted.
+        return (T) convertPayload(message);
+    }
+
+    @Override
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    private Object convertPayload(io.vertx.rabbitmq.RabbitMQMessage msg) {
+        // Neither of these are guaranteed to be non-null
+        final String contentType = msg.properties().getContentType();
+        final String contentEncoding = msg.properties().getContentEncoding();
+        final Buffer body = msg.body();
+
+        // If there is a content encoding specified, we don't try to unwrap
+        if (contentEncoding == null) {
+            // Do our best with text and json
+            if (HttpHeaderValues.APPLICATION_JSON.toString().equalsIgnoreCase(contentType)) {
+                // This could be  JsonArray, JsonObject, String etc. depending on buffer contents
+                return body.toJson();
+            } else if (HttpHeaderValues.TEXT_PLAIN.toString().equalsIgnoreCase(contentType)) {
+                return body.toString();
+            }
+        }
+
+        // Otherwise fall back to raw byte array
+        return body.getBytes();
+    }
+
+    public Optional<Integer> getPriority() {
+        return rabbitMQMetadata.getPriority();
+    }
+
+    public Optional<String> getReplyTo() {
+        return rabbitMQMetadata.getReplyTo();
+    }
+
+    public Optional<String> getUserId() {
+        return rabbitMQMetadata.getUserId();
+    }
+
+    public Optional<String> getMessageId() {
+        return rabbitMQMetadata.getId();
+    }
+
+    public Optional<ZonedDateTime> getCreationTime(final ZoneId zoneId) {
+        return rabbitMQMetadata.getCreationTime(zoneId);
+    }
+
+    public Optional<String> getContentType() {
+        return rabbitMQMetadata.getContentType();
+    }
+
+    public Optional<String> getCorrelationId() {
+        return rabbitMQMetadata.getCorrelationId();
+    }
+
+    public Optional<String> getContentEncoding() {
+        return rabbitMQMetadata.getContentEncoding();
+    }
+
+    public Map<String, Object> getHeaders() {
+        return rabbitMQMetadata.getHeaders();
+    }
+
+    public io.vertx.mutiny.rabbitmq.RabbitMQMessage getRabbitMQMessage() {
+        return new io.vertx.mutiny.rabbitmq.RabbitMQMessage(message);
+    }
+
+    public synchronized void injectTracingMetadata(TracingMetadata tracingMetadata) {
+        metadata = metadata.with(tracingMetadata);
+    }
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
@@ -25,7 +25,7 @@ public class IncomingRabbitMQMetadata {
 
     /**
      * Constructor.
-     * 
+     *
      * @param message the underlying {@link RabbitMQMessage}
      */
     IncomingRabbitMQMetadata(RabbitMQMessage message) {
@@ -41,7 +41,7 @@ public class IncomingRabbitMQMetadata {
 
     /**
      * Recursive function to root out {@link LongString} values in arbitrary depth nested lists.
-     * 
+     *
      * @param v the value to map
      * @return the mapped value, with any embedded {@link LongString} values transformed to their
      *         regular {@link String} equivalents
@@ -58,26 +58,26 @@ public class IncomingRabbitMQMetadata {
 
     /**
      * Retrieves the header value cast to the required type.
-     * 
+     *
      * @param header the name of the header
      * @param type the required type
      * @param <T> the type
-     * @return the cast header value, which may be null if the header is not present
+     * @return the cast header value, which may be empty if the header is not present
      * @throws IllegalArgumentException if the header value could not be cast as required
      */
     @SuppressWarnings("unused")
     @Nullable
-    public <T> T getHeader(final String header, final Class<T> type) {
+    public <T> Optional<T> getHeader(final String header, final Class<T> type) {
         final Object value = this.headers.get(header);
         if (value == null) {
-            return null;
+            return Optional.empty();
         }
         if (!type.isAssignableFrom(value.getClass())) {
             throw new IllegalArgumentException("Incorrect type specified for header '" +
                     header + "'. Expected [" + type + "] but actual type is [" + value.getClass() + "]");
         }
         //noinspection unchecked
-        return (T) value;
+        return Optional.of((T) value);
     }
 
     /**
@@ -128,7 +128,7 @@ public class IncomingRabbitMQMetadata {
      * with respect to the supplied {@link ZoneId}.
      * <p>
      * Stored in the message properties.
-     * 
+     *
      * @param zoneId the {@link ZoneId} representing the time zone in which the timestamp is to be interpreted
      * @return an {@link Optional} containing the date and time, which may be empty if no timestamp was received
      */

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
@@ -1,0 +1,199 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.rabbitmq.client.LongString;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.rabbitmq.RabbitMQMessage;
+
+/**
+ * Holds metadata from an incoming RabbitMQ message.
+ */
+public class IncomingRabbitMQMetadata {
+
+    private final RabbitMQMessage message;
+    private final Map<String, Object> headers;
+
+    /**
+     * Constructor.
+     * 
+     * @param message the underlying {@link RabbitMQMessage}
+     */
+    IncomingRabbitMQMetadata(RabbitMQMessage message) {
+        this.message = message;
+
+        // Ensure the message headers are cast appropriately
+        final Map<String, Object> incomingHeaders = message.properties().getHeaders();
+        headers = (incomingHeaders != null) ? incomingHeaders.entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> mapValue(e.getValue())))
+                : new HashMap<>();
+    }
+
+    /**
+     * Recursive function to root out {@link LongString} values in arbitrary depth nested lists.
+     * 
+     * @param v the value to map
+     * @return the mapped value, with any embedded {@link LongString} values transformed to their
+     *         regular {@link String} equivalents
+     */
+    private static Object mapValue(final Object v) {
+        if (v instanceof LongString) {
+            return v.toString();
+        } else if (v instanceof List) {
+            return ((List<?>) v).stream().map(IncomingRabbitMQMetadata::mapValue).collect(Collectors.toList());
+        } else {
+            return v;
+        }
+    }
+
+    /**
+     * Retrieves the header value cast to the required type.
+     * 
+     * @param header the name of the header
+     * @param type the required type
+     * @param <T> the type
+     * @return the cast header value, which may be null if the header is not present
+     * @throws IllegalArgumentException if the header value could not be cast as required
+     */
+    @SuppressWarnings("unused")
+    @Nullable
+    public <T> T getHeader(final String header, final Class<T> type) {
+        final Object value = this.headers.get(header);
+        if (value == null) {
+            return null;
+        }
+        if (!type.isAssignableFrom(value.getClass())) {
+            throw new IllegalArgumentException("Incorrect type specified for header '" +
+                    header + "'. Expected [" + type + "] but actual type is [" + value.getClass() + "]");
+        }
+        //noinspection unchecked
+        return (T) value;
+    }
+
+    /**
+     * The headers property is a key/value map that allows for arbitrary, user-defined keys and values.
+     * Keys are string values that have a maximum length of 255 characters. Values can be any valid AMQP value
+     * type; this includes {@link String}, {@link Long}, {@link Boolean} and {@link List}.
+     * <p>
+     * List values may contain a mixture of other values of any of the above types (including List).
+     * </p>
+     *
+     * @return the message headers as an unmodifiable {@link Map}
+     */
+    public Map<String, Object> getHeaders() {
+        return Collections.unmodifiableMap(headers);
+    }
+
+    /**
+     * The RFC-2046 MIME type for the message's application-data section (body).
+     * As per RFC-2046 this can contain a charset parameter defining the character encoding used: e.g.,
+     * 'text/plain; charset="utf-8"'.
+     * <p>
+     * If the payload is known to be truly opaque binary data, the content-type should be set to application/octet-stream.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the content-type, which may be empty if no content-type was received
+     */
+    public Optional<String> getContentType() {
+        return Optional.ofNullable(message.properties().getContentType());
+    }
+
+    /**
+     * The content-encoding property is used as a modifier to the content-type.
+     * When present, its value indicates what additional content encodings have been applied to the application-data,
+     * and thus what decoding mechanisms need to be applied in order to obtain the media-type referenced by the
+     * content-type header field.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the content-encoding, which may be empty if no content-encoding was received
+     */
+    public Optional<String> getContentEncoding() {
+        return Optional.ofNullable(message.properties().getContentEncoding());
+    }
+
+    /**
+     * The absolute time when this message was created, expressed as a {@link ZonedDateTime}
+     * with respect to the supplied {@link ZoneId}.
+     * <p>
+     * Stored in the message properties.
+     * 
+     * @param zoneId the {@link ZoneId} representing the time zone in which the timestamp is to be interpreted
+     * @return an {@link Optional} containing the date and time, which may be empty if no timestamp was received
+     */
+    public Optional<ZonedDateTime> getCreationTime(final ZoneId zoneId) {
+        final Optional<Date> timestamp = Optional.ofNullable(message.properties().getTimestamp());
+        return timestamp.map(t -> ZonedDateTime.ofInstant(t.toInstant(), zoneId));
+    }
+
+    /**
+     * The message-id, if set, uniquely identifies a message within the message system.
+     * The message producer is usually responsible for setting the message-id in such a way that it is assured to be
+     * globally unique. A broker may discard a message as a duplicate if the value of the message-id matches that of a
+     * previously received message sent to the same node.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the message-id, which may be empty if no message-id was received
+     */
+    public Optional<String> getId() {
+        return Optional.ofNullable(message.properties().getMessageId());
+    }
+
+    /**
+     * The identity of the user responsible for producing the message.
+     * The client sets this value, and it may be authenticated by intermediaries.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the user-id, which may be empty if no user-id was received
+     */
+    public Optional<String> getUserId() {
+        return Optional.ofNullable(message.properties().getUserId());
+    }
+
+    /**
+     * This priority field contains the relative message priority. Higher numbers indicate higher priority messages.
+     * Messages with higher priorities may be delivered before those with lower priorities.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the priority, which may be empty if no priority was received
+     */
+    public Optional<Integer> getPriority() {
+        return Optional.ofNullable(message.properties().getPriority());
+    }
+
+    /**
+     * The address of the node to send replies to.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the reply-to address, which may be empty if no reply-to was received
+     */
+    public Optional<String> getReplyTo() {
+        return Optional.ofNullable(message.properties().getReplyTo());
+    }
+
+    /**
+     * This is a client-specific id that can be used to mark or identify messages between clients.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the correlation-id, which may be empty if no correlation-id was received
+     */
+    public Optional<String> getCorrelationId() {
+        return Optional.ofNullable(message.properties().getCorrelationId());
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
@@ -1,0 +1,228 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.vertx.codegen.annotations.Fluent;
+
+/**
+ * Used to represent RabbitMQ metadata in on outgoing message.
+ */
+public class OutgoingRabbitMQMetadata {
+
+    private Integer priority;
+    private String contentType;
+    private String contentEncoding;
+    private final Map<String, Object> headers = new HashMap<>();
+    private Integer deliveryMode;
+    private String correlationId;
+    private String replyTo;
+    private String expiration;
+    private String messageId;
+    private ZonedDateTime timestamp;
+    private String type;
+    private String userId;
+    private String appId;
+    private String clusterId;
+    private String routingKey;
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public String getContentEncoding() {
+        return contentEncoding;
+    }
+
+    public Map<String, Object> getHeaders() {
+        return headers;
+    }
+
+    public Integer getDeliveryMode() {
+        return deliveryMode;
+    }
+
+    public Integer getPriority() {
+        return priority;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public String getReplyTo() {
+        return replyTo;
+    }
+
+    public String getExpiration() {
+        return expiration;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    public String getRoutingKey() {
+        return routingKey;
+    }
+
+    /**
+     * Allows the builder-style construction of {@link OutgoingRabbitMQMetadata}
+     */
+    public static class Builder {
+        private Integer priority;
+        private String contentType;
+        private String contentEncoding;
+        private Map<String, Object> headers = new HashMap<>();
+        private Integer deliveryMode;
+        private String correlationId;
+        private String replyTo;
+        private String expiration;
+        private String messageId;
+        private ZonedDateTime timestamp;
+        private String type;
+        private String userId;
+        private String appId;
+        private String clusterId;
+        private String routingKey;
+
+        /**
+         * Adds a message header.
+         * 
+         * @param header the header name
+         * @param value the header value
+         * @return this {@link Builder}
+         */
+        @Fluent
+        public Builder withHeader(final String header, final Object value) {
+            headers.put(header, value);
+            return this;
+        }
+
+        @Fluent
+        public Builder withAppId(final String appId) {
+            this.appId = appId;
+            return this;
+        }
+
+        @Fluent
+        public Builder withContentEncoding(final String contentEncoding) {
+            this.contentEncoding = contentEncoding;
+            return this;
+        }
+
+        @Fluent
+        public Builder withClusterId(final String clusterId) {
+            this.clusterId = clusterId;
+            return this;
+        }
+
+        @Fluent
+        public Builder withContentType(final String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        @Fluent
+        public Builder withCorrelationId(final String correlationId) {
+            this.correlationId = correlationId;
+            return this;
+        }
+
+        @Fluent
+        public Builder withDeliveryMode(final Integer deliveryMode) {
+            this.deliveryMode = deliveryMode;
+            return this;
+        }
+
+        @Fluent
+        public Builder withExpiration(final String expiration) {
+            this.expiration = expiration;
+            return this;
+        }
+
+        @Fluent
+        public Builder withMessageId(final String messageId) {
+            this.messageId = messageId;
+            return this;
+        }
+
+        @Fluent
+        public Builder withPriority(final Integer priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        @Fluent
+        public Builder withReplyTo(final String replyTo) {
+            this.replyTo = replyTo;
+            return this;
+        }
+
+        @Fluent
+        public Builder withRoutingKey(final String routingKey) {
+            this.routingKey = routingKey;
+            return this;
+        }
+
+        @Fluent
+        public Builder withTimestamp(final ZonedDateTime timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        @Fluent
+        public Builder withType(final String type) {
+            this.type = type;
+            return this;
+        }
+
+        @Fluent
+        public Builder withUserId(final String userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public OutgoingRabbitMQMetadata build() {
+            final OutgoingRabbitMQMetadata metadata = new OutgoingRabbitMQMetadata();
+            metadata.appId = appId;
+            metadata.contentEncoding = contentEncoding;
+            metadata.clusterId = clusterId;
+            metadata.correlationId = correlationId;
+            metadata.headers.putAll(headers);
+            metadata.contentType = contentType;
+            metadata.correlationId = correlationId;
+            metadata.deliveryMode = deliveryMode;
+            metadata.expiration = expiration;
+            metadata.messageId = messageId;
+            metadata.priority = priority;
+            metadata.replyTo = replyTo;
+            metadata.routingKey = routingKey;
+            metadata.timestamp = timestamp;
+            metadata.type = type;
+            metadata.userId = userId;
+            return metadata;
+        }
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
@@ -4,8 +4,6 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.vertx.codegen.annotations.Fluent;
-
 /**
  * Used to represent RabbitMQ metadata in on outgoing message.
  */
@@ -109,101 +107,176 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a message header.
-         * 
+         *
          * @param header the header name
          * @param value the header value
          * @return this {@link Builder}
          */
-        @Fluent
         public Builder withHeader(final String header, final Object value) {
             headers.put(header, value);
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds an application id property to the metadata
+         * 
+         * @param appId the application id
+         * @return this {@link Builder}
+         */
         public Builder withAppId(final String appId) {
             this.appId = appId;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a content encoding property to the metadata
+         * 
+         * @param contentEncoding the MIME content encoding
+         * @return this {@link Builder}
+         */
         public Builder withContentEncoding(final String contentEncoding) {
             this.contentEncoding = contentEncoding;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a cluster id property to the metadata
+         * 
+         * @param clusterId the cluster id
+         * @return this {@link Builder}
+         */
         public Builder withClusterId(final String clusterId) {
             this.clusterId = clusterId;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a content type property to the metadata
+         * 
+         * @param contentType the MIME content type
+         * @return this {@link Builder}
+         */
         public Builder withContentType(final String contentType) {
             this.contentType = contentType;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a correlation id property to the metadata
+         * 
+         * @param correlationId the correlation id
+         * @return this {@link Builder}
+         */
         public Builder withCorrelationId(final String correlationId) {
             this.correlationId = correlationId;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a delivery mode property to the metadata
+         * 
+         * @param deliveryMode the delivery mode; use 1 for non-persistent
+         *        and 2 for persistent
+         * @return this {@link Builder}
+         */
         public Builder withDeliveryMode(final Integer deliveryMode) {
             this.deliveryMode = deliveryMode;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds an expiration property to the metadata
+         * 
+         * @param expiration a string-valued representation of a time (ms)
+         * @return this {@link Builder}
+         */
         public Builder withExpiration(final String expiration) {
             this.expiration = expiration;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a message id property to the metadata
+         * 
+         * @param messageId the message id
+         * @return this {@link Builder}
+         */
         public Builder withMessageId(final String messageId) {
             this.messageId = messageId;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a priority property to the metadata
+         * 
+         * @param priority the priority (value between 0 and 9 inclusive)
+         * @return this {@link Builder}
+         */
         public Builder withPriority(final Integer priority) {
             this.priority = priority;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a reply to property to the metadata
+         * 
+         * @param replyTo the address to reply to the message
+         * @return this {@link Builder}
+         */
         public Builder withReplyTo(final String replyTo) {
             this.replyTo = replyTo;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a routing key property to the metadata
+         * 
+         * @param routingKey the routing key
+         * @return this {@link Builder}
+         */
         public Builder withRoutingKey(final String routingKey) {
             this.routingKey = routingKey;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a timestamp property to the metadata
+         * 
+         * @param timestamp a {@link ZonedDateTime} representing the timestamp
+         * @return this {@link Builder}
+         */
         public Builder withTimestamp(final ZonedDateTime timestamp) {
             this.timestamp = timestamp;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a type property to the metadata
+         * 
+         * @param type the type
+         * @return this {@link Builder}
+         */
         public Builder withType(final String type) {
             this.type = type;
             return this;
         }
 
-        @Fluent
+        /**
+         * Adds a user id property to the metadata
+         * 
+         * @param userId the user id
+         * @return this {@link Builder}
+         */
         public Builder withUserId(final String userId) {
             this.userId = userId;
             return this;
         }
 
+        /**
+         * Returns the built {@link OutgoingRabbitMQMetadata}.
+         * 
+         * @return the outgoing metadata
+         */
         public OutgoingRabbitMQMetadata build() {
             final OutgoingRabbitMQMetadata metadata = new OutgoingRabbitMQMetadata();
             metadata.appId = appId;

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -1,0 +1,548 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.INCOMING;
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.INCOMING_AND_OUTGOING;
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.OUTGOING;
+import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions.ex;
+import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
+import static java.time.Duration.ofSeconds;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.BeforeDestroyed;
+import javax.enterprise.event.Observes;
+import javax.enterprise.event.Reception;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.spi.Connector;
+import org.eclipse.microprofile.reactive.messaging.spi.IncomingConnectorFactory;
+import org.eclipse.microprofile.reactive.messaging.spi.OutgoingConnectorFactory;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
+import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
+import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.health.HealthReporter;
+import io.smallrye.reactive.messaging.rabbitmq.ack.RabbitMQAck;
+import io.smallrye.reactive.messaging.rabbitmq.ack.RabbitMQAckHandler;
+import io.smallrye.reactive.messaging.rabbitmq.ack.RabbitMQAutoAck;
+import io.smallrye.reactive.messaging.rabbitmq.fault.RabbitMQAccept;
+import io.smallrye.reactive.messaging.rabbitmq.fault.RabbitMQFailStop;
+import io.smallrye.reactive.messaging.rabbitmq.fault.RabbitMQFailureHandler;
+import io.smallrye.reactive.messaging.rabbitmq.fault.RabbitMQReject;
+import io.smallrye.reactive.messaging.rabbitmq.tracing.TracingUtils;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.rabbitmq.RabbitMQClient;
+import io.vertx.mutiny.rabbitmq.RabbitMQConsumer;
+import io.vertx.mutiny.rabbitmq.RabbitMQPublisher;
+import io.vertx.rabbitmq.QueueOptions;
+import io.vertx.rabbitmq.RabbitMQOptions;
+import io.vertx.rabbitmq.RabbitMQPublisherOptions;
+
+@ApplicationScoped
+@Connector(RabbitMQConnector.CONNECTOR_NAME)
+
+// RabbitMQClient configuration
+@ConnectorAttribute(name = "username", direction = INCOMING_AND_OUTGOING, description = "The username used to authenticate to the broker", type = "string", alias = "rabbitmq-username")
+@ConnectorAttribute(name = "password", direction = INCOMING_AND_OUTGOING, description = "The password used to authenticate to the broker", type = "string", alias = "rabbitmq-password")
+@ConnectorAttribute(name = "host", direction = INCOMING_AND_OUTGOING, description = "The broker hostname", type = "string", alias = "rabbitmq-host", defaultValue = "localhost")
+@ConnectorAttribute(name = "port", direction = INCOMING_AND_OUTGOING, description = "The broker port", type = "int", alias = "rabbitmq-port", defaultValue = "5672")
+@ConnectorAttribute(name = "connection-timeout", direction = INCOMING_AND_OUTGOING, description = "The TCP connection timeout (ms); 0 is interpreted as no timeout", type = "int", defaultValue = "60000")
+@ConnectorAttribute(name = "handshake-timeout", direction = INCOMING_AND_OUTGOING, description = "The AMQP 0-9-1 protocol handshake timeout (ms)", type = "int", defaultValue = "10000")
+@ConnectorAttribute(name = "automatic-recovery-enabled", direction = INCOMING_AND_OUTGOING, description = "Whether automatic connection recovery is enabled", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "automatic-recovery-on-initial-connection", direction = INCOMING_AND_OUTGOING, description = "Whether automatic recovery on initial connections is enabled", type = "boolean", defaultValue = "true")
+@ConnectorAttribute(name = "reconnect-attempts", direction = INCOMING_AND_OUTGOING, description = "The number of reconnection attempts", type = "int", alias = "rabbitmq-reconnect-attempts", defaultValue = "100")
+@ConnectorAttribute(name = "reconnect-interval", direction = INCOMING_AND_OUTGOING, description = "The interval (in seconds) between two reconnection attempts", type = "int", alias = "rabbitmq-reconnect-interval", defaultValue = "10")
+@ConnectorAttribute(name = "network-recovery-interval", direction = INCOMING_AND_OUTGOING, description = "How long (ms) will automatic recovery wait before attempting to reconnect", type = "int", defaultValue = "5000")
+@ConnectorAttribute(name = "user", direction = INCOMING_AND_OUTGOING, description = "The AMQP user name to use when connecting to the broker", type = "string", defaultValue = "guest")
+@ConnectorAttribute(name = "include-properties", direction = INCOMING_AND_OUTGOING, description = "Whether to include properties when a broker message is passed on the event bus", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "requested-channel-max", direction = INCOMING_AND_OUTGOING, description = "The initially requested maximum channel number", type = "int", defaultValue = "2047")
+@ConnectorAttribute(name = "requested-heartbeat", direction = INCOMING_AND_OUTGOING, description = "The initially requested heartbeat interval (seconds), zero for none", type = "int", defaultValue = "60")
+@ConnectorAttribute(name = "use-nio", direction = INCOMING_AND_OUTGOING, description = "Whether usage of NIO Sockets is enabled", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "virtual-host", direction = INCOMING_AND_OUTGOING, description = "The virtual host to use when connecting to the broker", type = "string", defaultValue = "/")
+
+// Exchange
+@ConnectorAttribute(name = "exchange.name", direction = INCOMING_AND_OUTGOING, description = "The exchange that messages are published to or consumed from. If not set, the channel name is used", type = "string")
+@ConnectorAttribute(name = "exchange.durable", direction = INCOMING_AND_OUTGOING, description = "Whether the exchange is durable", type = "boolean", defaultValue = "true")
+@ConnectorAttribute(name = "exchange.auto-delete", direction = INCOMING_AND_OUTGOING, description = "Whether the exchange should be deleted after use", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "exchange.type", direction = INCOMING_AND_OUTGOING, description = "The exchange type: direct, fanout, headers or topic (default)", type = "string", defaultValue = "topic")
+@ConnectorAttribute(name = "exchange.declare", direction = INCOMING_AND_OUTGOING, description = "Whether to declare the exchange; set to false if the exchange is expected to be set up independently", type = "boolean", defaultValue = "true")
+
+// Queue
+@ConnectorAttribute(name = "queue.name", direction = INCOMING, description = "The queue from which messages are consumed.", type = "string", mandatory = true)
+@ConnectorAttribute(name = "queue.durable", direction = INCOMING, description = "Whether the queue is durable", type = "boolean", defaultValue = "true")
+@ConnectorAttribute(name = "queue.exclusive", direction = INCOMING, description = "Whether the queue is for exclusive use", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "queue.auto-delete", direction = INCOMING, description = "Whether the queue should be deleted after use", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "queue.declare", direction = INCOMING, description = "Whether to declare the queue and binding; set to false if these are expected to be set up independently", type = "boolean", defaultValue = "true")
+@ConnectorAttribute(name = "queue.ttl", direction = INCOMING, description = "If specified, the time (ms) for which a message can remain in the queue undelivered before it is dead", type = "long")
+@ConnectorAttribute(name = "max-outgoing-internal-queue-size", direction = OUTGOING, description = "The maximum size of the outgoing internal queue", type = "int")
+@ConnectorAttribute(name = "max-incoming-internal-queue-size", direction = INCOMING, description = "The maximum size of the incoming internal queue", type = "int")
+
+// DLQs
+@ConnectorAttribute(name = "auto-bind-dlq", direction = INCOMING, description = "Whether to automatically declare the DLQ and bind it to the binder DLX", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "dead-letter-queue-name", direction = INCOMING, description = "The name of the DLQ; if not supplied will default to the queue name with '.dlq' appended", type = "string")
+@ConnectorAttribute(name = "dead-letter-exchange", direction = INCOMING, description = "A DLX to assign to the queue. Relevant only if auto-bind-dlq is true", type = "string", defaultValue = "DLX")
+@ConnectorAttribute(name = "dead-letter-exchange-type", direction = INCOMING, description = "The type of the DLX to assign to the queue. Relevant only if auto-bind-dlq is true", type = "string", defaultValue = "direct")
+@ConnectorAttribute(name = "dead-letter-routing-key", direction = INCOMING, description = "A dead letter routing key to assign to the queue; if not supplied will default to the queue name", type = "string")
+@ConnectorAttribute(name = "dlx.declare", direction = INCOMING, description = "Whether to declare the dead letter exchange binding. Relevant only if auto-bind-dlq is true; set to false if these are expected to be set up independently", type = "boolean", defaultValue = "false")
+
+// Message consumer
+@ConnectorAttribute(name = "failure-strategy", direction = INCOMING, description = "The failure strategy to apply when a RabbitMQ message is nacked. Accepted values are `fail`, `accept`, `reject` (default)", type = "string", defaultValue = "reject")
+@ConnectorAttribute(name = "broadcast", direction = INCOMING, description = "Whether the received RabbitMQ messages must be dispatched to multiple _subscribers_", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "auto-acknowledgement", direction = INCOMING, description = "Whether the received RabbitMQ messages must be acknowledged when received; if true then delivery constitutes acknowledgement", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "keep-most-recent", direction = INCOMING, description = "Whether to discard old messages instead of recent ones", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "routing-keys", direction = INCOMING, description = "A comma-separated list of routing keys to bind the queue to the exchange", type = "string", defaultValue = "#")
+
+// Message producer
+@ConnectorAttribute(name = "max-inflight-messages", direction = OUTGOING, description = "The maximum number of messages to be written to RabbitMQ concurrently; must be a positive number", type = "long", defaultValue = "1024")
+@ConnectorAttribute(name = "default-routing-key", direction = OUTGOING, description = "The default routing key to use when sending messages to the exchange", type = "string", defaultValue = "")
+@ConnectorAttribute(name = "default-ttl", direction = OUTGOING, description = "If specified, the time (ms) sent messages can remain in queues undelivered before they are dead", type = "long")
+
+// Tracing
+@ConnectorAttribute(name = "tracing.enabled", direction = INCOMING_AND_OUTGOING, description = "Whether tracing is enabled (default) or disabled", type = "boolean", defaultValue = "true")
+@ConnectorAttribute(name = "tracing.attribute-headers", direction = INCOMING_AND_OUTGOING, description = "A comma-separated list of headers that should be recorded as span attributes. Relevant only if tracing.enabled=true", type = "string", defaultValue = "")
+
+public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConnectorFactory, HealthReporter {
+    static final String CONNECTOR_NAME = "smallrye-rabbitmq";
+
+    private enum ChannelStatus {
+        CONNECTED,
+        NOT_CONNECTED,
+        INITIALISING
+    }
+
+    // The list of RabbitMQClient's currently managed by this connector
+    private final List<RabbitMQClient> clients = new CopyOnWriteArrayList<>();
+
+    // Keyed on channel name, value is the channel connection state
+    private final Map<String, ChannelStatus> incomingChannelStatus = new ConcurrentHashMap<>();
+    private final Map<String, ChannelStatus> outgoingChannelStatus = new ConcurrentHashMap<>();
+
+    // The list of RabbitMQMessageSender's currently managed by this connector
+    private final List<Subscription> subscriptions = new CopyOnWriteArrayList<>();
+
+    @Inject
+    ExecutionHolder executionHolder;
+
+    RabbitMQConnector() {
+        // used for proxies
+    }
+
+    private static String getExchangeName(final RabbitMQConnectorCommonConfiguration config) {
+        return config.getExchangeName().orElse(config.getChannel());
+    }
+
+    @PostConstruct
+    void init() {
+        TracingUtils.initialise();
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private Multi<? extends Message<?>> getStreamOfMessages(RabbitMQConsumer receiver,
+            ConnectionHolder holder,
+            RabbitMQConnectorIncomingConfiguration ic,
+            RabbitMQFailureHandler onNack,
+            RabbitMQAckHandler onAck) {
+        final String queueName = ic.getQueueName();
+        final boolean isTracingEnabled = ic.getTracingEnabled();
+        final List<String> attributeHeaders = Arrays.stream(ic.getTracingAttributeHeaders().split(","))
+                .map(String::trim).collect(Collectors.toList());
+        log.receiverListeningAddress(queueName);
+
+        // The processor is used to inject AMQP Connection failure in the stream and trigger a retry.
+        BroadcastProcessor processor = BroadcastProcessor.create();
+        receiver.exceptionHandler(t -> {
+            log.receiverError(t);
+            processor.onError(t);
+        });
+        holder.onFailure(processor::onError);
+
+        return Multi.createFrom().deferred(
+                () -> {
+                    Multi<? extends Message<?>> stream = receiver.toMulti()
+                            .map(m -> new IncomingRabbitMQMessage<>(m, holder, isTracingEnabled, onNack, onAck))
+                            .map(m -> isTracingEnabled ? TracingUtils.addIncomingTrace(m, queueName, attributeHeaders) : m);
+                    return Multi.createBy().merging().streams(stream, processor);
+                });
+    }
+
+    /**
+     * Creates a <em>channel</em> for the given configuration. The channel's configuration is associated with a
+     * specific {@code connector}, using the {@link Connector} qualifier's parameter indicating a key to
+     * which {@link IncomingConnectorFactory} to use.
+     *
+     * <p>
+     * Note that the connection to the <em>transport</em> or <em>broker</em> is generally postponed until the
+     * subscription occurs.
+     *
+     * @param config the configuration, must not be {@code null}, must contain the {@link #CHANNEL_NAME_ATTRIBUTE}
+     *        attribute.
+     * @return the created {@link PublisherBuilder}, will not be {@code null}.
+     * @throws IllegalArgumentException if the configuration is invalid.
+     * @throws NoSuchElementException if the configuration does not contain an expected attribute.
+     */
+    @Override
+    public PublisherBuilder<? extends Message<?>> getPublisherBuilder(final Config config) {
+        final RabbitMQConnectorIncomingConfiguration ic = new RabbitMQConnectorIncomingConfiguration(config);
+        incomingChannelStatus.put(ic.getChannel(), ChannelStatus.INITIALISING);
+
+        // Create a client
+        final RabbitMQClient client = createClient(new RabbitMQConnectorCommonConfiguration(config));
+
+        final ConnectionHolder holder = new ConnectionHolder(client, ic, getVertx());
+        final RabbitMQFailureHandler onNack = createFailureHandler(ic);
+        final RabbitMQAckHandler onAck = createAckHandler(ic);
+
+        // Ensure we set the queue up
+        Uni<RabbitMQClient> uniQueue = holder.getOrEstablishConnection()
+                // Once connected, ensure we create the queue from which messages are to be read
+                .onItem().call(connection -> establishQueue(connection, ic))
+                // If directed to do so, create a DLQ
+                .onItem().call(connection -> establishDLQ(connection, ic))
+                .onItem().invoke(connection -> incomingChannelStatus.put(ic.getChannel(), ChannelStatus.CONNECTED));
+
+        // Once the queue is set up, set yp a consumer
+        final Integer interval = ic.getReconnectInterval();
+        final Integer attempts = ic.getReconnectAttempts();
+        Multi<? extends Message<?>> multi = uniQueue
+                .onItem().transformToUni(connection -> client.basicConsumer(ic.getQueueName(), new QueueOptions()
+                        .setAutoAck(ic.getAutoAcknowledgement())
+                        .setMaxInternalQueueSize(ic.getMaxIncomingInternalQueueSize().orElse(Integer.MAX_VALUE))
+                        .setKeepMostRecent(ic.getKeepMostRecent())))
+                .onItem().transformToMulti(consumer -> getStreamOfMessages(consumer, holder, ic, onNack, onAck))
+                // Retry on failure.
+                .onFailure().invoke(log::retrieveMessagesRetrying)
+                .onFailure().retry().withBackOff(ofSeconds(1), ofSeconds(interval)).atMost(attempts)
+                .onFailure().invoke(t -> {
+                    incomingChannelStatus.put(ic.getChannel(), ChannelStatus.NOT_CONNECTED);
+                    log.retrieveMessagesNoMoreRetrying(t);
+                });
+
+        if (Boolean.TRUE.equals(ic.getBroadcast())) {
+            multi = multi.broadcast().toAllSubscribers();
+        }
+
+        return ReactiveStreams.fromPublisher(multi);
+    }
+
+    /**
+     * Establish a DLQ, possibly establishing a DLX too
+     *
+     * @param client the {@link RabbitMQClient}
+     * @param ic the {@link RabbitMQConnectorIncomingConfiguration}
+     * @return a {@link Uni<String>} containing the DLQ name
+     */
+    private Uni<?> establishDLQ(final RabbitMQClient client, final RabbitMQConnectorIncomingConfiguration ic) {
+        final String deadLetterQueueName = ic.getDeadLetterQueueName().orElse(String.format("%s.dlq", ic.getQueueName()));
+        final String deadLetterExchangeName = ic.getDeadLetterExchange();
+        final String deadLetterRoutingKey = ic.getDeadLetterRoutingKey().orElse(ic.getQueueName());
+
+        // Declare the exchange if we have been asked to do so
+        final Uni<String> dlxFlow = Uni.createFrom()
+                .item(() -> ic.getAutoBindDlq() && ic.getDlxDeclare() ? null : deadLetterExchangeName)
+                .onItem().ifNull().switchTo(() -> client.exchangeDeclare(deadLetterExchangeName, ic.getDeadLetterExchangeType(),
+                        true, false)
+                        .onItem().invoke(() -> log.dlxEstablished(deadLetterExchangeName))
+                        .onFailure().invoke(ex -> log.unableToEstablishDlx(deadLetterExchangeName, ex))
+                        .onItem().transform(v -> deadLetterExchangeName));
+
+        // Declare the queue (and its binding to the exchange) if we have been asked to do so
+        return dlxFlow
+                .onItem().transform(v -> Boolean.TRUE.equals(ic.getAutoBindDlq()) ? null : deadLetterQueueName)
+                .onItem().ifNull().switchTo(
+                        () -> client
+                                .queueDeclare(deadLetterQueueName, true, false, false)
+                                .onItem().invoke(() -> log.queueEstablished(deadLetterQueueName))
+                                .onFailure().invoke(ex -> log.unableToEstablishQueue(deadLetterQueueName, ex))
+                                .onItem()
+                                .call(v -> client.queueBind(deadLetterQueueName, deadLetterExchangeName, deadLetterRoutingKey))
+                                .onItem()
+                                .invoke(() -> log.bindingEstablished(deadLetterQueueName, deadLetterExchangeName,
+                                        deadLetterRoutingKey))
+                                .onFailure()
+                                .invoke(ex -> log.unableToEstablishBinding(deadLetterQueueName, deadLetterExchangeName, ex))
+                                .onItem().transform(v -> deadLetterQueueName));
+    }
+
+    private RabbitMQClient createClient(final RabbitMQConnectorCommonConfiguration config) {
+        final RabbitMQOptions rabbitMQClientConfig = new RabbitMQOptions()
+                .setHost(config.getHost())
+                .setPort(config.getPort())
+                .setAutomaticRecoveryEnabled(config.getAutomaticRecoveryEnabled())
+                .setAutomaticRecoveryOnInitialConnection(config.getAutomaticRecoveryOnInitialConnection())
+                .setReconnectAttempts(config.getReconnectAttempts())
+                .setReconnectInterval(config.getReconnectInterval())
+                .setUser(config.getUser())
+                .setConnectionTimeout(config.getConnectionTimeout())
+                .setHandshakeTimeout(config.getHandshakeTimeout())
+                .setIncludeProperties(config.getIncludeProperties())
+                .setNetworkRecoveryInterval(config.getNetworkRecoveryInterval())
+                .setRequestedChannelMax(config.getRequestedChannelMax())
+                .setRequestedHeartbeat(config.getRequestedHeartbeat())
+                .setUseNio(config.getUseNio())
+                .setVirtualHost(config.getVirtualHost());
+
+        config.getUsername().ifPresent(rabbitMQClientConfig::setUser);
+        config.getPassword().ifPresent(rabbitMQClientConfig::setPassword);
+
+        final RabbitMQClient client = RabbitMQClient.create(getVertx(), rabbitMQClientConfig);
+        addClient(client);
+        return client;
+    }
+
+    /**
+     * Creates a <em>channel</em> for the given configuration. The channel's configuration is associated with a
+     * specific {@code connector}, using the {@link Connector} qualifier's parameter indicating a key to
+     * which {@link org.eclipse.microprofile.reactive.messaging.Outgoing} to use.
+     * <p>
+     * Note that the connection to the <em>transport</em> or <em>broker</em> is generally postponed until the
+     * subscription.
+     *
+     * @param config the configuration, never {@code null}, must contain the {@link #CHANNEL_NAME_ATTRIBUTE}
+     *        attribute.
+     * @return the created {@link SubscriberBuilder}, must not be {@code null}.
+     * @throws IllegalArgumentException if the configuration is invalid.
+     * @throws NoSuchElementException if the configuration does not contain an expected attribute.
+     */
+    @Override
+    public SubscriberBuilder<? extends Message<?>, Void> getSubscriberBuilder(final Config config) {
+        final RabbitMQConnectorOutgoingConfiguration oc = new RabbitMQConnectorOutgoingConfiguration(config);
+        outgoingChannelStatus.put(oc.getChannel(), ChannelStatus.INITIALISING);
+
+        // Create a client
+        final RabbitMQClient client = createClient(new RabbitMQConnectorCommonConfiguration(config));
+
+        // This will hold our publisher, assuming we can get hold of one
+        final AtomicReference<RabbitMQPublisher> sender = new AtomicReference<>();
+
+        final ConnectionHolder holder = new ConnectionHolder(client, oc, getVertx());
+        final Uni<RabbitMQPublisher> getSender = Uni.createFrom().item(sender.get())
+                .onItem().ifNull().switchTo(() -> {
+
+                    // If we already have a sender, use it.
+                    RabbitMQPublisher current = sender.get();
+                    if (current != null && client.isConnected()) {
+                        return Uni.createFrom().item(current);
+                    }
+
+                    return holder.getOrEstablishConnection()
+                            // Once connected, ensure we create the exchange to which messages are to be sent
+                            .onItem().call(connection -> establishExchange(connection, oc))
+                            // Once exchange exists, create ourselves a publisher
+                            .onItem()
+                            .transformToUni(connection -> Uni.createFrom().item(RabbitMQPublisher.create(getVertx(), connection,
+                                    new RabbitMQPublisherOptions()
+                                            .setReconnectAttempts(oc.getReconnectAttempts())
+                                            .setReconnectInterval(oc.getReconnectInterval())
+                                            .setMaxInternalQueueSize(
+                                                    oc.getMaxOutgoingInternalQueueSize().orElse(Integer.MAX_VALUE)))))
+                            // Start the publisher
+                            .onItem().call(RabbitMQPublisher::start)
+                            .invoke(s -> {
+                                // Make a note of the publisher and add the channel in the opened state
+                                sender.set(s);
+                                outgoingChannelStatus.put(oc.getChannel(), ChannelStatus.CONNECTED);
+                            });
+                })
+                // If the downstream cancels or on failure, drop the sender.
+                .onFailure().invoke(t -> {
+                    sender.set(null);
+                    outgoingChannelStatus.put(oc.getChannel(), ChannelStatus.NOT_CONNECTED);
+                })
+                .onCancellation().invoke(() -> {
+                    sender.set(null);
+                    outgoingChannelStatus.put(oc.getChannel(), ChannelStatus.NOT_CONNECTED);
+                });
+
+        // Set up a sender based on the publisher we established above
+        final RabbitMQMessageSender processor = new RabbitMQMessageSender(
+                oc,
+                getSender);
+        subscriptions.add(processor);
+
+        // Return a SubscriberBuilder
+        return ReactiveStreams.<Message<?>> builder()
+                .via(processor)
+                .onError(t -> {
+                    log.error(oc.getChannel(), t);
+                    outgoingChannelStatus.put(oc.getChannel(), ChannelStatus.NOT_CONNECTED);
+                })
+                .ignore();
+    }
+
+    @Override
+    public HealthReport getReadiness() {
+        return getHealth(false);
+    }
+
+    @Override
+    public HealthReport getLiveness() {
+        return getHealth(false);
+    }
+
+    public HealthReport getHealth(boolean strict) {
+        final HealthReport.HealthReportBuilder builder = HealthReport.builder();
+
+        // Add health for incoming channels; since connections are made immediately
+        // for subscribers, we insist on channel status being connected
+        incomingChannelStatus.forEach((channel, status) -> builder.add(channel, status == ChannelStatus.CONNECTED));
+
+        // Add health for outgoing channels; since connections are made only on
+        // first message dispatch for publishers, we allow both connected and initialising
+        // unless in strict mode, in order to avoid a possible deadly embrace in
+        // kubernetes (k8s will refuse to allow the pod to accept traffic unless it is ready,
+        // and only if it is ready can e.g. calls be made to it that would trigger a message dispatch).
+        outgoingChannelStatus.forEach((channel, status) -> builder.add(channel,
+                (strict) ? status == ChannelStatus.CONNECTED : status != ChannelStatus.NOT_CONNECTED));
+
+        return builder.build();
+    }
+
+    /**
+     * Application shutdown tidy up; cancels all subscriptions and stops clients.
+     *
+     * @param ignored the incoming event, ignored
+     */
+    public void terminate(
+            @SuppressWarnings("unused") @Observes(notifyObserver = Reception.IF_EXISTS) @Priority(50) @BeforeDestroyed(ApplicationScoped.class) Object ignored) {
+        subscriptions.forEach(Subscription::cancel);
+        clients.forEach(RabbitMQClient::stop);
+        clients.clear();
+    }
+
+    private Vertx getVertx() {
+        return executionHolder.vertx();
+    }
+
+    private void addClient(RabbitMQClient client) {
+        clients.add(client);
+    }
+
+    /**
+     * Uses a {@link RabbitMQClient} to ensure the required exchange is created.
+     *
+     * @param client the RabbitMQ client
+     * @param config the channel configuration
+     * @return a {@link Uni<String>} which yields the exchange name
+     */
+    private Uni<String> establishExchange(
+            final RabbitMQClient client,
+            final RabbitMQConnectorCommonConfiguration config) {
+        final String exchangeName = getExchangeName(config);
+
+        // Declare the exchange if we have been asked to do so
+        return Uni.createFrom().item(() -> Boolean.TRUE.equals(config.getExchangeDeclare()) ? null : exchangeName)
+                .onItem().ifNull().switchTo(() -> client.exchangeDeclare(exchangeName, config.getExchangeType(),
+                        config.getExchangeDurable(), config.getExchangeAutoDelete())
+                        .onItem().invoke(() -> log.exchangeEstablished(exchangeName))
+                        .onFailure().invoke(ex -> log.unableToEstablishExchange(exchangeName, ex))
+                        .onItem().transform(v -> exchangeName));
+    }
+
+    /**
+     * Uses a {@link RabbitMQClient} to ensure the required queue-exchange bindings are created.
+     *
+     * @param client the RabbitMQ client
+     * @param ic the incoming channel configuration
+     * @return a {@link Uni<String>} which yields the queue name
+     */
+    private Uni<String> establishQueue(
+            final RabbitMQClient client,
+            final RabbitMQConnectorIncomingConfiguration ic) {
+        final String queueName = ic.getQueueName();
+
+        // Declare the queue (and its binding(s) to the exchange, and TTL) if we have been asked to do so
+        final JsonObject queueArgs = new JsonObject();
+        queueArgs.put("x-dead-letter-exchange", ic.getDeadLetterExchange());
+        queueArgs.put("x-dead-letter-routing-key", ic.getDeadLetterRoutingKey().orElse(queueName));
+
+        ic.getQueueTtl().ifPresent(queueTtl -> {
+            if (queueTtl >= 0) {
+                queueArgs.put("x-message-ttl", queueTtl);
+            } else {
+                throw ex.illegalArgumentInvalidQueueTtl();
+            }
+        });
+
+        return establishExchange(client, ic)
+                .onItem().transform(v -> Boolean.TRUE.equals(ic.getQueueDeclare()) ? null : queueName)
+                .onItem().ifNull().switchTo(
+                        () -> client
+                                .queueDeclare(queueName, ic.getQueueDurable(), ic.getQueueExclusive(), ic.getQueueAutoDelete(),
+                                        queueArgs)
+                                .onItem().invoke(() -> log.queueEstablished(queueName))
+                                .onFailure().invoke(ex -> log.unableToEstablishQueue(queueName, ex))
+                                .onItem().transformToMulti(v -> establishBindings(client, ic))
+                                // What follows is just to "rejoin" the Multi stream into a single Uni emitting the queue name
+                                .onCompletion().invoke(() -> Multi.createFrom().item("ignore"))
+                                .onItem().ignoreAsUni().onItem().transform(v -> queueName));
+    }
+
+    /**
+     * Returns a stream that will create bindings from the queue to the exchange with each of the
+     * supplied routing keys.
+     *
+     * @param client the {@link RabbitMQClient} to use
+     * @param ic the incoming channel configuration
+     * @return a stream of routing keys
+     */
+    private Multi<String> establishBindings(
+            final RabbitMQClient client,
+            final RabbitMQConnectorIncomingConfiguration ic) {
+        final String exchangeName = getExchangeName(ic);
+        final String queueName = ic.getQueueName();
+        final List<String> routingKeys = Arrays.stream(ic.getRoutingKeys().split(","))
+                .map(String::trim).collect(Collectors.toList());
+
+        return Multi.createFrom().iterable(routingKeys)
+                .onItem().call(routingKey -> client.queueBind(queueName, exchangeName, routingKey))
+                .onItem().invoke(routingKey -> log.bindingEstablished(queueName, exchangeName, routingKey))
+                .onFailure().invoke(ex -> log.unableToEstablishBinding(queueName, exchangeName, ex));
+    }
+
+    private RabbitMQFailureHandler createFailureHandler(RabbitMQConnectorIncomingConfiguration config) {
+        String strategy = config.getFailureStrategy();
+        RabbitMQFailureHandler.Strategy actualStrategy = RabbitMQFailureHandler.Strategy.from(strategy);
+        switch (actualStrategy) {
+            case FAIL:
+                return new RabbitMQFailStop(this, config.getChannel());
+            case ACCEPT:
+                return new RabbitMQAccept(config.getChannel());
+            case REJECT:
+                return new RabbitMQReject(config.getChannel());
+            default:
+                throw ex.illegalArgumentInvalidFailureStrategy(strategy);
+        }
+
+    }
+
+    private RabbitMQAckHandler createAckHandler(RabbitMQConnectorIncomingConfiguration ic) {
+        return (Boolean.TRUE.equals(ic.getAutoAcknowledgement())) ? new RabbitMQAutoAck(ic.getChannel())
+                : new RabbitMQAck(ic.getChannel());
+    }
+
+    public void reportIncomingFailure(String channel, Throwable reason) {
+        log.failureReported(channel, reason);
+        incomingChannelStatus.put(channel, ChannelStatus.NOT_CONNECTED);
+        terminate(null);
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageConverter.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageConverter.java
@@ -1,0 +1,254 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.BasicProperties;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.smallrye.reactive.messaging.rabbitmq.tracing.TracingUtils;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.rabbitmq.RabbitMQMessage;
+
+/**
+ * Utility class which can handle the transformation of a {@link Message}
+ * to an {@link OutgoingRabbitMQMessage}.
+ */
+public class RabbitMQMessageConverter {
+
+    private static final List<Class<?>> PRIMITIVES = Arrays.asList(
+            String.class,
+            UUID.class,
+            Boolean.class,
+            Byte.class,
+            Character.class,
+            Short.class,
+            Integer.class,
+            Double.class,
+            Float.class,
+            Long.class);
+
+    private RabbitMQMessageConverter() {
+        // Avoid direct instantiation.
+    }
+
+    /**
+     * Converts the supplied {@link Message} to an {@link OutgoingRabbitMQMessage}.
+     *
+     * @param message the source message
+     * @param exchange the destination exchange
+     * @param defaultRoutingKey the fallback routing key to use
+     * @param isTracingEnabled whether tracing is enabled
+     * @param attributeHeaders a list (possibly empty) of message header names whose values should be
+     *        included as span attributes
+     * @return an {@link OutgoingRabbitMQMessage}
+     */
+    public static OutgoingRabbitMQMessage convert(
+            final Message<?> message,
+            final String exchange,
+            final String defaultRoutingKey,
+            final Optional<Long> defaultTtl,
+            final boolean isTracingEnabled,
+            final List<String> attributeHeaders) {
+        final Optional<io.vertx.mutiny.rabbitmq.RabbitMQMessage> rabbitMQMessage = getRabbitMQMessage(message);
+        final String routingKey = getRoutingKey(message).orElse(defaultRoutingKey);
+
+        // Figure out the body and properties
+        Buffer body;
+        BasicProperties properties;
+
+        if (rabbitMQMessage.isPresent()) {
+            // If we already have a RabbitMQMessage present, use it as the basis for the outgoing one
+            body = rabbitMQMessage.get().body();
+            final BasicProperties sourceProperties = rabbitMQMessage.get().properties();
+            // Make a copy of the source headers as the original is probably immutable
+            final Map<String, Object> sourceHeaders = new HashMap<>(sourceProperties.getHeaders());
+
+            if (isTracingEnabled) {
+                // Create a new span for the outbound message and record updated tracing information in
+                // the headers; this has to be done before we build the properties below
+                TracingUtils.createOutgoingTrace(message, sourceHeaders, exchange, routingKey,
+                        attributeHeaders);
+            }
+
+            // Reconstruct the properties from the source, except with the (possibly) modified headers;
+            // only override the existing expiration if not already set and a non-negative default TTL
+            // has been specified.
+            final String expiration = (null != sourceProperties.getExpiration()) ? sourceProperties.getExpiration()
+                    : defaultTtl.map(String::valueOf).orElse(null);
+            properties = new AMQP.BasicProperties.Builder()
+                    .contentType(sourceProperties.getContentType())
+                    .contentEncoding(sourceProperties.getContentEncoding())
+                    .headers(sourceHeaders)
+                    .deliveryMode(sourceProperties.getDeliveryMode())
+                    .priority(sourceProperties.getPriority())
+                    .correlationId(sourceProperties.getCorrelationId())
+                    .replyTo(sourceProperties.getReplyTo())
+                    .expiration(expiration)
+                    .messageId(sourceProperties.getMessageId())
+                    .timestamp(sourceProperties.getTimestamp())
+                    .type(sourceProperties.getType())
+                    .userId(sourceProperties.getUserId())
+                    .appId(sourceProperties.getAppId())
+                    .build();
+        } else {
+            // Getting here means we have to work a little harder
+            String contentType;
+            final Object payload = message.getPayload();
+
+            if (isPrimitive(payload.getClass())) {
+                // Anything representable a string is rendered as a String
+                body = Buffer.buffer(payload.toString());
+                contentType = HttpHeaderValues.TEXT_PLAIN.toString();
+            } else if (payload instanceof Buffer) {
+                body = (Buffer) payload;
+                contentType = HttpHeaderValues.APPLICATION_OCTET_STREAM.toString();
+            } else if (payload instanceof io.vertx.core.buffer.Buffer) {
+                body = Buffer.buffer(((io.vertx.core.buffer.Buffer) payload).getBytes());
+                contentType = HttpHeaderValues.APPLICATION_OCTET_STREAM.toString();
+            } else if (payload instanceof byte[]) {
+                body = Buffer.buffer((byte[]) payload);
+                contentType = HttpHeaderValues.APPLICATION_OCTET_STREAM.toString();
+            } else if (payload instanceof JsonObject) {
+                body = Buffer.buffer(((JsonObject) payload).encode());
+                contentType = HttpHeaderValues.APPLICATION_JSON.toString();
+            } else if (payload instanceof JsonArray) {
+                body = Buffer.buffer(((JsonArray) payload).encode());
+                contentType = HttpHeaderValues.APPLICATION_JSON.toString();
+            } else {
+                // Other objects are serialized to JSON
+                body = Buffer.buffer(Json.encode(payload));
+                contentType = HttpHeaderValues.APPLICATION_JSON.toString();
+            }
+
+            final OutgoingRabbitMQMetadata metadata = message.getMetadata(OutgoingRabbitMQMetadata.class)
+                    .orElse(new OutgoingRabbitMQMetadata.Builder()
+                            .withContentType(contentType)
+                            .withExpiration(defaultTtl.map(String::valueOf).orElse(null))
+                            .build());
+
+            if (isTracingEnabled) {
+                // Create a new span for the outbound message and record updated tracing information in
+                // the message headers; this has to be done before we build the properties below
+                TracingUtils.createOutgoingTrace(message, metadata.getHeaders(), exchange, routingKey,
+                        attributeHeaders);
+            }
+
+            final ZonedDateTime timestamp = metadata.getTimestamp();
+            properties = new AMQP.BasicProperties.Builder()
+                    .contentType(metadata.getContentType())
+                    .contentEncoding(metadata.getContentEncoding())
+                    .headers(metadata.getHeaders())
+                    .deliveryMode(metadata.getDeliveryMode())
+                    .priority(metadata.getPriority())
+                    .correlationId(metadata.getCorrelationId())
+                    .replyTo(metadata.getReplyTo())
+                    .expiration(metadata.getExpiration())
+                    .messageId(metadata.getMessageId())
+                    .timestamp((timestamp != null) ? Date.from(timestamp.toInstant()) : null)
+                    .type(metadata.getType())
+                    .userId(metadata.getUserId())
+                    .appId(metadata.getAppId())
+                    .clusterId(metadata.getClusterId())
+                    .build();
+        }
+
+        return new OutgoingRabbitMQMessage(routingKey, body, properties);
+    }
+
+    private static Optional<RabbitMQMessage> getRabbitMQMessage(final Message<?> message) {
+        if (message instanceof IncomingRabbitMQMessage) {
+            return Optional.of(((IncomingRabbitMQMessage<?>) message)
+                    .getRabbitMQMessage());
+        } else if (message.getPayload() instanceof io.vertx.mutiny.rabbitmq.RabbitMQMessage) {
+            return Optional.of((io.vertx.mutiny.rabbitmq.RabbitMQMessage) message.getPayload());
+        } else if (message.getPayload() instanceof io.vertx.rabbitmq.RabbitMQMessage) {
+            return Optional.of(new io.vertx.mutiny.rabbitmq.RabbitMQMessage(
+                    (io.vertx.rabbitmq.RabbitMQMessage) message.getPayload()));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<String> getRoutingKey(final Message<?> message) {
+        final Optional<io.vertx.mutiny.rabbitmq.RabbitMQMessage> rabbitMQMessage = getRabbitMQMessage(message);
+
+        if (rabbitMQMessage.isPresent()) {
+            return Optional.of(rabbitMQMessage.get().envelope().getRoutingKey());
+        }
+
+        // Getting here means we have to work a little harder
+        final OutgoingRabbitMQMetadata metadata = message.getMetadata(OutgoingRabbitMQMetadata.class)
+                .orElse(new OutgoingRabbitMQMetadata());
+        return Optional.ofNullable(metadata.getRoutingKey());
+    }
+
+    private static boolean isPrimitive(Class<?> clazz) {
+        return clazz.isPrimitive() || PRIMITIVES.contains(clazz);
+    }
+
+    /**
+     * Represents an outgoing RabbitMQ message.
+     */
+    public static final class OutgoingRabbitMQMessage {
+        private final String routingKey;
+        private final Buffer body;
+        private final BasicProperties properties;
+
+        /**
+         * Constructor.
+         *
+         * @param routingKey the routing key for the message
+         * @param body the message body
+         * @param properties the message properties
+         */
+        private OutgoingRabbitMQMessage(
+                final String routingKey,
+                final Buffer body,
+                final BasicProperties properties) {
+            this.routingKey = routingKey;
+            this.body = body;
+            this.properties = properties;
+        }
+
+        /**
+         * The body of this message.
+         *
+         * @return the body
+         */
+        public Buffer getBody() {
+            return this.body;
+        }
+
+        /**
+         * The routing key for this message.
+         *
+         * @return the routing key
+         */
+        public String getRoutingKey() {
+            return this.routingKey;
+        }
+
+        /**
+         * The properties for this message.
+         *
+         * @return the properties
+         */
+        public BasicProperties getProperties() {
+            return properties;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
@@ -208,6 +208,9 @@ public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>,
      * <p>
      * A {@link Publisher} can send less than is requested if the stream ends but
      * then must emit either {@link Subscriber#onError(Throwable)} or {@link Subscriber#onComplete()}.
+     * <p>
+     * <strong>Note that this method is expected to be called only once on a given sender.</strong>
+     * </p>
      *
      * @param l the strictly positive number of elements to requests to the upstream {@link Publisher}
      */

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
@@ -152,7 +152,7 @@ public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>,
                 })
                 .subscribe().with(
                         tuple -> {
-                            if (tuple != null) { // Serialization issue
+                            if (tuple != null) {
                                 subscriber.onNext(tuple.getItem2());
 
                                 if (inflights != Long.MAX_VALUE) {

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
@@ -1,0 +1,272 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions.ex;
+import static java.time.Duration.ofSeconds;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.tuples.Tuple2;
+import io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions;
+import io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging;
+import io.vertx.mutiny.rabbitmq.RabbitMQPublisher;
+
+/**
+ * An implementation of {@link Processor} and {@link Subscription} that is responsible for sending
+ * RabbitMQ messages to an external broker.
+ */
+public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>, Subscription {
+
+    private final Uni<RabbitMQPublisher> retrieveSender;
+    private final RabbitMQConnectorOutgoingConfiguration configuration;
+
+    private final AtomicReference<Subscription> upstream = new AtomicReference<>();
+    private final AtomicReference<Subscriber<? super Message<?>>> downstream = new AtomicReference<>();
+    private final String configuredExchange;
+    private final boolean isTracingEnabled;
+
+    private final long inflights;
+    private final Optional<Long> defaultTtl;
+
+    /**
+     * Constructor.
+     *
+     * @param oc the configuration parameters for outgoing messages
+     * @param retrieveSender the underlying Vert.x {@link RabbitMQPublisher}
+     */
+    public RabbitMQMessageSender(
+            final RabbitMQConnectorOutgoingConfiguration oc,
+            final Uni<RabbitMQPublisher> retrieveSender) {
+        this.retrieveSender = retrieveSender;
+        this.configuration = oc;
+        this.configuredExchange = oc.getExchangeName().orElseGet(oc::getChannel);
+        this.isTracingEnabled = oc.getTracingEnabled();
+        this.inflights = oc.getMaxInflightMessages();
+        this.defaultTtl = oc.getDefaultTtl();
+
+        if (inflights <= 0) {
+            throw ex.illegalArgumentInvalidMaxInflightMessages();
+        }
+
+        if (defaultTtl.isPresent() && defaultTtl.get() < 0) {
+            throw ex.illegalArgumentInvalidDefaultTtl();
+        }
+    }
+
+    /* ----------------------------------------------------- */
+    /* METHODS OF PUBLISHER */
+    /* ----------------------------------------------------- */
+
+    /**
+     * Request {@link Publisher} to start streaming data.
+     * <p>
+     * This is a "factory method" and can be called multiple times, each time starting a new {@link Subscription}.
+     * <p>
+     * Each {@link Subscription} will work for only a single {@link Subscriber}.
+     * <p>
+     * A {@link Subscriber} should only subscribe once to a single {@link Publisher}.
+     * <p>
+     * If the {@link Publisher} rejects the subscription attempt or otherwise fails it will
+     * signal the error via {@link Subscriber#onError}.
+     *
+     * @param subscriber the {@link Subscriber} that will consume signals from this {@link Publisher}
+     */
+    @Override
+    public void subscribe(
+            final Subscriber<? super Message<?>> subscriber) {
+        if (!downstream.compareAndSet(null, subscriber)) {
+            Subscriptions.fail(subscriber, RabbitMQExceptions.ex.illegalStateOnlyOneSubscriberAllowed());
+        } else {
+            if (upstream.get() != null) {
+                subscriber.onSubscribe(this);
+            }
+        }
+    }
+
+    /* ----------------------------------------------------- */
+    /* METHODS OF SUBSCRIBER */
+    /* ----------------------------------------------------- */
+
+    /**
+     * Invoked after calling {@link Publisher#subscribe(Subscriber)}.
+     * <p>
+     * No data will start flowing until {@link Subscription#request(long)} is invoked.
+     * <p>
+     * It is the responsibility of this {@link Subscriber} instance to call {@link Subscription#request(long)} whenever more
+     * data is wanted.
+     * <p>
+     * The {@link Publisher} will send notifications only in response to {@link Subscription#request(long)}.
+     *
+     * @param subscription
+     *        {@link Subscription} that allows requesting data via {@link Subscription#request(long)}
+     */
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        if (this.upstream.compareAndSet(null, subscription)) {
+            Subscriber<? super Message<?>> subscriber = downstream.get();
+            if (subscriber != null) {
+                subscriber.onSubscribe(this);
+            }
+        } else {
+            Subscriber<? super Message<?>> subscriber = downstream.get();
+            if (subscriber != null) {
+                subscriber.onSubscribe(Subscriptions.CANCELLED);
+            }
+        }
+    }
+
+    /**
+     * Data notification sent by the {@link Publisher} in response to requests to {@link Subscription#request(long)}.
+     *
+     * @param message the element signaled
+     */
+    @Override
+    public void onNext(Message<?> message) {
+        if (isCancelled()) {
+            return;
+        }
+
+        final Subscriber<? super Message<?>> subscriber = this.downstream.get();
+
+        retrieveSender
+                .onItem().transformToUni(sender -> {
+                    try {
+                        return send(sender, message, configuredExchange, configuration)
+                                .onItem().transform(m -> Tuple2.of(sender, m));
+                    } catch (Exception e) {
+                        // Message can't be sent - nacking and skipping.
+                        message.nack(e);
+                        RabbitMQLogging.log.serializationFailure(configuration.getChannel(), e);
+                        return Uni.createFrom().nullItem();
+                    }
+                })
+                .subscribe().with(
+                        tuple -> {
+                            if (tuple != null) { // Serialization issue
+                                subscriber.onNext(tuple.getItem2());
+
+                                if (inflights != Long.MAX_VALUE) {
+                                    upstream.get().request(1);
+                                }
+                            }
+                        },
+                        subscriber::onError);
+    }
+
+    /**
+     * Failed terminal state.
+     * <p>
+     * No further events will be sent even if {@link Subscription#request(long)} is invoked again.
+     *
+     * @param t the throwable signaled
+     */
+    @Override
+    public void onError(Throwable t) {
+        Subscription sub = upstream.getAndSet(Subscriptions.CANCELLED);
+        Subscriber<? super Message<?>> subscriber = this.downstream.get();
+        if (sub != null && sub != Subscriptions.CANCELLED && subscriber != null) {
+            subscriber.onError(t);
+        }
+    }
+
+    /**
+     * Successful terminal state.
+     * <p>
+     * No further events will be sent even if {@link Subscription#request(long)} is invoked again.
+     */
+    @Override
+    public void onComplete() {
+        Subscription sub = upstream.getAndSet(Subscriptions.CANCELLED);
+        Subscriber<? super Message<?>> subscriber = this.downstream.get();
+        if (sub != null && sub != Subscriptions.CANCELLED && subscriber != null) {
+            subscriber.onComplete();
+        }
+    }
+
+    /* ----------------------------------------------------- */
+    /* METHODS OF SUBSCRIPTION */
+    /* ----------------------------------------------------- */
+
+    /**
+     * No events will be sent by a {@link Publisher} until demand is signaled via this method.
+     * <p>
+     * It can be called however often and whenever needed—but if the outstanding cumulative demand ever becomes Long.MAX_VALUE
+     * or more,
+     * it may be treated by the {@link Publisher} as "effectively unbounded".
+     * <p>
+     * Whatever has been requested can be sent by the {@link Publisher} so only signal demand for what can be safely handled.
+     * <p>
+     * A {@link Publisher} can send less than is requested if the stream ends but
+     * then must emit either {@link Subscriber#onError(Throwable)} or {@link Subscriber#onComplete()}.
+     *
+     * @param l the strictly positive number of elements to requests to the upstream {@link Publisher}
+     */
+    @Override
+    public void request(long l) {
+        if (l != Long.MAX_VALUE) {
+            throw ex.illegalStateConsumeWithoutBackPressure();
+        }
+        upstream.get().request(inflights);
+    }
+
+    /**
+     * Request the {@link Publisher} to stop sending data and clean up resources.
+     * <p>
+     * Data may still be sent to meet previously signalled demand after calling cancel.
+     */
+    @Override
+    public void cancel() {
+        Subscription sub = upstream.getAndSet(Subscriptions.CANCELLED);
+        if (sub != null && sub != Subscriptions.CANCELLED) {
+            sub.cancel();
+        }
+    }
+
+    /* ----------------------------------------------------- */
+    /* HELPER METHODS */
+    /* ----------------------------------------------------- */
+
+    private Uni<Message<?>> send(
+            final RabbitMQPublisher publisher,
+            final Message<?> msg,
+            final String exchange,
+            final RabbitMQConnectorOutgoingConfiguration configuration) {
+        final int retryAttempts = configuration.getReconnectAttempts();
+        final int retryInterval = configuration.getReconnectInterval();
+        final String defaultRoutingKey = configuration.getDefaultRoutingKey();
+
+        final RabbitMQMessageConverter.OutgoingRabbitMQMessage outgoingRabbitMQMessage = RabbitMQMessageConverter.convert(msg,
+                exchange, defaultRoutingKey, defaultTtl, isTracingEnabled,
+                Arrays.stream(configuration.getTracingAttributeHeaders().split(","))
+                        .map(String::trim).collect(Collectors.toList()));
+
+        RabbitMQLogging.log.sendingMessageToExchange(exchange, outgoingRabbitMQMessage.getRoutingKey());
+        return publisher.publish(exchange, outgoingRabbitMQMessage.getRoutingKey(), outgoingRabbitMQMessage.getProperties(),
+                outgoingRabbitMQMessage.getBody())
+                .onFailure().retry().withBackOff(ofSeconds(1), ofSeconds(retryInterval)).atMost(retryAttempts)
+                .onItemOrFailure().transformToUni((success, failure) -> {
+                    if (failure != null) {
+                        return Uni.createFrom().completionStage(msg.nack(failure));
+                    } else {
+                        return Uni.createFrom().completionStage(msg.ack());
+                    }
+                })
+                .onItem().transform(x -> msg);
+    }
+
+    private boolean isCancelled() {
+        final Subscription subscription = upstream.get();
+        return subscription == Subscriptions.CANCELLED || subscription == null;
+    }
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ack/RabbitMQAck.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ack/RabbitMQAck.java
@@ -1,0 +1,30 @@
+package io.smallrye.reactive.messaging.rabbitmq.ack;
+
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.reactive.messaging.rabbitmq.ConnectionHolder;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging;
+import io.vertx.mutiny.core.Context;
+
+/**
+ * A {@link RabbitMQAckHandler} used when auto-ack is off.
+ */
+public class RabbitMQAck implements RabbitMQAckHandler {
+    private final String channel;
+
+    /**
+     * Constructor.
+     * 
+     * @param channel the channel on which acks are issued
+     */
+    public RabbitMQAck(String channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public <V> CompletionStage<Void> handle(final IncomingRabbitMQMessage<V> msg, final Context context) {
+        RabbitMQLogging.log.ackMessage(channel);
+        return ConnectionHolder.runOnContext(context, msg::acknowledgeMessage);
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ack/RabbitMQAckHandler.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ack/RabbitMQAckHandler.java
@@ -1,0 +1,35 @@
+package io.smallrye.reactive.messaging.rabbitmq.ack;
+
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.vertx.mutiny.core.Context;
+
+/**
+ * Implemented to provide message acknowledgement strategies.
+ */
+public interface RabbitMQAckHandler {
+
+    enum Strategy {
+        /**
+         * Do no explicitly ack as it will be handled by RabbitMQ itself.
+         */
+        AUTO,
+        /**
+         * Explicit acks.
+         */
+        MANUAL;
+
+    }
+
+    /**
+     * Handle the request to acknowledge a message.
+     * 
+     * @param message the message to acknowledge
+     * @param context the {@link Context} in which the acknowledgement should take place
+     * @param <V> message body type
+     * @return a {@link CompletionStage}
+     */
+    <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Context context);
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ack/RabbitMQAutoAck.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ack/RabbitMQAutoAck.java
@@ -1,0 +1,31 @@
+package io.smallrye.reactive.messaging.rabbitmq.ack;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.reactive.messaging.rabbitmq.ConnectionHolder;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging;
+import io.vertx.mutiny.core.Context;
+
+/**
+ * A {@link RabbitMQAckHandler} used when auto-ack is on.
+ */
+public class RabbitMQAutoAck implements RabbitMQAckHandler {
+    private final String channel;
+
+    /**
+     * Constructor.
+     * 
+     * @param channel the channel on which acks are issued
+     */
+    public RabbitMQAutoAck(String channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public <V> CompletionStage<Void> handle(final IncomingRabbitMQMessage<V> msg, final Context context) {
+        RabbitMQLogging.log.ackAutoMessage(channel);
+        return ConnectionHolder.runOnContext(context, () -> new CompletableFuture<>());
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQAccept.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQAccept.java
@@ -1,0 +1,33 @@
+package io.smallrye.reactive.messaging.rabbitmq.fault;
+
+import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
+
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.reactive.messaging.rabbitmq.ConnectionHolder;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.vertx.mutiny.core.Context;
+
+/**
+ * A {@link RabbitMQFailureHandler} that in effect treats the nack as an ack.
+ */
+public class RabbitMQAccept implements RabbitMQFailureHandler {
+    private final String channel;
+
+    /**
+     * Constructor.
+     * 
+     * @param channel the channel
+     */
+    public RabbitMQAccept(String channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Context context, Throwable reason) {
+        // We mark the message as rejected and fail.
+        log.nackedAcceptMessage(channel);
+        log.fullIgnoredFailure(reason);
+        return ConnectionHolder.runOnContext(context, msg::acknowledgeMessage);
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailStop.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailStop.java
@@ -1,0 +1,35 @@
+package io.smallrye.reactive.messaging.rabbitmq.fault;
+
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.reactive.messaging.rabbitmq.ConnectionHolder;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
+import io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging;
+import io.vertx.mutiny.core.Context;
+
+/**
+ * A {@link RabbitMQFailureHandler} that rejects the message and reports a failure.
+ */
+public class RabbitMQFailStop implements RabbitMQFailureHandler {
+    private final String channel;
+    private final RabbitMQConnector connector;
+
+    /**
+     * Constructor.
+     * 
+     * @param channel the channel
+     */
+    public RabbitMQFailStop(RabbitMQConnector connector, String channel) {
+        this.connector = connector;
+        this.channel = channel;
+    }
+
+    @Override
+    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Context context, Throwable reason) {
+        // We mark the message as rejected and fail.
+        RabbitMQLogging.log.nackedFailMessage(channel);
+        connector.reportIncomingFailure(channel, reason);
+        return ConnectionHolder.runOnContextAndReportFailure(context, reason, () -> msg.rejectMessage(reason));
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailureHandler.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailureHandler.java
@@ -1,0 +1,61 @@
+package io.smallrye.reactive.messaging.rabbitmq.fault;
+
+import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions.ex;
+
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.vertx.mutiny.core.Context;
+
+/**
+ * Implemented to provide message failure strategies.
+ */
+public interface RabbitMQFailureHandler {
+
+    enum Strategy {
+        /**
+         * Mark the message as {@code rejected} and die.
+         */
+        FAIL,
+        /**
+         * Mark the message as {@code accepted} and continue.
+         */
+        ACCEPT,
+        /**
+         * Mark the message as {@code released} and continue.
+         */
+        RELEASE,
+        /**
+         * Mark the message as {@code rejected} and continue.
+         */
+        REJECT;
+
+        public static Strategy from(String s) {
+            if (s == null || s.equalsIgnoreCase("fail")) {
+                return FAIL;
+            }
+            if (s.equalsIgnoreCase("accept")) {
+                return ACCEPT;
+            }
+            if (s.equalsIgnoreCase("release")) {
+                return RELEASE;
+            }
+            if (s.equalsIgnoreCase("reject")) {
+                return REJECT;
+            }
+            throw ex.illegalArgumentUnknownFailureStrategy(s);
+        }
+    }
+
+    /**
+     * Handle message failure.
+     * 
+     * @param message the failed message
+     * @param context the {@link Context} in which the handling should be done
+     * @param reason the reason for the failure
+     * @param <V> message body type
+     * @return a {@link CompletionStage}
+     */
+    <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Context context, Throwable reason);
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQReject.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQReject.java
@@ -1,0 +1,30 @@
+package io.smallrye.reactive.messaging.rabbitmq.fault;
+
+import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
+
+import java.util.concurrent.CompletionStage;
+
+import io.smallrye.reactive.messaging.rabbitmq.ConnectionHolder;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.vertx.mutiny.core.Context;
+
+public class RabbitMQReject implements RabbitMQFailureHandler {
+    private final String channel;
+
+    /**
+     * Constructor.
+     * 
+     * @param channel the channel
+     */
+    public RabbitMQReject(String channel) {
+        this.channel = channel;
+    }
+
+    @Override
+    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Context context, Throwable reason) {
+        // We mark the message as rejected and fail.
+        log.nackedIgnoreMessage(channel);
+        log.fullIgnoredFailure(reason);
+        return ConnectionHolder.runOnContext(context, () -> msg.rejectMessage(reason));
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQExceptions.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQExceptions.java
@@ -1,0 +1,37 @@
+package io.smallrye.reactive.messaging.rabbitmq.i18n;
+
+import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageBundle;
+
+/**
+ * Defines a bundle of exception messages each with a unique id.
+ */
+@MessageBundle(projectCode = "SRMSG", length = 5)
+public interface RabbitMQExceptions {
+    RabbitMQExceptions ex = Messages.getBundle(RabbitMQExceptions.class);
+
+    @Message(id = 16001, value = "Expecting downstream to consume without back-pressure")
+    IllegalStateException illegalStateConsumeWithoutBackPressure();
+
+    @Message(id = 16002, value = "Invalid failure strategy: %s")
+    IllegalArgumentException illegalArgumentInvalidFailureStrategy(String strategy);
+
+    @Message(id = 16003, value = "AMQP Connection disconnected")
+    IllegalStateException illegalStateConnectionDisconnected();
+
+    @Message(id = 16004, value = "Unknown failure strategy: %s")
+    IllegalArgumentException illegalArgumentUnknownFailureStrategy(String strategy);
+
+    @Message(id = 16005, value = "Only one subscriber allowed")
+    IllegalStateException illegalStateOnlyOneSubscriberAllowed();
+
+    @Message(id = 16006, value = "The value of max-inflight-messages must be greater than 0")
+    IllegalArgumentException illegalArgumentInvalidMaxInflightMessages();
+
+    @Message(id = 16007, value = "If specified, the value of default-ttl must be greater than or equal to 0")
+    IllegalArgumentException illegalArgumentInvalidDefaultTtl();
+
+    @Message(id = 16008, value = "If specified, the value of queue.ttl must be greater than or equal to 0")
+    IllegalArgumentException illegalArgumentInvalidQueueTtl();
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQLogging.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQLogging.java
@@ -1,0 +1,114 @@
+package io.smallrye.reactive.messaging.rabbitmq.i18n;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+@MessageLogger(projectCode = "SRMSG", length = 5)
+public interface RabbitMQLogging extends BasicLogger {
+
+    RabbitMQLogging log = Logger.getMessageLogger(RabbitMQLogging.class, "io.smallrye.reactive.messaging.rabbitmq");
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 17000, value = "RabbitMQ Receiver listening address %s")
+    void receiverListeningAddress(String address);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17001, value = "RabbitMQ Receiver error")
+    void receiverError(@Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17002, value = "Unable to retrieve messages from RabbitMQ, retrying...")
+    void retrieveMessagesRetrying(@Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17003, value = "Unable to retrieve messages from RabbitMQ, no more retry")
+    void retrieveMessagesNoMoreRetrying(@Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 17006, value = "Establishing connection with RabbitMQ broker for channel `%s`")
+    void establishingConnection(String channel);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 17007, value = "Connection with RabbitMQ broker established for channel `%s`")
+    void connectionEstablished(String channel);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17008, value = "Unable to connect to the broker, retry will be attempted")
+    void unableToConnectToBroker(@Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17009, value = "Unable to recover from RabbitMQ connection disruption")
+    void unableToRecoverFromConnectionDisruption(@Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 17010, value = "A message sent to channel `%s` has been nacked, ignoring the failure and marking the RabbitMQ message as accepted")
+    void nackedAcceptMessage(String channel);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 17011, value = "The full ignored failure is")
+    void fullIgnoredFailure(@Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17012, value = "A message sent to channel `%s` has been nacked, rejecting the RabbitMQ message and fail-stop")
+    void nackedFailMessage(String channel);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 17013, value = "A message sent to channel `%s` has been nacked, ignoring the failure and marking the RabbitMQ message as rejected")
+    void nackedIgnoreMessage(String channel);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17018, value = "Failure reported for channel `%s`, closing client")
+    void failureReported(String channel, @Cause Throwable reason);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17021, value = "Unable to serialize message on channel `%s`, message has been nacked")
+    void serializationFailure(String channel, @Cause Throwable reason);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 17022, value = "Sending a message to exchange `%s` with routing key %s")
+    void sendingMessageToExchange(String exchange, String routingKey);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 17023, value = "Established exchange `%s`")
+    void exchangeEstablished(String exchangeName);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17024, value = "Unable to establish exchange `%s`")
+    void unableToEstablishExchange(String exchangeName, @Cause Throwable ex);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 17025, value = "Established queue `%s`")
+    void queueEstablished(String queueName);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17026, value = "Unable to bind queue '%s' to exchange '%s'")
+    void unableToEstablishBinding(String queueName, String exchangeName, @Cause Throwable ex);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 17027, value = "Established binding of queue `%s` to exchange '%s' using routing key '%s'")
+    void bindingEstablished(String queueName, String exchangeName, String routingKey);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17028, value = "Unable to establish queue `%s`")
+    void unableToEstablishQueue(String exchangeName, @Cause Throwable ex);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 17029, value = "Established dlx `%s`")
+    void dlxEstablished(String deadLetterExchangeName);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 17030, value = "Unable to establish dlx `%s`")
+    void unableToEstablishDlx(String deadLetterExchangeName, @Cause Throwable ex);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 17033, value = "A message sent to channel `%s` has been ack'd")
+    void ackMessage(String channel);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 17034, value = "A message sent to channel `%s` has not been explicitly ack'd as auto-ack is enabled")
+    void ackAutoMessage(String channel);
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQMessages.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQMessages.java
@@ -1,0 +1,15 @@
+package io.smallrye.reactive.messaging.rabbitmq.i18n;
+
+import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.MessageBundle;
+
+/**
+ * Messages for RabbitMQ Connector
+ * Assigned ID range is 16100-16199
+ */
+@MessageBundle(projectCode = "SRMSG", length = 5)
+public interface RabbitMQMessages {
+
+    RabbitMQMessages msg = Messages.getBundle(RabbitMQMessages.class);
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/HeadersMapExtractAdapter.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/HeadersMapExtractAdapter.java
@@ -1,0 +1,30 @@
+package io.smallrye.reactive.messaging.rabbitmq.tracing;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import io.opentelemetry.context.propagation.TextMapGetter;
+
+/**
+ * A {@link TextMapGetter} that is sourced from a string-keyed Map.
+ */
+public class HeadersMapExtractAdapter implements TextMapGetter<Map<String, Object>> {
+
+    public static final HeadersMapExtractAdapter GETTER = new HeadersMapExtractAdapter();
+
+    /**
+     * Constructor.
+     */
+    private HeadersMapExtractAdapter() {
+    }
+
+    @Override
+    public Iterable<String> keys(final Map<String, Object> carrier) {
+        return new ArrayList<>(carrier.keySet());
+    }
+
+    @Override
+    public String get(final Map<String, Object> carrier, final String key) {
+        return (carrier != null) ? String.valueOf(carrier.get(key)) : null;
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/HeadersMapInjectAdapter.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/HeadersMapInjectAdapter.java
@@ -1,0 +1,24 @@
+package io.smallrye.reactive.messaging.rabbitmq.tracing;
+
+import java.util.Map;
+
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+/**
+ * A {@link TextMapSetter} that targets a string-keyed Map.
+ */
+class HeadersMapInjectAdapter implements TextMapSetter<Map<String, Object>> {
+
+    public static final HeadersMapInjectAdapter SETTER = new HeadersMapInjectAdapter();
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private HeadersMapInjectAdapter() {
+    }
+
+    @Override
+    public void set(final Map<String, Object> carrier, final String key, final String value) {
+        carrier.put(key, value);
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/TracingUtils.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/TracingUtils.java
@@ -1,0 +1,236 @@
+package io.smallrye.reactive.messaging.rabbitmq.tracing;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import com.rabbitmq.client.Envelope;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.smallrye.reactive.messaging.TracingMetadata;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata;
+
+/**
+ * Utility methods to manage spans for incoming and outgoing messages.
+ */
+public abstract class TracingUtils {
+
+    private static final String SYSTEM_RABBITMQ = "rabbitmq";
+    private static final String DESTINATION_EXCHANGE = "exchange";
+    private static final String DESTINATION_QUEUE = "queue";
+
+    // A shared tracer for use throughout the connector
+    private static Tracer tracer;
+
+    public static void initialise() {
+        tracer = GlobalOpenTelemetry.getTracerProvider().get("io.smallrye.reactive.messaging.rabbitmq");
+    }
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private TracingUtils() {
+    }
+
+    /**
+     * Extract tracing metadata from a received RabbitMQ message and return
+     * it as {@link TracingMetadata}.
+     *
+     * @param msg the incoming RabbitMQ message
+     * @return a {@link TracingMetadata} instance, possibly empty but never null
+     */
+    public static TracingMetadata getTracingMetaData(
+            final io.vertx.rabbitmq.RabbitMQMessage msg) {
+        // Default
+        TracingMetadata tracingMetadata = TracingMetadata.empty();
+
+        if (msg.properties().getHeaders() != null) {
+            // Extract the tracing headers from the incoming RabbitMQ message into a tracing context
+            final Context context = GlobalOpenTelemetry.getPropagators().getTextMapPropagator()
+                    .extract(io.opentelemetry.context.Context.root(), msg.properties().getHeaders(),
+                            HeadersMapExtractAdapter.GETTER);
+
+            // create tracing metadata based on that tracing context
+            tracingMetadata = TracingMetadata.withPrevious(context);
+        }
+
+        return tracingMetadata;
+    }
+
+    /**
+     * Creates a span based on any tracing metadata in the incoming message.
+     *
+     * @param msg the incoming message
+     * @param attributeHeaders a list (possibly empty) of header names whose values (if present)
+     *        should be used as span attributes
+     * @param <T> the message body type
+     * @return the message, with injected tracing metadata
+     */
+    public static <T> Message<T> addIncomingTrace(
+            final IncomingRabbitMQMessage<T> msg,
+            final String queue,
+            final List<String> attributeHeaders) {
+        final TracingMetadata tracingMetadata = TracingMetadata.fromMessage(msg).orElse(TracingMetadata.empty());
+        final Envelope envelope = msg.getRabbitMQMessage().envelope();
+
+        final SpanBuilder spanBuilder = tracer.spanBuilder(envelope.getExchange() + " receive")
+                .setSpanKind(SpanKind.CONSUMER);
+
+        // Handle possible parent span
+        final Context parentSpanContext = tracingMetadata.getPreviousContext();
+        if (parentSpanContext != null) {
+            spanBuilder.setParent(parentSpanContext);
+        } else {
+            spanBuilder.setNoParent();
+        }
+
+        final Span span = spanBuilder.startSpan();
+
+        // Filter the incoming message headers to just those that should map to span tags
+        final Map<String, Object> headerValues = msg.getHeaders().entrySet().stream()
+                .filter(e -> attributeHeaders.contains(e.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        try {
+            setIncomingSpanAttributes(span, queue, envelope.getRoutingKey(), headerValues);
+
+            // Make available as parent for subsequent spans inside message processing
+            span.makeCurrent();
+
+            msg.injectTracingMetadata(tracingMetadata.withSpan(span));
+        } finally {
+            span.end();
+        }
+
+        return msg;
+    }
+
+    /**
+     * Adds "standard" RabbitMQ semantic tracing attributes to the span associated with an incoming message
+     *
+     * @param span the span
+     * @param queue the source queue
+     * @param routingKey the routing key
+     * @param attributeHeaders a map (possibly empty, but never null) of headers and their values that should
+     *        be mapped to span attributes. Only non-null values of type Long, String, Boolean or Double will be mapped.
+     */
+    private static void setIncomingSpanAttributes(
+            final Span span,
+            final String queue,
+            final String routingKey,
+            final Map<String, Object> attributeHeaders) {
+        span.setAttribute(SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY, routingKey);
+        span.setAttribute(SemanticAttributes.MESSAGING_SYSTEM, SYSTEM_RABBITMQ);
+        span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, queue);
+        span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND, DESTINATION_QUEUE);
+        setHeaderSpanAttributes(span, attributeHeaders);
+    }
+
+    /**
+     * Adds "standard" RabbitMQ semantic tracing attributes to the span associated with an outgoing message
+     *
+     * @param span the span
+     * @param exchange the destination exchange
+     * @param routingKey the routing key
+     * @param attributeHeaders a map (possibly empty, but never null) of headers and their values that should
+     *        be mapped to span attributes. Only non-null values of type Long, String, Boolean or Double will be mapped.
+     */
+    private static void setOutgoingSpanAttributes(
+            final Span span,
+            final String exchange,
+            final String routingKey,
+            final Map<String, Object> attributeHeaders) {
+        span.setAttribute(SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY, routingKey);
+        span.setAttribute(SemanticAttributes.MESSAGING_SYSTEM, SYSTEM_RABBITMQ);
+        span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, exchange);
+        span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND, DESTINATION_EXCHANGE);
+        setHeaderSpanAttributes(span, attributeHeaders);
+    }
+
+    /**
+     * Adds RabbitMQ header-sourced tracing attributes to the span.
+     *
+     * @param span the span
+     * @param attributeHeaders a map (possibly empty, but never null) of headers and their values that should
+     *        be mapped to span attributes. Only non-null values of type Long, String, Boolean or Double will be mapped.
+     */
+    private static void setHeaderSpanAttributes(final Span span, final Map<String, Object> attributeHeaders) {
+        // For any of the specified headers that have a non-null value of a type
+        // supported by opentelemetry, create a span attribute for that header that contains the value
+        attributeHeaders.forEach((header, value) -> {
+            if (value instanceof Long) {
+                span.setAttribute(header, (long) value);
+            } else if (value instanceof String) {
+                span.setAttribute(header, (String) value);
+            } else if (value instanceof Boolean) {
+                span.setAttribute(header, (Boolean) value);
+            } else if (value instanceof Double) {
+                span.setAttribute(header, (Double) value);
+            }
+        });
+    }
+
+    /**
+     * Creates a new outgoing message span message, and ensures span metadata is added to the
+     * message headers.
+     *
+     * @param message the source message
+     * @param headers the outgoing headers, must be mutable
+     * @param exchange the target exchange
+     * @param routingKey the routing key
+     * @param attributeHeaders a list (possibly empty) of header names whose values (if present)
+     *        should be used as span attributes
+     */
+    public static void createOutgoingTrace(
+            final Message<?> message,
+            final Map<String, Object> headers,
+            final String exchange,
+            final String routingKey,
+            final List<String> attributeHeaders) {
+        // Extract tracing metadata from the source message itself
+        final TracingMetadata tracingMetadata = TracingMetadata.fromMessage(message).orElse(null);
+
+        final SpanBuilder spanBuilder = tracer.spanBuilder(exchange + " send")
+                .setSpanKind(SpanKind.PRODUCER);
+
+        if (tracingMetadata != null) {
+            // Handle possible parent span
+            final Context parentSpanContext = tracingMetadata.getPreviousContext();
+
+            if (parentSpanContext != null) {
+                spanBuilder.setParent(parentSpanContext);
+            } else {
+                spanBuilder.setNoParent();
+            }
+        } else {
+            spanBuilder.setNoParent();
+        }
+
+        final Span span = spanBuilder.startSpan();
+        final Context sendingContext = Context.current().with(span);
+
+        // Filter the outgoing message headers to just those that should map to span tags
+        final Map<String, Object> headerValues = message.getMetadata(OutgoingRabbitMQMetadata.class)
+                .map(md -> md.getHeaders().entrySet().stream()
+                        .filter(e -> attributeHeaders.contains(e.getKey()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                .orElse(Collections.emptyMap());
+
+        setOutgoingSpanAttributes(span, exchange, routingKey, headerValues);
+
+        // Set span onto outgoing headers
+        GlobalOpenTelemetry.getPropagators().getTextMapPropagator()
+                .inject(sendingContext, headers, HeadersMapInjectAdapter.SETTER);
+        span.end();
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,9 @@
+<beans
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+        bean-discovery-mode="annotated">
+
+</beans>

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ConsumptionBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ConsumptionBean.java
@@ -1,0 +1,38 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+/**
+ * A bean that can be registered to support consumption of messages from an
+ * incoming rabbitmq channel.
+ */
+@ApplicationScoped
+public class ConsumptionBean {
+
+    private final List<Integer> list = new ArrayList<>();
+
+    @Incoming("data")
+    @Outgoing("sink")
+    @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+    public Message<Integer> process(IncomingRabbitMQMessage<String> input) {
+        int value = Integer.parseInt(input.getPayload());
+        return Message.of(value + 1, input::ack);
+    }
+
+    @Incoming("sink")
+    public void sink(int val) {
+        list.add(val);
+    }
+
+    public List<Integer> getResults() {
+        return list;
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingBean.java
@@ -1,0 +1,22 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Uni;
+
+/**
+ * A bean that can be registered to do just enough to support the
+ * declaration of an exchange/queue/etc backing an incoming rabbitmq channel.
+ */
+@ApplicationScoped
+public class IncomingBean {
+
+    @Incoming("data")
+    public Uni<Void> process(Message<Integer> input) {
+        return Uni.createFrom().voidItem();
+    }
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingBean.java
@@ -1,0 +1,20 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+/**
+ * A bean that can be registered to do just enough to support the
+ * declaration of an exchange backing an outgoing rabbitmq channel.
+ */
+@ApplicationScoped
+public class OutgoingBean {
+
+    @Outgoing("sink")
+    public Message<String> process() {
+        return Message.of("test");
+    }
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ProducingBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ProducingBean.java
@@ -1,0 +1,40 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import java.time.Duration;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * A bean that can be registered to support publishing of messages to an
+ * outgoing rabbitmq channel.
+ */
+@ApplicationScoped
+public class ProducingBean {
+
+    @Incoming("data")
+    @Outgoing("sink")
+    @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+    public Message<Integer> process(Message<Integer> input) {
+        return Message.of(input.getPayload() + 1, input::ack);
+    }
+
+    @Outgoing("data")
+    public Publisher<Integer> source() {
+        return Multi.createFrom().ticks().every(Duration.ofMillis(100))
+                .map(l -> l.intValue())
+                .onItem().invoke(l -> {
+                    if (l > 9) {
+                        throw new IllegalArgumentException("Done");
+                    }
+                });
+    }
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQBrokerTestBase.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQBrokerTestBase.java
@@ -1,0 +1,101 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.util.AnnotationLiteral;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.mutiny.core.Vertx;
+
+/**
+ * Provides a basis for test classes, by managing the RabbitMQ broker test container.
+ */
+public class RabbitMQBrokerTestBase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("RabbitMQ");
+
+    private static final GenericContainer<?> RABBIT = new GenericContainer<>(
+            DockerImageName.parse("rabbitmq:3-management"))
+                    .withExposedPorts(5672, 15672)
+                    .withLogConsumer(of -> LOGGER.info(of.getUtf8String()))
+                    .waitingFor(
+                            Wait.forLogMessage(".*Server startup complete; 3 plugins started.*\\n", 1))
+                    .withFileSystemBind("src/test/resources/rabbitmq/enabled_plugins", "/etc/rabbitmq/enabled_plugins",
+                            BindMode.READ_ONLY);
+
+    protected static String host;
+    protected static int port;
+    protected static int managementPort;
+    final static String username = "guest";
+    final static String password = "guest";
+    RabbitMQUsage usage;
+    ExecutionHolder executionHolder;
+
+    @BeforeAll
+    public static void startBroker() {
+        RABBIT.start();
+
+        port = RABBIT.getMappedPort(5672);
+        managementPort = RABBIT.getMappedPort(15672);
+        host = RABBIT.getContainerIpAddress();
+
+        System.setProperty("rabbitmq-host", host);
+        System.setProperty("rabbitmq-port", Integer.toString(port));
+    }
+
+    @AfterAll
+    public static void stopBroker() {
+        RABBIT.stop();
+        System.clearProperty("rabbitmq-host");
+        System.clearProperty("rabbitmq-port");
+    }
+
+    @BeforeEach
+    public void setup() {
+        executionHolder = new ExecutionHolder(Vertx.vertx());
+
+        usage = new RabbitMQUsage(executionHolder.vertx(), host, port, managementPort, username, password);
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+        MapBasedConfig.cleanup();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        usage.close();
+        executionHolder.terminate(null);
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+        MapBasedConfig.cleanup();
+    }
+
+    /**
+     * Indicates whether the connector has completed startup (including establishment of exchanges, queues
+     * and so forth)
+     * 
+     * @param container the {@link WeldContainer}
+     * @return true if the connector is ready, false otherwise
+     */
+    public boolean isRabbitMQConnectorAvailable(WeldContainer container) {
+        final RabbitMQConnector connector = container.getBeanManager().createInstance().select(RabbitMQConnector.class,
+                new AnnotationLiteral<Any>() {
+                }).get();
+
+        // Use strict mode for health because that indicates that outgoing channels have got to the point where
+        // a declared exchange has been established.
+        return connector.getHealth(true).isOk();
+    }
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -1,0 +1,387 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+@SuppressWarnings("ConstantConditions")
+class RabbitMQTest extends RabbitMQBrokerTestBase {
+
+    private WeldContainer container;
+
+    Weld weld = new Weld();
+
+    @AfterEach
+    public void cleanup() {
+        if (container != null) {
+            container.shutdown();
+        }
+
+        MapBasedConfig.cleanup();
+        SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+    }
+
+    /**
+     * Verifies that Exchanges are correctly declared as a result of outgoing connector
+     * configuration.
+     */
+    @Test
+    void testOutgoingDeclarations() throws Exception {
+
+        final String exchangeName = "exchgOutgoingDeclareTest";
+        final boolean exchangeDurable = false;
+        final boolean exchangeAutoDelete = true;
+        final String exchangeType = "fanout";
+
+        weld.addBeanClass(OutgoingBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.outgoing.sink.exchange.name", exchangeName)
+                .put("mp.messaging.outgoing.sink.exchange.durable", exchangeDurable)
+                .put("mp.messaging.outgoing.sink.exchange.auto-delete", exchangeAutoDelete)
+                .put("mp.messaging.outgoing.sink.exchange.type", exchangeType)
+                .put("mp.messaging.outgoing.sink.exchange.name", exchangeName)
+                .put("mp.messaging.outgoing.sink.exchange.declare", true)
+                .put("mp.messaging.outgoing.sink.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .put("mp.messaging.outgoing.sink.host", host)
+                .put("mp.messaging.outgoing.sink.port", port)
+                .put("mp.messaging.outgoing.sink.tracing.enabled", false)
+                .put("rabbitmq-username", username)
+                .put("rabbitmq-password", password)
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAvailable(container));
+
+        final JsonObject exchange = usage.getExchange(exchangeName);
+        assertThat(exchange).isNotNull();
+        assertThat(exchange.getString("name")).isEqualTo(exchangeName);
+        assertThat(exchange.getString("type")).isEqualTo(exchangeType);
+        assertThat(exchange.getBoolean("auto_delete")).isEqualTo(exchangeAutoDelete);
+        assertThat(exchange.getBoolean("durable")).isEqualTo(exchangeDurable);
+        assertThat(exchange.getBoolean("internal")).isFalse();
+    }
+
+    /**
+     * Verifies that Exchanges, Queues and Bindings are correctly declared as a result of
+     * incoming connector configuration.
+     */
+    @Test
+    void testIncomingDeclarations() throws Exception {
+        final String exchangeName = "exchgIncomingDeclareTest";
+        final boolean exchangeDurable = false;
+        final boolean exchangeAutoDelete = true;
+        final String exchangeType = "fanout";
+
+        final String queueName = "qIncomingDeclareTest";
+        final boolean queueDurable = false;
+        final boolean queueExclusive = true;
+        final boolean queueAutoDelete = true;
+        final long queueTtl = 10000L;
+
+        final String routingKeys = "urgent, normal";
+
+        weld.addBeanClass(IncomingBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.data.exchange.name", exchangeName)
+                .put("mp.messaging.incoming.data.exchange.durable", exchangeDurable)
+                .put("mp.messaging.incoming.data.exchange.auto-delete", exchangeAutoDelete)
+                .put("mp.messaging.incoming.data.exchange.type", exchangeType)
+                .put("mp.messaging.incoming.data.exchange.name", exchangeName)
+                .put("mp.messaging.incoming.data.exchange.declare", true)
+                .put("mp.messaging.incoming.data.queue.name", queueName)
+                .put("mp.messaging.incoming.data.queue.durable", queueDurable)
+                .put("mp.messaging.incoming.data.queue.exclusive", queueExclusive)
+                .put("mp.messaging.incoming.data.queue.auto-delete", queueAutoDelete)
+                .put("mp.messaging.incoming.data.queue.declare", true)
+                .put("mp.messaging.incoming.data.queue.ttl", queueTtl)
+                .put("mp.messaging.incoming.data.routing-keys", routingKeys)
+                .put("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data.host", host)
+                .put("mp.messaging.incoming.data.port", port)
+                .put("mp.messaging.incoming.data.tracing.enabled", false)
+                .put("rabbitmq-username", username)
+                .put("rabbitmq-password", password)
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAvailable(container));
+
+        // verify exchange
+        final JsonObject exchange = usage.getExchange(exchangeName);
+        assertThat(exchange).isNotNull();
+        assertThat(exchange.getString("name")).isEqualTo(exchangeName);
+        assertThat(exchange.getString("type")).isEqualTo(exchangeType);
+        assertThat(exchange.getBoolean("auto_delete")).isEqualTo(exchangeAutoDelete);
+        assertThat(exchange.getBoolean("durable")).isEqualTo(exchangeDurable);
+        assertThat(exchange.getBoolean("internal")).isFalse();
+
+        // verify queue
+        final JsonObject queue = usage.getQueue(queueName);
+        assertThat(queue).isNotNull();
+        assertThat(queue.getString("name")).isEqualTo(queueName);
+        assertThat(queue.getBoolean("auto_delete")).isEqualTo(queueAutoDelete);
+        assertThat(queue.getBoolean("durable")).isEqualTo(queueDurable);
+        assertThat(queue.getBoolean("exclusive")).isEqualTo(queueExclusive);
+
+        // verify bindings
+        final JsonObject queueArguments = queue.getJsonObject("arguments");
+        assertThat(queueArguments).isNotNull();
+        assertThat(queueArguments.getString("x-dead-letter-exchange")).isEqualTo("DLX");
+        assertThat(queueArguments.getString("x-dead-letter-routing-key")).isEqualTo(queueName);
+        assertThat(queueArguments.getLong("x-message-ttl")).isEqualTo(queueTtl);
+
+        final JsonArray queueBindings = usage.getBindings(exchangeName, queueName);
+        assertThat(queueBindings.size()).isEqualTo(2);
+
+        final List<?> bindings = queueBindings.stream()
+                .sorted(Comparator.comparing(x -> ((JsonObject) x).getString("routing_key")))
+                .collect(Collectors.toList());
+
+        final JsonObject binding1 = (JsonObject) bindings.get(0);
+        assertThat(binding1).isNotNull();
+        assertThat(binding1.getString("source")).isEqualTo(exchangeName);
+        assertThat(binding1.getString("vhost")).isEqualTo("/");
+        assertThat(binding1.getString("destination")).isEqualTo(queueName);
+        assertThat(binding1.getString("destination_type")).isEqualTo("queue");
+        assertThat(binding1.getString("routing_key")).isEqualTo("normal");
+
+        final JsonObject binding2 = (JsonObject) bindings.get(1);
+        assertThat(binding2).isNotNull();
+        assertThat(binding2.getString("source")).isEqualTo(exchangeName);
+        assertThat(binding2.getString("vhost")).isEqualTo("/");
+        assertThat(binding2.getString("destination")).isEqualTo(queueName);
+        assertThat(binding2.getString("destination_type")).isEqualTo("queue");
+        assertThat(binding2.getString("routing_key")).isEqualTo("urgent");
+    }
+
+    /**
+     * Verifies that Exchanges, Queues and Bindings are correctly declared as a result of
+     * incoming connector configuration that specifies DLQ/DLX overrides.
+     */
+    @Test
+    void testIncomingDeclarationsWithDLQ() throws Exception {
+        final String exchangeName = "exchgIncomingDeclareTestWithDLQ";
+        final boolean exchangeDurable = false;
+        final boolean exchangeAutoDelete = true;
+        final String exchangeType = "fanout";
+
+        final String queueName = "qIncomingDeclareTestWithDLQ";
+        final boolean queueDurable = false;
+        final boolean queueExclusive = true;
+        final boolean queueAutoDelete = true;
+        final long queueTtl = 10000L;
+
+        final String dlqName = "dlqIncomingDeclareTest";
+        final String dlxName = "dlxIncomingDeclareTest";
+        final String dlxType = "topic";
+        final String dlxRoutingKey = "failure";
+
+        final String routingKeys = "urgent, normal";
+
+        weld.addBeanClass(IncomingBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.data.exchange.name", exchangeName)
+                .put("mp.messaging.incoming.data.exchange.durable", exchangeDurable)
+                .put("mp.messaging.incoming.data.exchange.auto-delete", exchangeAutoDelete)
+                .put("mp.messaging.incoming.data.exchange.type", exchangeType)
+                .put("mp.messaging.incoming.data.exchange.name", exchangeName)
+                .put("mp.messaging.incoming.data.exchange.declare", true)
+                .put("mp.messaging.incoming.data.queue.name", queueName)
+                .put("mp.messaging.incoming.data.queue.durable", queueDurable)
+                .put("mp.messaging.incoming.data.queue.exclusive", queueExclusive)
+                .put("mp.messaging.incoming.data.queue.auto-delete", queueAutoDelete)
+                .put("mp.messaging.incoming.data.queue.declare", true)
+                .put("mp.messaging.incoming.data.queue.ttl", queueTtl)
+                .put("mp.messaging.incoming.data.routing-keys", routingKeys)
+                .put("mp.messaging.incoming.data.auto-bind-dlq", true)
+                .put("mp.messaging.incoming.data.dead-letter-queue-name", dlqName)
+                .put("mp.messaging.incoming.data.dead-letter-exchange", dlxName)
+                .put("mp.messaging.incoming.data.dead-letter-exchange-type", dlxType)
+                .put("mp.messaging.incoming.data.dead-letter-routing-key", dlxRoutingKey)
+                .put("mp.messaging.incoming.data.dlx.declare", true)
+                .put("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data.host", host)
+                .put("mp.messaging.incoming.data.port", port)
+                .put("mp.messaging.incoming.data.tracing.enabled", false)
+                .put("rabbitmq-username", username)
+                .put("rabbitmq-password", password)
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAvailable(container));
+
+        // verify exchange
+        final JsonObject exchange = usage.getExchange(exchangeName);
+        assertThat(exchange).isNotNull();
+        assertThat(exchange.getString("name")).isEqualTo(exchangeName);
+        assertThat(exchange.getString("type")).isEqualTo(exchangeType);
+        assertThat(exchange.getBoolean("auto_delete")).isEqualTo(exchangeAutoDelete);
+        assertThat(exchange.getBoolean("durable")).isEqualTo(exchangeDurable);
+        assertThat(exchange.getBoolean("internal")).isFalse();
+
+        // verify dlx
+        final JsonObject dlx = usage.getExchange(dlxName);
+        assertThat(dlx).isNotNull();
+        assertThat(dlx.getString("name")).isEqualTo(dlxName);
+        assertThat(dlx.getString("type")).isEqualTo(dlxType);
+        assertThat(dlx.getBoolean("auto_delete")).isFalse();
+        assertThat(dlx.getBoolean("durable")).isTrue();
+        assertThat(dlx.getBoolean("internal")).isFalse();
+
+        // verify queue
+        final JsonObject queue = usage.getQueue(queueName);
+        assertThat(queue).isNotNull();
+        assertThat(queue.getString("name")).isEqualTo(queueName);
+        assertThat(queue.getBoolean("auto_delete")).isEqualTo(queueAutoDelete);
+        assertThat(queue.getBoolean("durable")).isEqualTo(queueDurable);
+        assertThat(queue.getBoolean("exclusive")).isEqualTo(queueExclusive);
+
+        final JsonObject queueArguments = queue.getJsonObject("arguments");
+        assertThat(queueArguments).isNotNull();
+        assertThat(queueArguments.getString("x-dead-letter-exchange")).isEqualTo(dlxName);
+        assertThat(queueArguments.getString("x-dead-letter-routing-key")).isEqualTo(dlxRoutingKey);
+        assertThat(queueArguments.getLong("x-message-ttl")).isEqualTo(queueTtl);
+
+        // verify dlq
+        final JsonObject dlq = usage.getQueue(dlqName);
+        assertThat(dlq).isNotNull();
+        assertThat(dlq.getString("name")).isEqualTo(dlqName);
+        assertThat(dlq.getBoolean("auto_delete")).isFalse();
+        assertThat(dlq.getBoolean("durable")).isTrue();
+        assertThat(dlq.getBoolean("exclusive")).isFalse();
+
+        final JsonObject dlqArguments = dlq.getJsonObject("arguments");
+        assertThat(dlqArguments.fieldNames()).isEqualTo(Collections.emptySet());
+
+        // verify bindings
+        final JsonArray queueBindings = usage.getBindings(exchangeName, queueName);
+        assertThat(queueBindings.size()).isEqualTo(2);
+
+        final List<?> bindings = queueBindings.stream()
+                .sorted(Comparator.comparing(x -> ((JsonObject) x).getString("routing_key")))
+                .collect(Collectors.toList());
+
+        final JsonObject binding1 = (JsonObject) bindings.get(0);
+        assertThat(binding1).isNotNull();
+        assertThat(binding1.getString("source")).isEqualTo(exchangeName);
+        assertThat(binding1.getString("vhost")).isEqualTo("/");
+        assertThat(binding1.getString("destination")).isEqualTo(queueName);
+        assertThat(binding1.getString("destination_type")).isEqualTo("queue");
+        assertThat(binding1.getString("routing_key")).isEqualTo("normal");
+
+        final JsonObject binding2 = (JsonObject) bindings.get(1);
+        assertThat(binding2).isNotNull();
+        assertThat(binding2.getString("source")).isEqualTo(exchangeName);
+        assertThat(binding2.getString("vhost")).isEqualTo("/");
+        assertThat(binding2.getString("destination")).isEqualTo(queueName);
+        assertThat(binding2.getString("destination_type")).isEqualTo("queue");
+        assertThat(binding2.getString("routing_key")).isEqualTo("urgent");
+
+        // verify dlq bindings
+        final JsonArray dlqBindings = usage.getBindings(dlxName, dlqName);
+        assertThat(dlqBindings.size()).isEqualTo(1);
+
+        final JsonObject dlqBinding1 = (JsonObject) dlqBindings.getJsonObject(0);
+        assertThat(dlqBinding1).isNotNull();
+        assertThat(dlqBinding1.getString("source")).isEqualTo(dlxName);
+        assertThat(dlqBinding1.getString("vhost")).isEqualTo("/");
+        assertThat(dlqBinding1.getString("destination")).isEqualTo(dlqName);
+        assertThat(dlqBinding1.getString("destination_type")).isEqualTo("queue");
+        assertThat(dlqBinding1.getString("routing_key")).isEqualTo(dlxRoutingKey);
+    }
+
+    /**
+     * Verifies that messages can be sent to RabbitMQ.
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    void testSendingMessagesToRabbitMQ() throws InterruptedException {
+        final String exchangeName = "exchg1";
+        final String routingKey = "normal";
+
+        CountDownLatch latch = new CountDownLatch(10);
+        usage.consumeIntegers(exchangeName, routingKey,
+                v -> latch.countDown());
+
+        weld.addBeanClass(ProducingBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.outgoing.sink.exchange.name", exchangeName)
+                .put("mp.messaging.outgoing.sink.exchange.declare", false)
+                .put("mp.messaging.outgoing.sink.default-routing-key", routingKey)
+                .put("mp.messaging.outgoing.sink.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .put("mp.messaging.outgoing.sink.host", host)
+                .put("mp.messaging.outgoing.sink.port", port)
+                .put("mp.messaging.outgoing.sink.tracing.enabled", false)
+                .put("rabbitmq-username", username)
+                .put("rabbitmq-password", password)
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAvailable(container));
+
+        assertThat(latch.await(3, TimeUnit.MINUTES)).isTrue();
+    }
+
+    /**
+     * Verifies that messages can be received from RabbitMQ.
+     */
+    @Test
+    void testReceivingMessagesFromRabbitMQ() {
+        final String exchangeName = "exchg2";
+        final String queueName = "q2";
+        final String routingKey = "xyzzy";
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.data.exchange.name", exchangeName)
+                .put("mp.messaging.incoming.data.exchange.durable", false)
+                .put("mp.messaging.incoming.data.queue.name", queueName)
+                .put("mp.messaging.incoming.data.queue.durable", false)
+                .put("mp.messaging.incoming.data.queue.routing-keys", routingKey)
+                .put("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data.host", host)
+                .put("mp.messaging.incoming.data.port", port)
+                .put("mp.messaging.incoming.data.tracing-enabled", false)
+                .put("rabbitmq-username", username)
+                .put("rabbitmq-password", password)
+                .write();
+
+        weld.addBeanClass(ConsumptionBean.class);
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAvailable(container));
+        ConsumptionBean bean = container.getBeanManager().createInstance().select(ConsumptionBean.class).get();
+
+        await().until(() -> isRabbitMQConnectorAvailable(container));
+
+        List<Integer> list = bean.getResults();
+        assertThat(list).isEmpty();
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers(exchangeName, queueName, routingKey, counter::getAndIncrement);
+
+        await().atMost(1, TimeUnit.MINUTES).until(() -> list.size() >= 10);
+        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQUsage.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQUsage.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2018-2019 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *        The Eclipse Public License is available at
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ *        The Apache License v2.0 is available at
+ *        http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.BasicProperties;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.context.Context;
+import io.smallrye.reactive.messaging.rabbitmq.tracing.HeadersMapExtractAdapter;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.rabbitmq.RabbitMQClient;
+import io.vertx.rabbitmq.QueueOptions;
+import io.vertx.rabbitmq.RabbitMQOptions;
+
+/**
+ * Provides methods to interact directly with a RabbitMQ instance.
+ */
+public class RabbitMQUsage {
+
+    private final static Logger LOGGER = Logger.getLogger(RabbitMQUsage.class);
+    private final RabbitMQClient client;
+    private final RabbitMQOptions options;
+    private final Vertx vertx;
+    private final int managementPort;
+
+    /**
+     * Constructor.
+     *
+     * @param vertx the {@link Vertx} instance
+     * @param host the rabbitmq hostname
+     * @param port the mapped rabbitmq port
+     * @param managementPort the mapped rabbitmq management port
+     * @param user user credential for accessing rabbitmq
+     * @param pwd password credential for accessing rabbitmq
+     */
+    public RabbitMQUsage(final Vertx vertx, final String host, final int port, final int managementPort, final String user,
+            final String pwd) {
+        this.vertx = vertx;
+        this.managementPort = managementPort;
+        this.options = new RabbitMQOptions().setHost(host).setPort(port).setUser(user).setPassword(pwd);
+        this.client = RabbitMQClient.create(new Vertx(vertx.getDelegate()), options);
+    }
+
+    /**
+     * Use the supplied function to asynchronously produce messages and write them to the host.
+     *
+     * @param exchange the exchange, must not be null
+     * @param messageCount the number of messages to produce; must be positive
+     * @param messageSupplier the function to produce messages; may not be null
+     */
+    void produce(String exchange, String queue, String routingKey, int messageCount, Supplier<Object> messageSupplier) {
+        CountDownLatch done = new CountDownLatch(messageCount);
+        // Start the machinery to receive the messages
+        client.startAndAwait();
+
+        final Thread t = new Thread(() -> {
+            LOGGER.infof("Starting RabbitMQ sender to write %s messages with routing key %s", messageCount, routingKey);
+            try {
+                for (int i = 0; i != messageCount; ++i) {
+                    final Object payload = messageSupplier.get();
+                    final Buffer body = Buffer.buffer(payload.toString());
+                    final BasicProperties properties = new AMQP.BasicProperties().builder()
+                            .expiration("10000")
+                            .contentType("text/plain")
+                            .build();
+
+                    client.basicPublish(exchange, routingKey, properties, body)
+                            .subscribe().with(
+                                    v -> {
+                                        LOGGER.infof("Producer sent message %s", payload);
+                                        done.countDown();
+                                    },
+                                    ex -> ex.printStackTrace());
+                }
+            } catch (Exception e) {
+                LOGGER.error("Unable to send message", e);
+            }
+            LOGGER.infof("Finished sending %s messages with routing key %s", messageCount, routingKey);
+        });
+
+        t.setName(exchange + "-thread");
+        t.start();
+
+        try {
+            done.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            // Ignore me
+        }
+    }
+
+    /**
+     * Use the supplied function to asynchronously consume messages from a queue.
+     *
+     * @param exchange the exchange
+     * @param routingKey the routing key
+     * @param consumerFunction the function to consume the messages; may not be null
+     */
+    public void consume(String exchange, String routingKey,
+            Consumer<io.vertx.mutiny.rabbitmq.RabbitMQMessage> consumerFunction) {
+        final String queue = "tempConsumeMessages";
+        // Start by the machinery to receive the messages
+        client.exchangeDeclareAndAwait(exchange, "topic", false, false);
+        client.queueDeclareAndAwait(queue, false, false, false);
+        client.queueBindAndAwait(queue, exchange, routingKey);
+
+        // Now set up a consumer
+        client.basicConsumerAndAwait(queue, new QueueOptions()).handler(
+                msg -> {
+                    LOGGER.infof("Consumer %s: consuming message", exchange);
+                    consumerFunction.accept(msg);
+                });
+    }
+
+    public void consumeIntegers(String exchange, String routingKey, Consumer<Integer> consumer) {
+        final String queue = "tempConsumeIntegers";
+        // Start by the machinery to receive the messages
+        client.startAndAwait();
+        LOGGER.infof("RabbitMQ client now started");
+        client.exchangeDeclareAndAwait(exchange, "topic", false, true);
+        LOGGER.infof("RabbitMQ exchange declared %s", exchange);
+        client.queueDeclareAndAwait(queue, false, false, true);
+        LOGGER.infof("RabbitMQ queue declared %s", queue);
+        LOGGER.infof("About to bind RabbitMQ queue % to exchange %s via routing key %s", queue, exchange, routingKey);
+        client.queueBindAndAwait(queue, exchange, routingKey);
+        LOGGER.infof("RabbitMQ queue % bound to exchange %s via routing key %s", queue, exchange, routingKey);
+
+        // Now set up a consumer
+        client.basicConsumerAndAwait(queue, new QueueOptions()).handler(
+                msg -> {
+                    final String payload = msg.body().toString();
+                    LOGGER.infof("Consumer %s: consuming message %s", exchange, payload);
+                    consumer.accept(Integer.parseInt(payload));
+                });
+        LOGGER.infof("Created consumer");
+    }
+
+    public void consumeIntegersWithTracing(String exchange, String routingKey, Consumer<Integer> consumer,
+            Consumer<Context> tracingConsumer) {
+        this.consume(exchange, routingKey,
+                (msg) -> {
+                    consumer.accept(msg.body().getInt(0));
+                    tracingConsumer.accept(
+                            GlobalOpenTelemetry.getPropagators().getTextMapPropagator()
+                                    .extract(Context.current(), msg.properties().getHeaders(),
+                                            HeadersMapExtractAdapter.GETTER));
+                });
+    }
+
+    public void close() {
+        client.stopAndAwait();
+    }
+
+    void produceTenIntegers(String exchange, String queue, String routingKey, Supplier<Integer> messageSupplier) {
+        this.produce(exchange, queue, routingKey, 10, messageSupplier::get);
+    }
+
+    public void consumeStrings(String exchange, String routingKey, Consumer<String> consumerFunction) {
+
+        this.consume(exchange, routingKey, value -> consumerFunction.accept(value.body().toString()));
+    }
+
+    /**
+     * Returns the RabbitMQ JSON representation of the named exchange.
+     *
+     * @param exchangeName the name of the exchange
+     * @return a {@link JsonObject} describing the exchange
+     * @throws IOException if an error occurs
+     */
+    public JsonObject getExchange(final String exchangeName) throws IOException {
+        return getObjectByTypeAndName("exchanges", exchangeName);
+    }
+
+    /**
+     * Returns the RabbitMQ JSON representation of the named queue.
+     *
+     * @param queueName the name of the queue
+     * @return a {@link JsonObject} describing the queue
+     * @throws IOException if an error occurs
+     */
+    public JsonObject getQueue(final String queueName) throws IOException {
+        return getObjectByTypeAndName("queues", queueName);
+    }
+
+    /**
+     * Returns the RabbitMQ JSON representation of the bindings between the
+     * named exchange and queue..
+     * 
+     * @param exchangeName the name of the exchange
+     * @param queueName the name of the queue
+     * @return a {@link JsonArray} of binding descriptions
+     * @throws IOException if an error occurs
+     */
+    public JsonArray getBindings(final String exchangeName, final String queueName) throws IOException {
+        final URL url = new URL(String.format("http://%s:%d/api/bindings/%%2F/e/%s/q/%s",
+                options.getHost(), managementPort, exchangeName, queueName));
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestProperty("Authorization", "Basic " + getBasicAuth());
+        conn.connect();
+
+        if (conn.getResponseCode() == 200) {
+            final String jsonString = getResponseString(conn);
+            return new JsonArray(jsonString);
+        } else {
+            return null;
+        }
+    }
+
+    private JsonObject getObjectByTypeAndName(final String objectType, final String objectName) throws IOException {
+        final URL url = new URL(String.format("http://%s:%d/api/%s/%%2F/%s", options.getHost(), managementPort,
+                objectType, objectName));
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestProperty("Authorization", "Basic " + getBasicAuth());
+        conn.connect();
+        if (conn.getResponseCode() == 200) {
+            final String jsonString = getResponseString(conn);
+            return new JsonObject(jsonString);
+        } else {
+            return null;
+        }
+    }
+
+    private String getBasicAuth() {
+        final String loginPassword = this.options.getUser() + ":" + this.options.getPassword();
+        return Base64.getEncoder().encodeToString(loginPassword.getBytes());
+    }
+
+    private static String getResponseString(final HttpURLConnection conn) throws IOException {
+        final BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
+        final StringBuilder sb = new StringBuilder();
+        String output;
+        while ((output = br.readLine()) != null) {
+            sb.append(output);
+        }
+
+        return sb.toString();
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/resources/rabbitmq/enabled_plugins
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/resources/rabbitmq/enabled_plugins
@@ -1,0 +1,2 @@
+[rabbitmq_management,rabbitmq_management_agent,rabbitmq_web_dispatch].
+


### PR DESCRIPTION
This commit encompasses a new smallrye reactive connector that supports access to RabbitMQ via the AMQP 0-9-1 protocol.

The connector includes support for:

- Sending and receiving messages from a RabbitMQ broker
- Optional declaration Exchanges, Queues, Bindings as well as DLQ/DLX via configuration
- Health reporting on both incoming and outgoing channels