### PR TITLE
Added Startup health check

### DIFF
--- a/api/src/main/java/io/smallrye/reactive/messaging/health/HealthReporter.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/health/HealthReporter.java
@@ -13,4 +13,8 @@ public interface HealthReporter {
         return HealthReport.OK_INSTANCE;
     }
 
+    default HealthReport getStartup() {
+        return HealthReport.OK_INSTANCE;
+    }
+
 }

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -21,11 +21,19 @@ Type: _boolean_ | false | `true`
 
 Type: _boolean_ | false | `true`
 
-| *health-readiness-topic-verification* | Whether the readiness check should verify that topics exist on the broker. Default to false. Enabling it requires an admin connection.
+| *health-readiness-topic-verification* | _deprecated_ - Whether the readiness check should verify that topics exist on the broker. Default to false. Enabling it requires an admin connection. Deprecated: Use 'health-topic-verification-enabled' instead.
+
+Type: _boolean_ | false | 
+
+| *health-readiness-timeout* | _deprecated_ - During the readiness health check, the connector connects to the broker and retrieves the list of topics. This attribute specifies the maximum duration (in ms) for the retrieval. If exceeded, the channel is considered not-ready. Deprecated: Use 'health-topic-verification-timeout' instead.
+
+Type: _long_ | false | 
+
+| *health-topic-verification-enabled* | Whether the startup and readiness check should verify that topics exist on the broker. Default to false. Enabling it requires an admin client connection.
 
 Type: _boolean_ | false | `false`
 
-| *health-readiness-timeout* | During the readiness health check, the connector connects to the broker and retrieves the list of topics. This attribute specifies the maximum duration (in ms) for the retrieval. If exceeded, the channel is considered not-ready.
+| *health-topic-verification-timeout* | During the startup and readiness health check, the connector connects to the broker and retrieves the list of topics. This attribute specifies the maximum duration (in ms) for the retrieval. If exceeded, the channel is considered not-ready.
 
 Type: _long_ | false | `2000`
 

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-outgoing.adoc
@@ -73,13 +73,21 @@ Type: _boolean_ | false | `true`
 
 Type: _boolean_ | false | `true`
 
-| *health-readiness-timeout* | During the readiness health check, the connector connects to the broker and retrieves the list of topics. This attribute specifies the maximum duration (in ms) for the retrieval. If exceeded, the channel is considered not-ready.
+| *health-readiness-timeout* | _deprecated_ - During the readiness health check, the connector connects to the broker and retrieves the list of topics. This attribute specifies the maximum duration (in ms) for the retrieval. If exceeded, the channel is considered not-ready. Deprecated: Use 'health-topic-verification-timeout' instead.
 
-Type: _long_ | false | `2000`
+Type: _long_ | false | 
 
-| *health-readiness-topic-verification* | Whether the readiness check should verify that topics exist on the broker. Default to false. Enabling it requires an admin connection.
+| *health-readiness-topic-verification* | _deprecated_ - Whether the readiness check should verify that topics exist on the broker. Default to false. Enabling it requires an admin connection. Deprecated: Use 'health-topic-verification-enabled' instead.
+
+Type: _boolean_ | false | 
+
+| *health-topic-verification-enabled* | Whether the startup and readiness check should verify that topics exist on the broker. Default to false. Enabling it requires an admin client connection.
 
 Type: _boolean_ | false | `false`
+
+| *health-topic-verification-timeout* | During the startup and readiness health check, the connector connects to the broker and retrieves the list of topics. This attribute specifies the maximum duration (in ms) for the retrieval. If exceeded, the channel is considered not-ready.
+
+Type: _long_ | false | `2000`
 
 | *key* | A key to used when writing the record
 

--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingStartupCheck.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingStartupCheck.java
@@ -1,0 +1,24 @@
+package io.smallrye.reactive.messaging.health;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Startup;
+
+import io.smallrye.reactive.messaging.extension.HealthCenter;
+
+@ApplicationScoped
+@Startup
+public class SmallRyeReactiveMessagingStartupCheck implements HealthCheck {
+
+    @Inject
+    HealthCenter health;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthReport report = health.getStartup();
+        return HealthChecks.getHealthCheck(report, "startup check");
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -286,6 +286,24 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     }
 
     @Override
