### PR TITLE
Update to Vert.x Mutiny Binding 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <opentelemetry.version>1.4.1</opentelemetry.version>
     <opentelemetry-semver.version>1.4.1-alpha</opentelemetry-semver.version>
 
-    <smallrye-vertx-mutiny-clients.version>2.10.0</smallrye-vertx-mutiny-clients.version>
+    <smallrye-vertx-mutiny-clients.version>2.11.0</smallrye-vertx-mutiny-clients.version>
     <smallrye-reactive-converters.version>2.6.0</smallrye-reactive-converters.version>
 
     <testcontainers.version>1.15.3</testcontainers.version>


### PR DESCRIPTION
The 2.10.0 version has broken dependency declarations leaking junit and friends to the classpath. 