+    public HealthReport getStartup() {
+        HealthReport.HealthReportBuilder builder = HealthReport.builder();
+        if (sources.isEmpty() && sinks.isEmpty()) {
+            return builder.add("kafka-connector", false).build();
+        }
+
+        for (KafkaSource<?, ?> source : sources) {
+            source.isStarted(builder);
+        }
+
+        for (KafkaSink sink : sinks) {
+            sink.isStarted(builder);
+        }
+
+        return builder.build();
+    }
+
+    @Override
     public HealthReport getReadiness() {
         HealthReport.HealthReportBuilder builder = HealthReport.builder();
         if (sources.isEmpty() && sinks.isEmpty()) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/BaseHealth.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/BaseHealth.java
@@ -31,12 +31,21 @@ public abstract class BaseHealth {
         }
     }
 
+    public void isStarted(HealthReport.HealthReportBuilder builder) {
+        KafkaAdmin admin = getAdmin();
+        if (admin != null) {
+            clientBasedStartupCheck(builder);
+        } else {
+            metricsBasedStartupCheck(builder);
+        }
+    }
+
     public void isReady(HealthReport.HealthReportBuilder builder) {
         KafkaAdmin admin = getAdmin();
         if (admin != null) {
-            adminBasedHealthCheck(builder);
+            clientBasedReadinessCheck(builder);
         } else {
-            metricsBasedHealthCheck(builder);
+            metricsBasedReadinessCheck(builder);
         }
     }
 
@@ -51,9 +60,13 @@ public abstract class BaseHealth {
         return metric;
     }
 
-    protected abstract void metricsBasedHealthCheck(HealthReport.HealthReportBuilder builder);
+    protected abstract void metricsBasedStartupCheck(HealthReport.HealthReportBuilder builder);
 
-    protected abstract void adminBasedHealthCheck(HealthReport.HealthReportBuilder builder);
+    protected abstract void metricsBasedReadinessCheck(HealthReport.HealthReportBuilder builder);
+
+    protected abstract void clientBasedStartupCheck(HealthReport.HealthReportBuilder builder);
+
+    protected abstract void clientBasedReadinessCheck(HealthReport.HealthReportBuilder builder);
 
     public abstract KafkaAdmin getAdmin();
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSinkHealth.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSinkHealth.java
@@ -14,14 +14,14 @@ import io.smallrye.reactive.messaging.kafka.KafkaAdmin;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorOutgoingConfiguration;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaAdminHelper;
 
-public class KafkaSinkReadinessHealth extends BaseHealth {
+public class KafkaSinkHealth extends BaseHealth {
 
     private final KafkaConnectorOutgoingConfiguration config;
     private final KafkaAdmin admin;
     private final Metric metric;
     private final String topic;
 
-    public KafkaSinkReadinessHealth(KafkaConnectorOutgoingConfiguration config,
+    public KafkaSinkHealth(KafkaConnectorOutgoingConfiguration config,
             Map<String, ?> kafkaConfiguration, Producer<?, ?> producer) {
         super(config.getChannel());
         this.topic = config.getTopic().orElse(config.getChannel());
@@ -44,7 +44,8 @@ public class KafkaSinkReadinessHealth extends BaseHealth {
         return admin;
     }
 
-    protected void metricsBasedHealthCheck(HealthReport.HealthReportBuilder builder) {
+    @Override
+    protected void metricsBasedStartupCheck(HealthReport.HealthReportBuilder builder) {
         if (metric != null) {
             builder.add(channel, (double) metric.metricValue() >= 1.0);
         } else {
@@ -52,18 +53,34 @@ public class KafkaSinkReadinessHealth extends BaseHealth {
         }
     }
 
-    protected void adminBasedHealthCheck(HealthReport.HealthReportBuilder builder) {
+    protected void metricsBasedReadinessCheck(HealthReport.HealthReportBuilder builder) {
+        metricsBasedStartupCheck(builder);
+    }
+
+    @Override
+    protected void clientBasedStartupCheck(HealthReport.HealthReportBuilder builder) {
+        try {
+            admin.listTopics()
+                    .await().atMost(Duration.ofMillis(config.getHealthReadinessTimeout()));
+            builder.add(channel, true);
+        } catch (Exception failed) {
+            builder.add(channel, false, "Failed to get response from broker for channel "
+                    + channel + " : " + failed);
+        }
+    }
+
+    protected void clientBasedReadinessCheck(HealthReport.HealthReportBuilder builder) {
         Set<String> topics;
         try {
             topics = admin.listTopics()
                     .await().atMost(Duration.ofMillis(config.getHealthReadinessTimeout()));
             if (topics.contains(topic)) {
-                builder.add(config.getChannel(), true);
+                builder.add(channel, true);
             } else {
-                builder.add(config.getChannel(), false, "Unable to find topic " + topic);
+                builder.add(channel, false, "Unable to find topic " + topic);
             }
         } catch (Exception failed) {
-            builder.add(config.getChannel(), false, "No response from broker for topic "
+            builder.add(channel, false, "No response from broker for topic "
                     + topic + " : " + failed);
         }
     }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSourceHealth.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSourceHealth.java
@@ -4,51 +4,49 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
 
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.kafka.KafkaAdmin;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaAdminHelper;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
+import io.smallrye.reactive.messaging.kafka.impl.ReactiveKafkaConsumer;
 
-public class KafkaSourceReadinessHealth extends BaseHealth {
+public class KafkaSourceHealth extends BaseHealth {
 
     private final KafkaAdmin admin;
     private final KafkaConnectorIncomingConfiguration config;
-    private final Pattern pattern;
     private final String channel;
-    private final Set<String> topics;
     private final Metric metric;
     private final KafkaSource<?, ?> source;
+    private final ReactiveKafkaConsumer<?, ?> client;
 
-    public KafkaSourceReadinessHealth(KafkaSource<?, ?> source, KafkaConnectorIncomingConfiguration config,
-            Map<String, ?> kafkaConfiguration, Consumer<?, ?> consumer, Set<String> topics, Pattern pattern) {
+    public KafkaSourceHealth(KafkaSource<?, ?> source, KafkaConnectorIncomingConfiguration config,
+            ReactiveKafkaConsumer<?, ?> client) {
         super(config.getChannel());
         this.config = config;
         this.channel = config.getChannel();
-        this.topics = topics;
-        this.pattern = pattern;
         this.source = source;
+        this.client = client;
         if (config.getHealthReadinessTopicVerification()) {
             // Do not create the client if the readiness health checks are disabled
-            Map<String, Object> adminConfiguration = new HashMap<>(kafkaConfiguration);
+            Map<String, Object> adminConfiguration = new HashMap<>(client.configuration());
             this.admin = KafkaAdminHelper.createAdminClient(adminConfiguration, config.getChannel(), true);
             this.metric = null;
 
         } else {
             this.admin = null;
-            Map<MetricName, ? extends Metric> metrics = consumer.metrics();
+            Map<MetricName, ? extends Metric> metrics = client.unwrap().metrics();
             this.metric = getMetric(metrics);
         }
     }
 
-    protected void metricsBasedHealthCheck(HealthReport.HealthReportBuilder builder) {
+    @Override
+    protected void metricsBasedStartupCheck(HealthReport.HealthReportBuilder builder) {
         if (metric != null) {
             boolean connected = (double) metric.metricValue() >= 1.0;
             boolean hasSubscribers = source.hasSubscribers();
@@ -64,31 +62,40 @@ public class KafkaSourceReadinessHealth extends BaseHealth {
         }
     }
 
-    protected void adminBasedHealthCheck(HealthReport.HealthReportBuilder builder) {
-        Set<String> existingTopics;
+    @Override
+    protected void metricsBasedReadinessCheck(HealthReport.HealthReportBuilder builder) {
+        metricsBasedStartupCheck(builder);
+    }
+
+    @Override
+    protected void clientBasedStartupCheck(HealthReport.HealthReportBuilder builder) {
         try {
-            existingTopics = admin.listTopics()
+            admin.listTopics()
                     .await().atMost(Duration.ofMillis(config.getHealthReadinessTimeout()));
-            if (pattern == null && existingTopics.containsAll(topics)) {
-                builder.add(channel, true);
-            } else if (pattern != null) {
-                // Check that at least one topic matches
-                boolean ok = existingTopics.stream()
-                        .anyMatch(s -> pattern.matcher(s).matches());
-                if (ok) {
-                    builder.add(channel, ok);
-                } else {
-                    builder.add(channel, false,
-                            "Unable to find a topic matching the given pattern: " + pattern);
-                }
-            } else {
-                String missing = topics.stream().filter(s -> !existingTopics.contains(s))
-                        .collect(Collectors.joining());
-                builder.add(channel, false, "Unable to find topic(s): " + missing);
-            }
+            builder.add(channel, true);
         } catch (Exception failed) {
-            builder.add(channel, false, "No response from broker for channel "
+            builder.add(channel, false, "Failed to get response from broker for channel "
                     + channel + " : " + failed);
+        }
+    }
+
+    protected void clientBasedReadinessCheck(HealthReport.HealthReportBuilder builder) {
+        if (source.hasSubscribers()) {
+            Set<TopicPartition> partitions;
+            try {
+                partitions = client.getAssignments()
+                        .await().atMost(Duration.ofMillis(config.getHealthReadinessTimeout()));
+                if (partitions.isEmpty()) {
+                    builder.add(channel, false, "No partition assignments for channel " + channel);
+                } else {
+                    builder.add(channel, true);
+                }
+            } catch (Exception failed) {
+                builder.add(channel, false, "No response from broker for channel "
+                        + channel + " : " + failed);
+            }
+        } else {
+            builder.add(channel, true, "no subscription yet, so no partition assignments");
         }
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -217,4 +217,8 @@ public interface KafkaLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.ERROR)
     @Message(id = 18249, value = "Unable to recover from the deserialization failure (topic: %s), configure a DeserializationFailureHandler to recover from errors.")
     void unableToDeserializeMessage(String topic, @Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 18250, value = "The configuration property '%s' is deprecated and is replaced by '%s'.")
+    void deprecatedConfig(String deprecated, String replace);
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
@@ -14,7 +14,10 @@ public class ConfigurationCleaner {
 
             "health-enabled",
             "health-readiness-enabled",
+            "health-readiness-topic-verification",
             "health-readiness-timeout",
+            "health-topic-verification-enabled",
+            "health-topic-verification-timeout",
 
             "tracing-enabled",
             "cloud-events");
@@ -56,6 +59,7 @@ public class ConfigurationCleaner {
             "consumer-rebalance-listener.name",
             "key-deserialization-failure-handler",
             "value-deserialization-failure-handler",
+            "graceful-shutdown",
 
             // Remove most common attributes, may have been configured from the default config
             "key.serializer",

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
@@ -45,7 +45,7 @@ import io.smallrye.reactive.messaging.kafka.KafkaConnectorOutgoingConfiguration;
 import io.smallrye.reactive.messaging.kafka.KafkaProducer;
 import io.smallrye.reactive.messaging.kafka.Record;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
-import io.smallrye.reactive.messaging.kafka.health.KafkaSinkReadinessHealth;
+import io.smallrye.reactive.messaging.kafka.health.KafkaSinkHealth;
 import io.smallrye.reactive.messaging.kafka.impl.ce.KafkaCloudEventHelper;
 import io.smallrye.reactive.messaging.kafka.tracing.HeaderInjectAdapter;
 
@@ -67,7 +67,7 @@ public class KafkaSink {
     private final boolean writeCloudEvents;
     private final boolean mandatoryCloudEventAttributeSet;
     private final boolean isTracingEnabled;
-    private final KafkaSinkReadinessHealth health;
+    private final KafkaSinkHealth health;
     private final boolean isHealthEnabled;
 
     public KafkaSink(KafkaConnectorOutgoingConfiguration config, KafkaCDIEvents kafkaCDIEvents) {
@@ -104,8 +104,8 @@ public class KafkaSink {
         }
 
         this.isHealthEnabled = configuration.getHealthEnabled();
-        if (isHealthEnabled && this.configuration.getHealthReadinessEnabled()) {
-            this.health = new KafkaSinkReadinessHealth(config, client.configuration(), client.unwrap());
+        if (isHealthEnabled) {
+            this.health = new KafkaSinkHealth(config, client.configuration(), client.unwrap());
         } else {
             this.health = null;
         }
@@ -330,8 +330,16 @@ public class KafkaSink {
 
     public void isReady(HealthReport.HealthReportBuilder builder) {
         // This method must not be called from the event loop.
-        if (health != null) {
+        if (health != null && this.configuration.getHealthReadinessEnabled()) {
             health.isReady(builder);
+        }
+        // If health is disable do not add anything to the builder.
+    }
+
+    public void isStarted(HealthReport.HealthReportBuilder builder) {
+        // This method must not be called from the event loop.
+        if (health != null) {
+            health.isStarted(builder);
         }
         // If health is disable do not add anything to the builder.
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
@@ -119,10 +119,15 @@ public class WeldTestBase {
         return container.getBeanManager().createInstance().select(HealthCenter.class).get();
     }
 
+    public boolean isStarted() {
+        return getHealth().getStartup().isOk();
+    }
+
     public boolean isReady() {
         System.out
-                .println(getHealth().getReadiness().getChannels().stream().map(ci -> ci.getChannel() + " " + ci.isOk()).collect(
-                        Collectors.joining()));
+                .println(getHealth().getReadiness().getChannels().stream()
+                        .map(ci -> ci.getChannel() + " " + ci.isOk() + " " + ci.getMessage())
+                        .collect(Collectors.joining()));
         return getHealth().getReadiness().isOk();
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/health/HealthCheckTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/health/HealthCheckTest.java
@@ -62,7 +62,7 @@ public class HealthCheckTest extends KafkaTestBase {
     void testHealthOfApplicationWithOutgoingTopicUsingTopicVerification() {
         createTopic("output", 1);
         KafkaMapBasedConfig config = getKafkaSinkConfigForProducingBean()
-                .put("health-readiness-topic-verification", true)
+                .put("health-topic-verification-enabled", true)
                 .build();
         config.put("my.topic", topic);
         runApplication(config, ProducingBean.class);

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/HealthCenter.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/HealthCenter.java
@@ -37,6 +37,13 @@ public class HealthCenter {
         return builder.build();
     }
 
+    public HealthReport getStartup() {
+        HealthReport.HealthReportBuilder builder = HealthReport.builder();
+        reporters.forEach(r -> r.getStartup().getChannels().forEach(builder::add));
+        failures.forEach(rf -> builder.add(rf.source, false, rf.failure.getMessage()));
+        return builder.build();
+    }
+
     public void report(String source, Throwable cause) {
         failures.add(new ReportedFailure(source, cause));
     }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/HealthCenter.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/HealthCenter.java
@@ -40,7 +40,7 @@ public class HealthCenter {
     public HealthReport getStartup() {
         HealthReport.HealthReportBuilder builder = HealthReport.builder();
         reporters.forEach(r -> r.getStartup().getChannels().forEach(builder::add));
-        failures.forEach(rf -> builder.add(rf.source, false, rf.failure.getMessage()));
+        // failures do not contribute to the startup probe when app is running
         return builder.build();
     }
 


### PR DESCRIPTION
The incoming channel is ready after partition assignments. Fixes #1300

Here is a recap of proposed health checks

### Incoming channel (Kafka Consumer)
**Startup** 
Broker is accessible
- with Admin client: topic list returns with or without results
- with Metric: connection-count > 0 (Is this still relevant with startup ?)

**Readiness**
Assigned topic partitions for the channel is not empty
- with Consumer client: assigned partitions is not empty 
 NOTE: If the `partitions` config passed to the application is greater than the number of topic partitions on the broker, a consumer will end up with no partition assignments, and this will fail the readiness check of the application. 
- with Metric: connection-count > 0

**Liveness**
Check: No failures reported for channel

### Outgoing channel (Kafka Producer)
**Startup**
Broker is accessible
- with Admin client: topic list returns with or without results
- with Metric: connection-count > 0

**Readiness**
- with Admin client: topic exists
- with Metric: connection-count > 0 (Is this still relevant with startup ?)

**Liveness**
Check: No failures reported for channel