### PR TITLE
Kafka connector option for consuming messages in batch

### DIFF
--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -149,11 +149,11 @@ Type: _int_ | false | `1000`
 
 Type: _boolean_ | false | `true`
 
-| *batch* | Whether the Kafka records are consumed in batch
+| [.no-hyphens]#*batch*# | Whether the Kafka records are consumed in batch. The channel injection point must consume a compatible type, such as `List<Payload>` or `KafkaRecordBatch<Payload>`.
 
 Type: _boolean_ | false | `false`
 
-| *max-queue-size-factor* | Multiplier factor to determine maximum number of records queued for processing, using `max.poll.records` * `max-queue-size-factor`. Defaults to 2. In `batch` mode `max.poll.records` is considered `1`.
+| [.no-hyphens]#*max-queue-size-factor*# | Multiplier factor to determine maximum number of records queued for processing, using `max.poll.records` * `max-queue-size-factor`. Defaults to 2. In `batch` mode `max.poll.records` is considered `1`.
 
 Type: _int_ | false | `2`
 

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -149,4 +149,12 @@ Type: _int_ | false | `1000`
 
 Type: _boolean_ | false | `true`
 
+| *batch* | Whether the Kafka records are consumed in batch
+
+Type: _boolean_ | false | `false`
+
+| *max-queue-size-factor* | Multiplier factor to determine maximum number of records queued for processing, using `max.poll.records` * `max-queue-size-factor`. Defaults to 2. In `batch` mode `max.poll.records` is considered `1`.
+
+Type: _int_ | false | `2`
+
 |===

--- a/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRecordBatchExample.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRecordBatchExample.java
@@ -1,5 +1,6 @@
 package inbound;
 
+import java.time.Instant;
 import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -11,6 +12,7 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 
 import io.smallrye.reactive.messaging.kafka.KafkaRecordBatch;
 import io.smallrye.reactive.messaging.kafka.KafkaRecord;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordBatchMetadata;
 import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
 
 @ApplicationScoped
@@ -24,10 +26,11 @@ public class KafkaRecordBatchExample {
             record.getMetadata(IncomingKafkaRecordMetadata.class).ifPresent(metadata -> {
                 int partition = metadata.getPartition();
                 long offset = metadata.getOffset();
-                ConsumerRecord<String, Double> consumerRecord = metadata.getRecord();
+                Instant timestamp = metadata.getTimestamp();
                 //... process messages
             });
         }
+        // ack will commit the latest offsets (per partition) of the batch.
         return records.ack();
     }
 

--- a/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRecordBatchExample.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRecordBatchExample.java
@@ -1,0 +1,44 @@
+package inbound;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.smallrye.reactive.messaging.kafka.KafkaRecordBatch;
+import io.smallrye.reactive.messaging.kafka.KafkaRecord;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
+
+@ApplicationScoped
+public class KafkaRecordBatchExample {
+
+    @SuppressWarnings("unchecked")
+    // tag::code[]
+    @Incoming("prices")
+    public CompletionStage<Void> consumeMessage(KafkaRecordBatch<String, Double> records) {
+        for (KafkaRecord<String, Double> record : records) {
+            record.getMetadata(IncomingKafkaRecordMetadata.class).ifPresent(metadata -> {
+                int partition = metadata.getPartition();
+                long offset = metadata.getOffset();
+                ConsumerRecord<String, Double> consumerRecord = metadata.getRecord();
+                //... process messages
+            });
+        }
+        return records.ack();
+    }
+
+    @Incoming("prices")
+    public void consumeRecords(ConsumerRecords<String, Double> records) {
+        for (TopicPartition partition : records.partitions()) {
+            for (ConsumerRecord<String, Double> record : records.records(partition)) {
+                //... process messages
+            }
+        }
+    }
+    // end::code[]
+
+}

--- a/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRecordBatchPayloadExample.java
+++ b/documentation/src/main/doc/modules/kafka/examples/inbound/KafkaRecordBatchPayloadExample.java
@@ -1,0 +1,21 @@
+package inbound;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class KafkaRecordBatchPayloadExample {
+
+    // tag::code[]
+    @Incoming("prices")
+    public void consume(List<Double> prices) {
+        for (double price : prices) {
+            // process price
+        }
+    }
+    // end::code[]
+
+}

--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -280,7 +280,7 @@ include::consumer-rebalance-listener.adoc[]
 By default, incoming methods receive each Kafka record individually.
 Under the hood, Kafka consumer clients poll the broker constantly and receive records in batches, presented inside the `ConsumerRecords` container.
 
-In *batch* mode, your application can receive all the records returned by the consumer *poll*.
+In *batch* mode, your application can receive all the records returned by the consumer *poll* in one go.
 
 To achieve this you need to set `mp.messaging.incoming.$channel.batch=true` *and* specify a compatible container type to receive all the data:
 
@@ -289,16 +289,16 @@ To achieve this you need to set `mp.messaging.incoming.$channel.batch=true` *and
 include::example$inbound/KafkaRecordBatchPayloadExample.java[tags=code]
 ----
 
-The incoming method can also receive `Message<List<Payload>`, `KafkaBatchRecords<Payload>` `ConsumerRecords<Key, Payload>` types. These types give access :
+The incoming method can also receive `Message<List<Payload>`, `KafkaBatchRecords<Payload>` `ConsumerRecords<Key, Payload>` types, They give access to record details such as offset or timestamp :
 
 [source, java, indent=0]
 ----
 include::example$inbound/KafkaRecordBatchExample.java[tags=code]
 ----
 
-Note that the successful processing of the incoming batch record will commit the latest offsets for each partition received inside the batch. The configured commit strategy will be applied for these records only.
+Note that the successful processing of the incoming record batch will commit the latest offsets for each partition received inside the batch. The configured commit strategy will be applied for these records only.
 
-Conversely, if the processing error throws an exception, all messages are _nacked_, applying the failure strategy for all the records inside the batch.
+Conversely, if the processing throws an exception, all messages are _nacked_, applying the failure strategy for all the records inside the batch.
 
 === Configuration Reference
 

--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -275,6 +275,31 @@ The `partitionkey` attribute is mapped to the record's key if any.
 
 include::consumer-rebalance-listener.adoc[]
 
+=== Receiving Kafka Records in Batches
+
+By default, incoming methods receive each Kafka record individually.
+Under the hood, Kafka consumer clients poll the broker constantly and receive records in batches, presented inside the `ConsumerRecords` container.
+
+In *batch* mode, your application can receive all the records returned by the consumer *poll*.
+
+To achieve this you need to set `mp.messaging.incoming.$channel.batch=true` *and* specify a compatible container type to receive all the data:
+
+[source, java, indent=0]
+----
+include::example$inbound/KafkaRecordBatchPayloadExample.java[tags=code]
+----
+
+The incoming method can also receive `Message<List<Payload>`, `KafkaBatchRecords<Payload>` `ConsumerRecords<Key, Payload>` types. These types give access :
+
+[source, java, indent=0]
+----
+include::example$inbound/KafkaRecordBatchExample.java[tags=code]
+----
+
+Note that the successful processing of the incoming batch record will commit the latest offsets for each partition received inside the batch. The configured commit strategy will be applied for these records only.
+
+Conversely, if the processing error throws an exception, all messages are _nacked_, applying the failure strategy for all the records inside the batch.
+
 === Configuration Reference
 
 include::connectors:partial$META-INF/connector/smallrye-kafka-incoming.adoc[]

--- a/smallrye-reactive-messaging-kafka-api/src/main/java/io/smallrye/reactive/messaging/kafka/api/IncomingKafkaRecordBatchMetadata.java
+++ b/smallrye-reactive-messaging-kafka-api/src/main/java/io/smallrye/reactive/messaging/kafka/api/IncomingKafkaRecordBatchMetadata.java
@@ -1,0 +1,46 @@
+package io.smallrye.reactive.messaging.kafka.api;
+
+import java.util.Set;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * Contains information about the batch of messages received from a channel backed by Kafka.
+ * Encapsulates underlying Kafka {@link ConsumerRecords} received from the consumer client.
+ *
+ * As this is an incoming message metadata it is created by the framework and injected into incoming batch messages.
+ *
+ * @param <K> The record key type
+ * @param <T> The record payload type
+ */
+public class IncomingKafkaRecordBatchMetadata<K, T> {
+
+    private final ConsumerRecords<K, T> records;
+
+    public IncomingKafkaRecordBatchMetadata(ConsumerRecords<K, T> records) {
+        this.records = records;
+    }
+
+    /**
+     * @return the underlying Kafka {@link ConsumerRecords}
+     */
+    public ConsumerRecords<K, T> getRecords() {
+        return records;
+    }
+
+    /**
+     * @return the number of records for all topics
+     */
+    public int count() {
+        return records.count();
+    }
+
+    /**
+     * @return the set of topic partitions with data in this batch record
+     */
+    public Set<TopicPartition> partitions() {
+        return records.partitions();
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka-api/src/main/java/io/smallrye/reactive/messaging/kafka/api/IncomingKafkaRecordBatchMetadata.java
+++ b/smallrye-reactive-messaging-kafka-api/src/main/java/io/smallrye/reactive/messaging/kafka/api/IncomingKafkaRecordBatchMetadata.java
@@ -30,14 +30,14 @@ public class IncomingKafkaRecordBatchMetadata<K, T> {
     }
 
     /**
-     * @return the number of records for all topics
+     * @return the total number of records for all topic partitions
      */
     public int count() {
         return records.count();
     }
 
     /**
-     * @return the set of topic partitions with data in this batch record
+     * @return the set of topic partitions with data in this record batch
      */
     public Set<TopicPartition> partitions() {
         return records.partitions();

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecordBatch.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecordBatch.java
@@ -32,16 +32,11 @@ public class IncomingKafkaRecordBatch<K, T> implements KafkaRecordBatch<K, T> {
         List<IncomingKafkaRecord<K, T>> incomingRecords = new ArrayList<>();
         Map<TopicPartition, IncomingKafkaRecord<K, T>> latestOffsetRecords = new HashMap<>();
         for (TopicPartition partition : records.partitions()) {
-            IncomingKafkaRecord<K, T> latestOffsetRecord = null;
             for (ConsumerRecord<K, T> record : records.records(partition)) {
                 IncomingKafkaRecord<K, T> rec = new IncomingKafkaRecord<>(record, commitHandler, onNack,
                         cloudEventEnabled, tracingEnabled);
                 incomingRecords.add(rec);
                 latestOffsetRecords.put(partition, rec);
-                latestOffsetRecord = rec;
-            }
-            if (latestOffsetRecord != null) {
-                commitHandler.received(latestOffsetRecord);
             }
         }
         this.incomingRecords = Collections.unmodifiableList(incomingRecords);

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecordBatch.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecordBatch.java
@@ -1,0 +1,104 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordBatchMetadata;
+import io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler;
+import io.smallrye.reactive.messaging.kafka.fault.KafkaFailureHandler;
+
+public class IncomingKafkaRecordBatch<K, T> implements KafkaRecordBatch<K, T> {
+
+    private final Metadata metadata;
+    private final List<KafkaRecord<K, T>> incomingRecords;
+    private final Map<TopicPartition, KafkaRecord<K, T>> latestOffsetRecords;
+
+    public IncomingKafkaRecordBatch(ConsumerRecords<K, T> records, KafkaCommitHandler commitHandler,
+            KafkaFailureHandler onNack, boolean cloudEventEnabled, boolean tracingEnabled) {
+        List<IncomingKafkaRecord<K, T>> incomingRecords = new ArrayList<>();
+        Map<TopicPartition, IncomingKafkaRecord<K, T>> latestOffsetRecords = new HashMap<>();
+        for (TopicPartition partition : records.partitions()) {
+            IncomingKafkaRecord<K, T> latestOffsetRecord = null;
+            for (ConsumerRecord<K, T> record : records.records(partition)) {
+                IncomingKafkaRecord<K, T> rec = new IncomingKafkaRecord<>(record, commitHandler, onNack,
+                        cloudEventEnabled, tracingEnabled);
+                incomingRecords.add(rec);
+                latestOffsetRecords.put(partition, rec);
+                latestOffsetRecord = rec;
+            }
+            if (latestOffsetRecord != null) {
+                commitHandler.received(latestOffsetRecord);
+            }
+        }
+        this.incomingRecords = Collections.unmodifiableList(incomingRecords);
+        this.latestOffsetRecords = Collections.unmodifiableMap(latestOffsetRecords);
+        this.metadata = Metadata.of(new IncomingKafkaRecordBatchMetadata<>(records));
+    }
+
+    @Override
+    public List<T> getPayload() {
+        return this.incomingRecords.stream().map(KafkaRecord::getPayload).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<KafkaRecord<K, T>> getRecords() {
+        return this.incomingRecords;
+    }
+
+    @Override
+    public Iterator<KafkaRecord<K, T>> iterator() {
+        return this.getRecords().iterator();
+    }
+
+    @Override
+    public Map<TopicPartition, KafkaRecord<K, T>> getLatestOffsetRecords() {
+        return this.latestOffsetRecords;
+    }
+
+    @Override
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public Supplier<CompletionStage<Void>> getAck() {
+        return this::ack;
+    }
+
+    @Override
+    public Function<Throwable, CompletionStage<Void>> getNack() {
+        return this::nack;
+    }
+
+    @Override
+    public CompletionStage<Void> ack() {
+        return Multi.createBy().concatenating().collectFailures()
+                .streams(this.latestOffsetRecords.values().stream()
+                        .map(record -> Multi.createFrom().completionStage(record::ack))
+                        .collect(Collectors.toList()))
+                .toUni().subscribeAsCompletionStage();
+    }
+
+    @Override
+    public CompletionStage<Void> nack(Throwable reason, Metadata metadata) {
+        return Multi.createBy().concatenating().collectFailures()
+                .streams(this.incomingRecords.stream()
+                        .map(record -> Multi.createFrom().completionStage(() -> record.nack(reason, metadata)))
+                        .collect(Collectors.toList()))
+                .toUni().subscribeAsCompletionStage();
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -93,7 +93,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "graceful-shutdown", type = "boolean", direction = Direction.INCOMING, description = "Whether or not a graceful shutdown should be attempted when the application terminates.", defaultValue = "true")
 @ConnectorAttribute(name = "poll-timeout", type = "int", direction = Direction.INCOMING, description = "The polling timeout in milliseconds. When polling records, the poll will wait at most that duration before returning records. Default is 1000ms", defaultValue = "1000")
 @ConnectorAttribute(name = "pause-if-no-requests", type = "boolean", direction = Direction.INCOMING, description = "Whether the polling must be paused when the application does not request items and resume when it does. This allows implementing back-pressure based on the application capacity. Note that polling is not stopped, but will not retrieve any records when paused.", defaultValue = "true")
-@ConnectorAttribute(name = "batch", type = "boolean", direction = Direction.INCOMING, description = "Whether the Kafka records are consumed in batch", defaultValue = "false")
+@ConnectorAttribute(name = "batch", type = "boolean", direction = Direction.INCOMING, description = "Whether the Kafka records are consumed in batch. The channel injection point must consume a compatible type, such as `List<Payload>` or `KafkaRecordBatch<Payload>`.", defaultValue = "false")
 @ConnectorAttribute(name = "max-queue-size-factor", type = "int", direction = Direction.INCOMING, description = "Multiplier factor to determine maximum number of records queued for processing, using `max.poll.records` * `max-queue-size-factor`. Defaults to 2. In `batch` mode `max.poll.records` is considered `1`.", defaultValue = "2")
 
 @ConnectorAttribute(name = "key.serializer", type = "string", direction = Direction.OUTGOING, description = "The serializer classname used to serialize the record's key", defaultValue = "org.apache.kafka.common.serialization.StringSerializer")
@@ -226,7 +226,8 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
             }
         }
 
-        // TODO
+        // TODO MultiMerge#streams should also accept list, change this after the signature is added
+        @SuppressWarnings("unchecked")
         Multi<? extends Message<?>> multi = Multi.createBy().merging().streams(streams.toArray(new Publisher[0]));
         boolean broadcast = ic.getBroadcast();
         if (broadcast) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatch.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatch.java
@@ -1,0 +1,28 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * Represents a batch of Kafka records received by polling the {@link org.apache.kafka.clients.consumer.KafkaConsumer}
+ *
+ * This type extends the {@code Message<List<T>>} where {@code T} is the type of records' payloads.
+ * The complete list of Kafka record payloads are accessible via the {@link Message#getPayload()} method.
+ *
+ * @param <K> The record key type
+ * @param <T> The record payload type
+ */
+public interface KafkaRecordBatch<K, T> extends Message<List<T>>, Iterable<KafkaRecord<K, T>> {
+    /**
+     * @return list of records contained in this batch message
+     */
+    List<KafkaRecord<K, T>> getRecords();
+
+    /**
+     * @return map of records with latest offset by topic partition
+     */
+    Map<TopicPartition, KafkaRecord<K, T>> getLatestOffsetRecords();
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatch.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatch.java
@@ -17,7 +17,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
  */
 public interface KafkaRecordBatch<K, T> extends Message<List<T>>, Iterable<KafkaRecord<K, T>> {
     /**
-     * @return list of records contained in this batch message
+     * @return list of records contained in this message batch
      */
     List<KafkaRecord<K, T>> getRecords();
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/converters/ConsumerRecordsConverter.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/converters/ConsumerRecordsConverter.java
@@ -1,0 +1,31 @@
+package io.smallrye.reactive.messaging.kafka.converters;
+
+import java.lang.reflect.Type;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.reactive.messaging.MessageConverter;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordBatchMetadata;
+
+/**
+ * Convert an incoming Kafka batch message into a {@link ConsumerRecords}.
+ */
+@ApplicationScoped
+public class ConsumerRecordsConverter implements MessageConverter {
+    @Override
+    public boolean canConvert(Message<?> in, Type target) {
+        return in.getMetadata(IncomingKafkaRecordBatchMetadata.class).isPresent()
+                && target.equals(ConsumerRecords.class);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Message<?> convert(Message<?> in, Type target) {
+        IncomingKafkaRecordBatchMetadata metadata = in.getMetadata(IncomingKafkaRecordBatchMetadata.class)
+                .orElseThrow(() -> new IllegalStateException("No Kafka metadata"));
+        return in.withPayload(metadata.getRecords());
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
@@ -49,6 +49,7 @@ public class ConfigurationCleaner {
             "retry-attempts",
             "retry-max-wait",
             "broadcast",
+            "batch",
             "failure-strategy",
             "commit-strategy",
             "throttled.unprocessed-record-max-age.ms",

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
@@ -50,6 +50,7 @@ public class ConfigurationCleaner {
             "retry-max-wait",
             "broadcast",
             "batch",
+            "max-queue-size-factor",
             "failure-strategy",
             "commit-strategy",
             "throttled.unprocessed-record-max-age.ms",

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordBatchStream.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordBatchStream.java
@@ -1,0 +1,31 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import io.smallrye.mutiny.operators.AbstractMulti;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.vertx.core.Context;
+
+public class KafkaRecordBatchStream<K, V> extends AbstractMulti<ConsumerRecords<K, V>> {
+
+    private final ReactiveKafkaConsumer<K, V> client;
+    private final KafkaConnectorIncomingConfiguration config;
+    private final Context context;
+
+    public KafkaRecordBatchStream(ReactiveKafkaConsumer<K, V> client,
+            KafkaConnectorIncomingConfiguration config, Context context) {
+        this.config = config;
+        this.client = client;
+        this.context = context;
+    }
+
+    @Override
+    public void subscribe(MultiSubscriber<? super ConsumerRecords<K, V>> subscriber) {
+        // Enqueue ConsumerRecords by batches, max poll records is considered 1
+        KafkaRecordStreamSubscription<K, V, ConsumerRecords<K, V>> subscription = new KafkaRecordStreamSubscription<>(
+                client, config, subscriber, context, 1, (cr, q) -> q.offer(cr));
+        subscriber.onSubscribe(subscription);
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordStream.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordStream.java
@@ -1,28 +1,15 @@
 package io.smallrye.reactive.messaging.kafka.impl;
 
-import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
 
-import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.reactivestreams.Subscription;
 
-import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.helpers.Subscriptions;
 import io.smallrye.mutiny.operators.AbstractMulti;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.vertx.core.Context;
 
 public class KafkaRecordStream<K, V> extends AbstractMulti<ConsumerRecord<K, V>> {
-    private static final int STATE_NEW = 0; // no request yet -- we start polling on the first request
-    private static final int STATE_POLLING = 1;
-    private static final int STATE_PAUSED = 2;
-    private static final int STATE_CANCELLED = 3;
 
     private final ReactiveKafkaConsumer<K, V> client;
     private final KafkaConnectorIncomingConfiguration config;
@@ -38,209 +25,11 @@ public class KafkaRecordStream<K, V> extends AbstractMulti<ConsumerRecord<K, V>>
     @Override
     public void subscribe(
             MultiSubscriber<? super ConsumerRecord<K, V>> subscriber) {
-        KafkaRecordStreamSubscription subscription = new KafkaRecordStreamSubscription(client, config, subscriber);
+        // Kafka also defaults to 500, but doesn't have a constant for it
+        int maxPollRecords = config.config().getOptionalValue(MAX_POLL_RECORDS_CONFIG, Integer.class).orElse(500);
+        KafkaRecordStreamSubscription<K, V, ConsumerRecord<K, V>> subscription = new KafkaRecordStreamSubscription<>(
+                client, config, subscriber, context, maxPollRecords, (cr, q) -> q.addAll(cr));
         subscriber.onSubscribe(subscription);
     }
 
-    private class KafkaRecordStreamSubscription implements Subscription {
-        private final ReactiveKafkaConsumer<K, V> client;
-        private final MultiSubscriber<? super ConsumerRecord<K, V>> downstream;
-        private final boolean pauseResumeEnabled;
-
-        /**
-         * Current state: new (no request yet), polling, paused, cancelled
-         */
-        private final AtomicInteger state = new AtomicInteger(STATE_NEW);
-
-        private final AtomicInteger wip = new AtomicInteger();
-        /**
-         * Stores the current downstream demands.
-         */
-        private final AtomicLong requested = new AtomicLong();
-
-        /**
-         * The polling uni to avoid re-assembling a Uni everytime.
-         */
-        private final Uni<ConsumerRecords<K, V>> pollUni;
-
-        private final int maxQueueSize;
-        private final int halfMaxQueueSize;
-        private final RecordQueue<ConsumerRecord<K, V>> queue;
-        private final long retries;
-
-        public KafkaRecordStreamSubscription(
-                ReactiveKafkaConsumer<K, V> client,
-                KafkaConnectorIncomingConfiguration config,
-                MultiSubscriber<? super ConsumerRecord<K, V>> subscriber) {
-            this.client = client;
-            this.pauseResumeEnabled = config.getPauseIfNoRequests();
-            this.downstream = subscriber;
-            // Kafka also defaults to 500, but doesn't have a constant for it
-            int batchSize = config.config().getOptionalValue(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer.class).orElse(500);
-            this.maxQueueSize = batchSize * 2;
-            this.halfMaxQueueSize = batchSize;
-            // we can exceed maxQueueSize by at most 1 batchSize
-            this.queue = new RecordQueue<>(3 * batchSize);
-            this.retries = config.getRetryAttempts() == -1 ? Long.MAX_VALUE : config.getRetryAttempts();
-            this.pollUni = client.poll()
-                    .onItem().transform(cr -> {
-                        if (cr.isEmpty()) {
-                            return null;
-                        }
-                        if (log.isTraceEnabled()) {
-                            log.tracef("Adding %s messages to the queue", cr.count());
-                        }
-                        queue.addAll(cr);
-                        return cr;
-                    })
-                    .plug(m -> {
-                        if (config.getRetry()) {
-                            int maxWait = config.getRetryMaxWait();
-                            return m.onFailure().retry().withBackOff(Duration.ofSeconds(1), Duration.ofSeconds(maxWait))
-                                    .atMost(retries);
-                        }
-                        return m;
-                    });
-        }
-
-        @Override
-        public void request(long n) {
-            if (n > 0) {
-                boolean cancelled = state.get() == STATE_CANCELLED;
-                if (!cancelled) {
-                    Subscriptions.add(requested, n);
-                    if (state.compareAndSet(STATE_NEW, STATE_POLLING)) {
-                        poll();
-                    } else {
-                        dispatch();
-                    }
-                }
-            } else {
-                throw new IllegalArgumentException("Invalid request");
-            }
-
-        }
-
-        private void poll() {
-            int state = this.state.get();
-            if (state == STATE_CANCELLED || state == STATE_NEW || client.isClosed()) {
-                return;
-            }
-
-            if (pauseResumeEnabled) {
-                pauseResume();
-            }
-
-            pollUni.subscribe().with(cr -> {
-                if (cr == null) {
-                    client.executeWithDelay(this::poll, Duration.ofMillis(2))
-                            .subscribe().with(this::emptyConsumer, this::report);
-                } else {
-                    dispatch();
-                    client.runOnPollingThread(c -> {
-                        poll();
-                    }).subscribe().with(this::emptyConsumer, this::report);
-                }
-            }, this::report);
-        }
-
-        private void pauseResume() {
-            int size = queue.size();
-            if (size >= maxQueueSize && state.compareAndSet(STATE_POLLING, STATE_PAUSED)) {
-                log.pausingChannel(config.getChannel(), size, maxQueueSize);
-                client.pause()
-                        .subscribe().with(this::emptyConsumer, this::report);
-            } else if (size <= halfMaxQueueSize && state.compareAndSet(STATE_PAUSED, STATE_POLLING)) {
-                log.resumingChannel(config.getChannel(), size, halfMaxQueueSize);
-                client.resume()
-                        .subscribe().with(this::emptyConsumer, this::report);
-            }
-        }
-
-        private <T> void emptyConsumer(T ignored) {
-        }
-
-        private void report(Throwable fail) {
-            while (true) {
-                int state = this.state.get();
-                if (state == STATE_CANCELLED) {
-                    break;
-                }
-                if (this.state.compareAndSet(state, STATE_CANCELLED)) {
-                    downstream.onFailure(fail);
-                    break;
-                }
-            }
-        }
-
-        void dispatch() {
-            if (wip.getAndIncrement() != 0) {
-                return;
-            }
-            context.runOnContext(ignored -> run());
-        }
-
-        private void run() {
-            int missed = 1;
-            final RecordQueue<ConsumerRecord<K, V>> q = queue;
-            long emitted = 0;
-            long requests = requested.get();
-            for (;;) {
-                if (isCancelled()) {
-                    return;
-                }
-
-                while (emitted != requests) {
-                    ConsumerRecord<K, V> item = q.poll();
-
-                    if (item == null || isCancelled()) {
-                        break;
-                    }
-
-                    downstream.onItem(item);
-                    emitted++;
-                }
-
-                requests = requested.addAndGet(-emitted);
-                emitted = 0;
-
-                int w = wip.get();
-                if (missed == w) {
-                    missed = wip.addAndGet(-missed);
-                    if (missed == 0) {
-                        break;
-                    }
-                } else {
-                    missed = w;
-                }
-            }
-        }
-
-        @Override
-        public void cancel() {
-            while (true) {
-                int state = this.state.get();
-                if (state == STATE_CANCELLED) {
-                    break;
-                }
-                if (this.state.compareAndSet(state, STATE_CANCELLED)) {
-                    if (wip.getAndIncrement() == 0) {
-                        // nothing was currently dispatched, clearing the queue.
-                        client.close();
-                        queue.clear();
-                    }
-                    break;
-                }
-            }
-        }
-
-        boolean isCancelled() {
-            if (state.get() == STATE_CANCELLED) {
-                queue.clear();
-                client.close();
-                return true;
-            }
-            return false;
-        }
-    }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordStreamSubscription.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordStreamSubscription.java
@@ -1,0 +1,240 @@
+package io.smallrye.reactive.messaging.kafka.impl;
+
+import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.reactivestreams.Subscription;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.Subscriptions;
+import io.smallrye.mutiny.subscription.MultiSubscriber;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.vertx.core.Context;
+
+/**
+ * A {@link Subscription} which, on {@link #request(long)}, polls {@link ConsumerRecords} from the given consumer client
+ * and emits records downstream.
+ *
+ * It uses an internal queue to store records received but not yet emitted downstream.
+ * The given enqueue function can flatten the polled {@link ConsumerRecords} into individual records or enqueue it as-is.
+ *
+ * @param <K> type of incoming record key
+ * @param <V> type of incoming record payload
+ * @param <T> type of the items to emit downstream
+ */
+public class KafkaRecordStreamSubscription<K, V, T> implements Subscription {
+    private static final int STATE_NEW = 0; // no request yet -- we start polling on the first request
+    private static final int STATE_POLLING = 1;
+    private static final int STATE_PAUSED = 2;
+    private static final int STATE_CANCELLED = 3;
+
+    private final ReactiveKafkaConsumer<K, V> client;
+    private final MultiSubscriber<? super T> downstream;
+    private final Context context;
+    private final boolean pauseResumeEnabled;
+
+    /**
+     * Current state: new (no request yet), polling, paused, cancelled
+     */
+    private final AtomicInteger state = new AtomicInteger(STATE_NEW);
+
+    private final AtomicInteger wip = new AtomicInteger();
+    /**
+     * Stores the current downstream demands.
+     */
+    private final AtomicLong requested = new AtomicLong();
+
+    /**
+     * The polling uni to avoid re-assembling a Uni everytime.
+     */
+    private final Uni<ConsumerRecords<K, V>> pollUni;
+
+    private final String channel;
+    private final int maxQueueSize;
+    private final int halfMaxQueueSize;
+    private final RecordQueue<T> queue;
+    private final long retries;
+
+    public KafkaRecordStreamSubscription(
+            ReactiveKafkaConsumer<K, V> client,
+            KafkaConnectorIncomingConfiguration config,
+            MultiSubscriber<? super T> subscriber,
+            Context context,
+            int maxPollRecords,
+            BiConsumer<ConsumerRecords<K, V>, RecordQueue<T>> enqueueFunction) {
+        this.client = client;
+        this.channel = config.getChannel();
+        this.pauseResumeEnabled = config.getPauseIfNoRequests();
+        this.downstream = subscriber;
+        this.context = context;
+        this.maxQueueSize = maxPollRecords * config.getMaxQueueSizeFactor();
+        this.halfMaxQueueSize = maxPollRecords;
+        // we can exceed maxQueueSize by at most 1 maxPollRecords
+        this.queue = new RecordQueue<>(maxQueueSize + maxPollRecords);
+        this.retries = config.getRetryAttempts() == -1 ? Long.MAX_VALUE : config.getRetryAttempts();
+        this.pollUni = client.poll()
+                .onItem().transform(cr -> {
+                    if (cr.isEmpty()) {
+                        return null;
+                    }
+                    if (log.isTraceEnabled()) {
+                        log.tracef("Adding %s messages to the queue", cr.count());
+                    }
+                    enqueueFunction.accept(cr, queue);
+                    return cr;
+                })
+                .plug(m -> {
+                    if (config.getRetry()) {
+                        int maxWait = config.getRetryMaxWait();
+                        return m.onFailure().retry().withBackOff(Duration.ofSeconds(1), Duration.ofSeconds(maxWait))
+                                .atMost(retries);
+                    }
+                    return m;
+                });
+    }
+
+    @Override
+    public void request(long n) {
+        if (n > 0) {
+            boolean cancelled = state.get() == STATE_CANCELLED;
+            if (!cancelled) {
+                Subscriptions.add(requested, n);
+                if (state.compareAndSet(STATE_NEW, STATE_POLLING)) {
+                    poll();
+                } else {
+                    dispatch();
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("Invalid request");
+        }
+
+    }
+
+    private void poll() {
+        int state = this.state.get();
+        if (state == STATE_CANCELLED || state == STATE_NEW || client.isClosed()) {
+            return;
+        }
+
+        if (pauseResumeEnabled) {
+            pauseResume();
+        }
+
+        pollUni.subscribe().with(cr -> {
+            if (cr == null) {
+                client.executeWithDelay(this::poll, Duration.ofMillis(2))
+                        .subscribe().with(this::emptyConsumer, this::report);
+            } else {
+                dispatch();
+                client.runOnPollingThread(c -> {
+                    poll();
+                }).subscribe().with(this::emptyConsumer, this::report);
+            }
+        }, this::report);
+    }
+
+    private void pauseResume() {
+        int size = queue.size();
+        if (size >= maxQueueSize && state.compareAndSet(STATE_POLLING, STATE_PAUSED)) {
+            log.pausingChannel(channel, size, maxQueueSize);
+            client.pause()
+                    .subscribe().with(this::emptyConsumer, this::report);
+        } else if (size <= halfMaxQueueSize && state.compareAndSet(STATE_PAUSED, STATE_POLLING)) {
+            log.resumingChannel(channel, size, halfMaxQueueSize);
+            client.resume()
+                    .subscribe().with(this::emptyConsumer, this::report);
+        }
+    }
+
+    private <I> void emptyConsumer(I ignored) {
+    }
+
+    private void report(Throwable fail) {
+        while (true) {
+            int state = this.state.get();
+            if (state == STATE_CANCELLED) {
+                break;
+            }
+            if (this.state.compareAndSet(state, STATE_CANCELLED)) {
+                downstream.onFailure(fail);
+                break;
+            }
+        }
+    }
+
+    void dispatch() {
+        if (wip.getAndIncrement() != 0) {
+            return;
+        }
+        context.runOnContext(ignored -> run());
+    }
+
+    private void run() {
+        int missed = 1;
+        final RecordQueue<T> q = queue;
+        long emitted = 0;
+        long requests = requested.get();
+        for (;;) {
+            if (isCancelled()) {
+                return;
+            }
+
+            while (emitted != requests) {
+                T item = q.poll();
+
+                if (item == null || isCancelled()) {
+                    break;
+                }
+
+                downstream.onItem(item);
+                emitted++;
+            }
+
+            requests = requested.addAndGet(-emitted);
+            emitted = 0;
+
+            int w = wip.get();
+            if (missed == w) {
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            } else {
+                missed = w;
+            }
+        }
+    }
+
+    @Override
+    public void cancel() {
+        while (true) {
+            int state = this.state.get();
+            if (state == STATE_CANCELLED) {
+                break;
+            }
+            if (this.state.compareAndSet(state, STATE_CANCELLED)) {
+                if (wip.getAndIncrement() == 0) {
+                    // nothing was currently dispatched, clearing the queue.
+                    client.close();
+                    queue.clear();
+                }
+                break;
+            }
+        }
+    }
+
+    boolean isCancelled() {
+        if (state.get() == STATE_CANCELLED) {
+            queue.clear();
+            client.close();
+            return true;
+        }
+        return false;
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RecordQueue.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RecordQueue.java
@@ -5,7 +5,8 @@ import java.util.Collection;
 
 /**
  * Stores the records coming from Kafka.
- * Only a few operations are supported: {@link #addAll(Iterable)}, {@link #clear()}, {@link #size()} and {@link #poll()}.
+ * Only a few operations are supported: {@link #offer(Object)}, {@link #addAll(Iterable)}, {@link #clear()},
+ * {@link #size()} and {@link #poll()}.
  * <p>
  * The access is guarded by the monitor lock.
  */
@@ -35,7 +36,9 @@ public class RecordQueue<T> extends ArrayDeque<T> {
 
     @Override
     public boolean offer(T item) {
-        throw new UnsupportedOperationException();
+        synchronized (this) {
+            return super.offer(item);
+        }
     }
 
     @Override

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/BatchConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/BatchConsumerTest.java
@@ -1,0 +1,154 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordBatchMetadata;
+import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+
+public class BatchConsumerTest extends KafkaTestBase {
+
+    @Test
+    void testIncomingConsumingListPayload() {
+        KafkaMapBasedConfig.Builder builder = KafkaMapBasedConfig.builder("mp.messaging.incoming.kafka")
+                .put("value.deserializer", StringDeserializer.class.getName())
+                .put("auto.offset.reset", "earliest")
+                .put("topic", topic)
+                .put("batch", true);
+
+        BeanConsumingListPayload bean = runApplication(builder.build(), BeanConsumingListPayload.class);
+
+        AtomicInteger count = new AtomicInteger();
+        usage.produceStrings(10, null, () -> new ProducerRecord<>(topic, null, "v-" + count.get()));
+
+        await().until(() -> bean.messages().size() == 10);
+
+        assertThat(bean.messages()).hasSize(10).allSatisfy(p -> assertThat(p).startsWith("v-"));
+    }
+
+    @Test
+    void testIncomingConsumingKafkaBatchRecords() {
+        KafkaMapBasedConfig.Builder builder = KafkaMapBasedConfig.builder("mp.messaging.incoming.kafka")
+                .put("value.deserializer", StringDeserializer.class.getName())
+                .put("auto.offset.reset", "earliest")
+                .put("topic", topic)
+                .put("batch", true);
+        BeanConsumingKafkaRecordBatch bean = runApplication(builder.build(), BeanConsumingKafkaRecordBatch.class);
+
+        AtomicInteger count = new AtomicInteger();
+        usage.produceStrings(10, null, () -> new ProducerRecord<>(topic, "k-" + count.getAndIncrement(), "v-" + count.get()));
+
+        await().until(() -> bean.messages().size() == 10);
+
+        assertThat(bean.messages()).hasSize(10).allSatisfy(r -> {
+            assertThat(r.getKey()).startsWith("k-");
+            assertThat(r.getPayload()).startsWith("v-");
+        });
+    }
+
+    @Test
+    void testIncomingConsumingMessageWithMetadata() {
+        String newTopic = UUID.randomUUID().toString();
+        createTopic(newTopic, 3);
+
+        KafkaMapBasedConfig.Builder builder = KafkaMapBasedConfig.builder("mp.messaging.incoming.kafka")
+                .put("value.deserializer", StringDeserializer.class.getName())
+                .put("auto.offset.reset", "earliest")
+                .put("topic", newTopic)
+                .put("batch", true);
+        BeanConsumingMessageWithBatchMetadata bean = runApplication(builder.build(),
+                BeanConsumingMessageWithBatchMetadata.class);
+
+        AtomicInteger count = new AtomicInteger();
+        usage.produceStrings(10, null,
+                () -> new ProducerRecord<>(newTopic, "k-" + count.getAndIncrement(), "v-" + count.get()));
+
+        await().until(() -> bean.metadata().stream().mapToInt(m -> m.getRecords().count()).sum() == 10);
+
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> records = new HashMap<>();
+        for (IncomingKafkaRecordBatchMetadata<String, String> metadata : bean.metadata()) {
+            for (TopicPartition partition : metadata.getRecords().partitions()) {
+                List<ConsumerRecord<String, String>> list = records.computeIfAbsent(partition, p -> new ArrayList<>());
+                list.addAll(metadata.getRecords().records(partition));
+            }
+        }
+
+        assertThat(records.keySet()).hasSize(3);
+        assertThat(records.values()).flatMap(l -> l).hasSize(10).allSatisfy(r -> {
+            assertThat(r.value()).startsWith("v-");
+            assertThat(r.key()).startsWith("k");
+        });
+    }
+
+    @ApplicationScoped
+    public static class BeanConsumingListPayload {
+
+        final List<String> messages = new CopyOnWriteArrayList<>();
+
+        @Incoming("kafka")
+        public void consume(List<String> records) {
+            messages.addAll(records);
+        }
+
+        public List<String> messages() {
+            return this.messages;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class BeanConsumingKafkaRecordBatch {
+
+        final List<KafkaRecord<String, String>> messages = new CopyOnWriteArrayList<>();
+
+        @Incoming("kafka")
+        public CompletionStage<Void> consume(KafkaRecordBatch<String, String> records) {
+            messages.addAll(records.getRecords());
+            return records.ack();
+        }
+
+        public List<KafkaRecord<String, String>> messages() {
+            return this.messages;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class BeanConsumingMessageWithBatchMetadata {
+
+        final List<IncomingKafkaRecordBatchMetadata<String, String>> metadata = new CopyOnWriteArrayList<>();
+
+        @Incoming("kafka")
+        @SuppressWarnings("unchecked")
+        public CompletionStage<Void> consume(Message<List<String>> batchMessage) {
+            this.metadata.add(batchMessage.getMetadata(IncomingKafkaRecordBatchMetadata.class)
+                    .orElseThrow(() -> new IllegalArgumentException("kafka batch metadata not found")));
+            return batchMessage.ack();
+        }
+
+        public List<IncomingKafkaRecordBatchMetadata<String, String>> metadata() {
+            return this.metadata;
+        }
+
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatchTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatchTest.java
@@ -1,0 +1,138 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler;
+import io.smallrye.reactive.messaging.kafka.commit.KafkaIgnoreCommit;
+import io.smallrye.reactive.messaging.kafka.fault.KafkaFailureHandler;
+
+public class KafkaRecordBatchTest {
+
+    @Mock
+    KafkaCommitHandler commitHandler;
+
+    @Mock
+    KafkaFailureHandler onNack;
+
+    @Captor
+    ArgumentCaptor<IncomingKafkaRecord<String, Integer>> captor;
+
+    private ConsumerRecords<String, Integer> records;
+
+    @BeforeEach
+    void setupRecords() {
+        MockitoAnnotations.initMocks(this);
+        when(commitHandler.handle(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(onNack.handle(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+
+        HashMap<TopicPartition, List<ConsumerRecord<String, Integer>>> consumerRecords = new HashMap<>();
+        consumerRecords.put(new TopicPartition("t", 1),
+                Arrays.asList(
+                        new ConsumerRecord<>("t", 1, 0, "0", 0),
+                        new ConsumerRecord<>("t", 1, 1, "2", 2),
+                        new ConsumerRecord<>("t", 1, 2, "4", 4),
+                        new ConsumerRecord<>("t", 1, 3, "6", 6)));
+        consumerRecords.put(new TopicPartition("t", 2),
+                Arrays.asList(
+                        new ConsumerRecord<>("t", 2, 5, "1", 1),
+                        new ConsumerRecord<>("t", 2, 6, "3", 3),
+                        new ConsumerRecord<>("t", 2, 7, "5", 5)));
+        records = new ConsumerRecords<>(consumerRecords);
+    }
+
+    @Test
+    void testGetPayload() {
+        IncomingKafkaRecordBatch<String, Integer> batchRecords = new IncomingKafkaRecordBatch<>(records,
+                commitHandler, onNack, false, false);
+
+        List<Integer> batchPayload = batchRecords.getPayload();
+        assertThat(batchPayload).hasSize(7);
+        assertThat(batchPayload).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void testGetRecords() {
+        IncomingKafkaRecordBatch<String, Integer> batchRecords = new IncomingKafkaRecordBatch<>(records,
+                commitHandler, onNack, false, false);
+
+        List<KafkaRecord<String, Integer>> batchIncomingRecords = batchRecords.getRecords();
+        assertThat(batchIncomingRecords).hasSize(7);
+        assertThat(batchIncomingRecords).allSatisfy(record -> {
+            assertThat(record).isInstanceOf(IncomingKafkaRecord.class);
+            assertThat(record.getMetadata(IncomingKafkaRecordMetadata.class)).isPresent();
+        });
+        assertThat(batchIncomingRecords).map(Message::getPayload).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void testCommitHandlerReceivedCalledAtConstruction() {
+        IncomingKafkaRecordBatch<String, Integer> batchRecords = new IncomingKafkaRecordBatch<>(records,
+                commitHandler, onNack, false, false);
+
+        verify(commitHandler, times(2)).received(captor.capture());
+        List<IncomingKafkaRecord<String, Integer>> receivedValues = captor.getAllValues();
+
+        assertThat(receivedValues).hasSize(2).map(IncomingKafkaRecord::getPayload).containsExactlyInAnyOrder(5, 6);
+
+        assertThat(batchRecords.getLatestOffsetRecords().get(new TopicPartition("t", 1))).isNotNull()
+                .satisfies(record -> {
+                    assertThat(record.getMetadata(IncomingKafkaRecordMetadata.class)).isPresent().get()
+                            .extracting(IncomingKafkaRecordMetadata::getOffset).isEqualTo(3L);
+                    assertThat(record.getPayload()).isEqualTo(6);
+                    assertThat(record).isIn(receivedValues);
+                });
+        assertThat(batchRecords.getLatestOffsetRecords().get(new TopicPartition("t", 2))).isNotNull()
+                .satisfies(record -> {
+                    assertThat(record.getMetadata(IncomingKafkaRecordMetadata.class)).isPresent().get()
+                            .extracting(IncomingKafkaRecordMetadata::getOffset).isEqualTo(7L);
+                    assertThat(record.getPayload()).isEqualTo(5);
+                    assertThat(record).isIn(receivedValues);
+                });
+    }
+
+    @Test
+    void testAckLatestOffsetRecords() {
+        IncomingKafkaRecordBatch<String, Integer> batchRecords = new IncomingKafkaRecordBatch<>(records,
+                commitHandler, null, false, false);
+
+        batchRecords.ack().toCompletableFuture().join();
+
+        verify(commitHandler, times(2)).handle(captor.capture());
+        assertThat(captor.getAllValues()).hasSize(2)
+                .map(IncomingKafkaRecord::getPayload).containsExactlyInAnyOrder(5, 6);
+    }
+
+    @Test
+    void testNackAllRecords() {
+        IncomingKafkaRecordBatch<String, Integer> batchRecords = new IncomingKafkaRecordBatch<>(records,
+                new KafkaIgnoreCommit(), onNack, false, false);
+
+        batchRecords.nack(new IllegalArgumentException()).toCompletableFuture().join();
+
+        verify(onNack, times(7)).handle(captor.capture(), any(), any());
+        assertThat(captor.getAllValues()).hasSize(7)
+                .map(IncomingKafkaRecord::getPayload).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6);
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatchTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatchTest.java
@@ -86,32 +86,6 @@ public class KafkaRecordBatchTest {
     }
 
     @Test
-    void testCommitHandlerReceivedCalledAtConstruction() {
-        IncomingKafkaRecordBatch<String, Integer> batchRecords = new IncomingKafkaRecordBatch<>(records,
-                commitHandler, onNack, false, false);
-
-        verify(commitHandler, times(2)).received(captor.capture());
-        List<IncomingKafkaRecord<String, Integer>> receivedValues = captor.getAllValues();
-
-        assertThat(receivedValues).hasSize(2).map(IncomingKafkaRecord::getPayload).containsExactlyInAnyOrder(5, 6);
-
-        assertThat(batchRecords.getLatestOffsetRecords().get(new TopicPartition("t", 1))).isNotNull()
-                .satisfies(record -> {
-                    assertThat(record.getMetadata(IncomingKafkaRecordMetadata.class)).isPresent().get()
-                            .extracting(IncomingKafkaRecordMetadata::getOffset).isEqualTo(3L);
-                    assertThat(record.getPayload()).isEqualTo(6);
-                    assertThat(record).isIn(receivedValues);
-                });
-        assertThat(batchRecords.getLatestOffsetRecords().get(new TopicPartition("t", 2))).isNotNull()
-                .satisfies(record -> {
-                    assertThat(record.getMetadata(IncomingKafkaRecordMetadata.class)).isPresent().get()
-                            .extracting(IncomingKafkaRecordMetadata::getOffset).isEqualTo(7L);
-                    assertThat(record.getPayload()).isEqualTo(5);
-                    assertThat(record).isIn(receivedValues);
-                });
-    }
-
-    @Test
     void testAckLatestOffsetRecords() {
         IncomingKafkaRecordBatch<String, Integer> batchRecords = new IncomingKafkaRecordBatch<>(records,
                 commitHandler, null, false, false);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
@@ -1,7 +1,6 @@
 package io.smallrye.reactive.messaging.kafka.base;
 
 import java.util.HashMap;
-import java.util.stream.Collectors;
 
 import javax.enterprise.inject.spi.BeanManager;
 
@@ -124,10 +123,6 @@ public class WeldTestBase {
     }
 
     public boolean isReady() {
-        System.out
-                .println(getHealth().getReadiness().getChannels().stream()
-                        .map(ci -> ci.getChannel() + " " + ci.isOk() + " " + ci.getMessage())
-                        .collect(Collectors.joining()));
         return getHealth().getReadiness().isOk();
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceBatchWithCloudEventsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceBatchWithCloudEventsTest.java
@@ -1,0 +1,498 @@
+package io.smallrye.reactive.messaging.kafka.ce;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
+import io.smallrye.reactive.messaging.kafka.ConsumptionConsumerRebalanceListener;
+import io.smallrye.reactive.messaging.kafka.CountKafkaCdiEvents;
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaCloudEventMetadata;
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordBatch;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaRecord;
+import io.smallrye.reactive.messaging.kafka.KafkaRecordBatch;
+import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
+import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.serialization.BufferDeserializer;
+import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
+import io.vertx.kafka.client.serialization.JsonObjectSerializer;
+
+public class KafkaSourceBatchWithCloudEventsTest extends KafkaTestBase {
+
+    KafkaSource<String, Integer> source;
+
+    @AfterEach
+    public void stopping() {
+        if (source != null) {
+            source.closeQuietly();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Message<?>> getRecordsFromBatchMessage(IncomingKafkaRecordBatch<String, Integer> m) {
+        return m.unwrap(KafkaRecordBatch.class).getRecords();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReceivingStructuredCloudEventsWithJsonObjectDeserializer() {
+        KafkaMapBasedConfig config = newCommonConfig();
+        config.put("topic", topic);
+        config.put("value.deserializer", JsonObjectDeserializer.class.getName());
+        config.put("channel-name", topic);
+        KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+                UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
+
+        List<Message<?>> messages = new ArrayList<>();
+        source.getBatchStream().subscribe().with(m -> messages.addAll(getRecordsFromBatchMessage(m)));
+
+        new Thread(() -> usage
+                .produce(UUID.randomUUID().toString(), 1, new StringSerializer(), new JsonObjectSerializer(), null,
+                        () -> {
+                            JsonObject json = new JsonObject()
+                                    .put("specversion", CloudEventMetadata.CE_VERSION_1_0)
+                                    .put("type", "type")
+                                    .put("id", "id")
+                                    .put("source", "test://test")
+                                    .put("subject", "foo")
+                                    .put("data", new JsonObject().put("name", "neo"));
+
+                            return new ProducerRecord<>(topic, null, null, "key", json,
+                                    Collections.singletonList(
+                                            new RecordHeader("content-type",
+                                                    "application/cloudevents+json; charset=utf-8".getBytes())));
+                        })).start();
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 1);
+
+        Message<?> message = messages.get(0);
+        IncomingKafkaCloudEventMetadata<String, JsonObject> metadata = message
+                .getMetadata(IncomingKafkaCloudEventMetadata.class).orElse(null);
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getSpecVersion()).isEqualTo(CloudEventMetadata.CE_VERSION_1_0);
+        assertThat(metadata.getType()).isEqualTo("type");
+        assertThat(metadata.getId()).isEqualTo("id");
+        assertThat(metadata.getSource()).isEqualTo(URI.create("test://test"));
+        assertThat(metadata.getSubject()).hasValue("foo");
+        assertThat(metadata.getTimeStamp()).isEmpty();
+        assertThat(metadata.getDataContentType()).isEmpty();
+        assertThat(metadata.getDataSchema()).isEmpty();
+        assertThat(metadata.getData().getString("name")).isEqualTo("neo");
+
+        // Extensions
+        assertThat(metadata.getKey()).isEqualTo("key");
+        // Rule 3.1 - partitionkey attribute
+        assertThat(metadata.<String> getExtension("partitionkey")).hasValue("key");
+        assertThat(metadata.getTopic()).isEqualTo(topic);
+
+        assertThat(message.getPayload()).isInstanceOf(JsonObject.class);
+        assertThat(((JsonObject) message.getPayload()).getString("name")).isEqualTo("neo");
+
+    }
+
+    @Test
+    public void testReceivingStructuredCloudEventsWithUnsupportedDeserializer() {
+        KafkaMapBasedConfig config = newCommonConfig();
+        config.put("topic", topic);
+        // Unsupported on purpose
+        config.put("value.deserializer", BufferDeserializer.class.getName());
+        config.put("channel-name", topic);
+        KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+                UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
+
+        List<Message<?>> messages = new ArrayList<>();
+        source.getBatchStream().subscribe().with(messages::add);
+
+        new Thread(() -> usage
+                .produce(UUID.randomUUID().toString(), 1, new StringSerializer(), new JsonObjectSerializer(), null,
+                        () -> {
+                            JsonObject json = new JsonObject()
+                                    .put("specversion", CloudEventMetadata.CE_VERSION_1_0)
+                                    .put("type", "type")
+                                    .put("id", "id")
+                                    .put("source", "test://test")
+                                    .put("data", new JsonObject().put("name", "neo"));
+
+                            return new ProducerRecord<>(topic, null, null, "key", json,
+                                    Collections.singletonList(
+                                            new RecordHeader("content-type",
+                                                    "application/cloudevents+json; charset=utf-8".getBytes())));
+                        })).start();
+
+        await()
+                .pollDelay(Duration.ofSeconds(1))
+                .atMost(2, TimeUnit.MINUTES).until(() -> messages.size() == 0);
+
+        // Nothing has been received because the deserializer is not supported.
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReceivingBinaryCloudEvents() {
+        KafkaMapBasedConfig config = newCommonConfig();
+        config.put("topic", topic);
+        config.put("value.deserializer", StringDeserializer.class.getName());
+        config.put("channel-name", topic);
+        KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+                UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
+
+        List<Message<?>> messages = new ArrayList<>();
+        source.getBatchStream().subscribe().with(m -> messages.addAll(getRecordsFromBatchMessage(m)));
+
+        new Thread(
+                () -> usage.produce(UUID.randomUUID().toString(), 1, new StringSerializer(), new StringSerializer(), null,
+                        () -> {
+
+                            List<Header> headers = new ArrayList<>();
+                            headers.add(new RecordHeader("ce_specversion", CloudEventMetadata.CE_VERSION_1_0.getBytes()));
+                            headers.add(new RecordHeader("ce_type", "type".getBytes()));
+                            headers.add(new RecordHeader("ce_source", "test://test".getBytes()));
+                            headers.add(new RecordHeader("ce_id", "id".getBytes()));
+                            headers.add(new RecordHeader("ce_time", "2020-07-23T07:59:04Z".getBytes()));
+                            headers.add(new RecordHeader("content-type", "text/plain".getBytes()));
+                            headers.add(new RecordHeader("ce_subject", "foo".getBytes()));
+                            headers.add(new RecordHeader("ce_dataschema", "http://schema.io".getBytes()));
+                            headers.add(new RecordHeader("ce_ext", "bar".getBytes()));
+                            headers.add(new RecordHeader("some-header", "baz".getBytes()));
+
+                            return new ProducerRecord<>(topic, null, null, "key", "Hello World", headers);
+                        })).start();
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 1);
+
+        Message<?> message = messages.get(0);
+        IncomingKafkaCloudEventMetadata<String, String> metadata = message.getMetadata(IncomingKafkaCloudEventMetadata.class)
+                .orElse(null);
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getSpecVersion()).isEqualTo(CloudEventMetadata.CE_VERSION_1_0);
+        assertThat(metadata.getType()).isEqualTo("type");
+        assertThat(metadata.getId()).isEqualTo("id");
+        assertThat(metadata.getSource()).isEqualTo(URI.create("test://test"));
+
+        assertThat(metadata.getSubject()).hasValue("foo");
+        assertThat(metadata.getDataSchema()).hasValue(URI.create("http://schema.io"));
+        assertThat(metadata.getTimeStamp()).isNotEmpty();
+
+        assertThat(metadata.getData()).isEqualTo("Hello World");
+        // Rule 3.2.1 - the content-type must be mapped to the datacontenttype attribute
+        assertThat(metadata.getDataContentType()).hasValue("text/plain");
+        // Rule 3.2.3
+        assertThat(metadata.getExtension("ext")).hasValue("bar");
+        assertThat(metadata.getExtension("some-header")).isEmpty();
+
+        // Extensions
+        assertThat(metadata.getKey()).isEqualTo("key");
+        // Rule 3.1 - partitionkey attribute
+        assertThat(metadata.<String> getExtension("partitionkey")).hasValue("key");
+        assertThat(metadata.getTopic()).isEqualTo(topic);
+
+        assertThat(message.getPayload()).isInstanceOf(String.class).isEqualTo("Hello World");
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testWithBeanReceivingBinaryAndStructuredCloudEvents() {
+        ConsumptionBean bean = run(getConfig(topic));
+
+        List<KafkaRecord<String, String>> list = bean.getKafkaRecords();
+        assertThat(list).isEmpty();
+
+        // Send a binary cloud event
+        usage.produce(UUID.randomUUID().toString(), 1, new StringSerializer(), new StringSerializer(), null,
+                () -> {
+                    List<Header> headers = new ArrayList<>();
+                    headers.add(new RecordHeader("ce_specversion", CloudEventMetadata.CE_VERSION_1_0.getBytes()));
+                    headers.add(new RecordHeader("ce_type", "type".getBytes()));
+                    headers.add(new RecordHeader("ce_source", "test://test".getBytes()));
+                    headers.add(new RecordHeader("ce_id", "id".getBytes()));
+                    headers.add(new RecordHeader("content-type", "text/plain".getBytes()));
+                    headers.add(new RecordHeader("ce_subject", "foo".getBytes()));
+                    return new ProducerRecord<>(topic, null, null, "binary", "Hello Binary 1", headers);
+                });
+
+        await().atMost(10, TimeUnit.SECONDS).until(() -> list.size() >= 1);
+        KafkaRecord<String, String> record = list.get(0);
+        assertThat(record.getTopic()).isEqualTo(topic);
+        IncomingKafkaCloudEventMetadata<String, String> metadata = record
+                .getMetadata(IncomingKafkaCloudEventMetadata.class).orElse(null);
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getTopic()).isEqualTo(topic);
+        assertThat(metadata.getKey()).isEqualTo("binary");
+        assertThat(metadata.getId()).isEqualTo("id");
+        assertThat(metadata.getSubject()).hasValue("foo");
+        assertThat(metadata.getData()).isEqualTo("Hello Binary 1");
+        assertThat(record.getPayload()).isEqualTo("Hello Binary 1");
+
+        // send a structured event
+        usage.produce(UUID.randomUUID().toString(), 1, new StringSerializer(), new StringSerializer(), null,
+                () -> {
+                    JsonObject json = new JsonObject()
+                            .put("specversion", CloudEventMetadata.CE_VERSION_1_0)
+                            .put("type", "type")
+                            .put("id", "id")
+                            .put("source", "test://test")
+                            .put("subject", "bar")
+                            .put("datacontenttype", "application/json")
+                            .put("dataschema", "http://schema.io")
+                            .put("time", "2020-07-23T09:12:34Z")
+                            .put("data", "Hello Structured 1");
+
+                    return new ProducerRecord<>(topic, null, null, "structured", json.encode(),
+                            Collections.singletonList(
+                                    new RecordHeader("content-type",
+                                            "application/cloudevents+json; charset=utf-8".getBytes())));
+                });
+
+        await().atMost(10, TimeUnit.SECONDS).until(() -> list.size() >= 2);
+        record = list.get(1);
+        assertThat(record.getTopic()).isEqualTo(topic);
+        metadata = record
+                .getMetadata(IncomingKafkaCloudEventMetadata.class).orElse(null);
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getTopic()).isEqualTo(topic);
+        assertThat(metadata.getKey()).isEqualTo("structured");
+        assertThat(metadata.getId()).isEqualTo("id");
+        assertThat(metadata.getSubject()).hasValue("bar");
+        assertThat(metadata.getData()).isEqualTo("Hello Structured 1");
+        assertThat(record.getPayload()).contains("Hello Structured 1");
+
+        // Send a last binary cloud event
+        usage.produce(UUID.randomUUID().toString(), 1, new StringSerializer(), new StringSerializer(), null,
+                () -> {
+                    List<Header> headers = new ArrayList<>();
+                    headers.add(new RecordHeader("ce_specversion", CloudEventMetadata.CE_VERSION_1_0.getBytes()));
+                    headers.add(new RecordHeader("ce_type", "type".getBytes()));
+                    headers.add(new RecordHeader("ce_source", "test://test".getBytes()));
+                    headers.add(new RecordHeader("ce_id", "id".getBytes()));
+                    headers.add(new RecordHeader("content-type", "text/plain".getBytes()));
+                    headers.add(new RecordHeader("ce_subject", "foo".getBytes()));
+                    return new ProducerRecord<>(topic, null, null, "binary", "Hello Binary 2", headers);
+                });
+
+        await().atMost(10, TimeUnit.SECONDS).until(() -> list.size() >= 3);
+        record = list.get(2);
+        assertThat(record.getTopic()).isEqualTo(topic);
+        metadata = record
+                .getMetadata(IncomingKafkaCloudEventMetadata.class).orElse(null);
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getTopic()).isEqualTo(topic);
+        assertThat(metadata.getKey()).isEqualTo("binary");
+        assertThat(metadata.getId()).isEqualTo("id");
+        assertThat(metadata.getSubject()).hasValue("foo");
+        assertThat(metadata.getData()).isEqualTo("Hello Binary 2");
+        assertThat(record.getPayload()).isEqualTo("Hello Binary 2");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReceivingBinaryCloudEventsWithSupportDisabled() {
+        KafkaMapBasedConfig config = newCommonConfig();
+        config.put("topic", topic);
+        config.put("value.deserializer", StringDeserializer.class.getName());
+        config.put("channel-name", topic);
+        config.put("cloud-events", false);
+        KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+                UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
+
+        List<Message<?>> messages = new ArrayList<>();
+        source.getBatchStream().subscribe().with(m -> messages.addAll(getRecordsFromBatchMessage(m)));
+
+        new Thread(
+                () -> usage.produce(UUID.randomUUID().toString(), 1, new StringSerializer(), new StringSerializer(), null,
+                        () -> {
+
+                            List<Header> headers = new ArrayList<>();
+                            headers.add(new RecordHeader("ce_specversion", CloudEventMetadata.CE_VERSION_1_0.getBytes()));
+                            headers.add(new RecordHeader("ce_type", "type".getBytes()));
+                            headers.add(new RecordHeader("ce_source", "test://test".getBytes()));
+                            headers.add(new RecordHeader("ce_id", "id".getBytes()));
+                            headers.add(new RecordHeader("ce_time", "2020-07-23T07:59:04Z".getBytes()));
+                            headers.add(new RecordHeader("content-type", "text/plain".getBytes()));
+                            headers.add(new RecordHeader("ce_subject", "foo".getBytes()));
+                            headers.add(new RecordHeader("ce_dataschema", "http://schema.io".getBytes()));
+                            headers.add(new RecordHeader("ce_ext", "bar".getBytes()));
+                            headers.add(new RecordHeader("some-header", "baz".getBytes()));
+
+                            return new ProducerRecord<>(topic, null, null, "key", "Hello World", headers);
+                        })).start();
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 1);
+
+        Message<?> message = messages.get(0);
+        IncomingKafkaCloudEventMetadata<String, String> metadata = message.getMetadata(IncomingKafkaCloudEventMetadata.class)
+                .orElse(null);
+        assertThat(metadata).isNull();
+        assertThat(message.getPayload()).isInstanceOf(String.class).isEqualTo("Hello World");
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReceivingStructuredCloudEventsWithSupportDisabled() {
+        KafkaMapBasedConfig config = newCommonConfig();
+        config.put("topic", topic);
+        config.put("value.deserializer", JsonObjectDeserializer.class.getName());
+        config.put("channel-name", topic);
+        config.put("cloud-events", false);
+        KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+                UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
+
+        List<Message<?>> messages = new ArrayList<>();
+        source.getBatchStream().subscribe().with(m -> messages.addAll(getRecordsFromBatchMessage(m)));
+
+        new Thread(
+                () -> usage.produce(UUID.randomUUID().toString(), 1, new StringSerializer(), new StringSerializer(), null,
+                        () -> {
+                            JsonObject json = new JsonObject()
+                                    .put("specversion", CloudEventMetadata.CE_VERSION_1_0)
+                                    .put("type", "type")
+                                    .put("id", "id")
+                                    .put("source", "test://test")
+                                    .put("subject", "foo")
+                                    .put("datacontenttype", "application/json")
+                                    .put("dataschema", "http://schema.io")
+                                    .put("time", "2020-07-23T09:12:34Z")
+                                    .put("data", new JsonObject().put("name", "neo"));
+
+                            return new ProducerRecord<>(topic, null, null, null, json.encode(),
+                                    Collections.singletonList(
+                                            new RecordHeader("content-type",
+                                                    "application/cloudevents+json; charset=utf-8".getBytes())));
+                        })).start();
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 1);
+
+        Message<?> message = messages.get(0);
+        IncomingKafkaCloudEventMetadata<String, JsonObject> metadata = message
+                .getMetadata(IncomingKafkaCloudEventMetadata.class)
+                .orElse(null);
+        assertThat(metadata).isNull();
+        assertThat(message.getPayload()).isInstanceOf(JsonObject.class);
+        assertThat(((JsonObject) message.getPayload()).getJsonObject("data").getString("name")).isEqualTo("neo");
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testReceivingStructuredCloudEventsNoData() {
+        KafkaMapBasedConfig config = newCommonConfig();
+        config.put("topic", topic);
+        config.put("value.deserializer", StringDeserializer.class.getName());
+        config.put("channel-name", topic);
+        KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+                UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
+
+        List<Message<?>> messages = new ArrayList<>();
+        source.getBatchStream().subscribe().with(m -> messages.addAll(getRecordsFromBatchMessage(m)));
+
+        new Thread(
+                () -> usage.produce(UUID.randomUUID().toString(), 1, new StringSerializer(), new StringSerializer(), null,
+                        () -> {
+                            JsonObject json = new JsonObject()
+                                    .put("specversion", CloudEventMetadata.CE_VERSION_1_0)
+                                    .put("type", "type")
+                                    .put("id", "id")
+                                    .put("source", "test://test");
+
+                            return new ProducerRecord<>(topic, null, null, null, json.encode(),
+                                    Collections.singletonList(
+                                            new RecordHeader("content-type",
+                                                    "application/cloudevents+json; charset=utf-8".getBytes())));
+                        })).start();
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 1);
+
+        Message<?> message = messages.get(0);
+        IncomingKafkaCloudEventMetadata<String, JsonObject> metadata = message
+                .getMetadata(IncomingKafkaCloudEventMetadata.class)
+                .orElse(null);
+        assertThat(metadata).isNotNull();
+        assertThat(metadata.getSpecVersion()).isEqualTo(CloudEventMetadata.CE_VERSION_1_0);
+        assertThat(metadata.getType()).isEqualTo("type");
+        assertThat(metadata.getId()).isEqualTo("id");
+        assertThat(metadata.getSource()).isEqualTo(URI.create("test://test"));
+        assertThat(metadata.getData()).isNull();
+
+        assertThat(message.getPayload()).isNull();
+
+    }
+
+    private ConsumptionBean run(KafkaMapBasedConfig config) {
+        addBeans(ConsumptionBean.class, ConsumptionConsumerRebalanceListener.class);
+        runApplication(config);
+        return get(ConsumptionBean.class);
+    }
+
+    private KafkaMapBasedConfig getConfig(String topic) {
+        KafkaMapBasedConfig.Builder builder = KafkaMapBasedConfig.builder("mp.messaging.incoming.data");
+        builder.put("value.deserializer", StringDeserializer.class.getName());
+        builder.put("enable.auto.commit", "false");
+        builder.put("auto.offset.reset", "earliest");
+        builder.put("topic", topic);
+        builder.put("batch", true);
+        return builder.build();
+    }
+
+    private KafkaMapBasedConfig newCommonConfig() {
+        String randomId = UUID.randomUUID().toString();
+        KafkaMapBasedConfig config = new KafkaMapBasedConfig();
+        config.put("bootstrap.servers", getBootstrapServers());
+        config.put("group.id", randomId);
+        config.put("key.deserializer", StringDeserializer.class.getName());
+        config.put("graceful-shutdown", false);
+        config.put("enable.auto.commit", "false");
+        config.put("auto.offset.reset", "earliest");
+        config.put("tracing-enabled", false);
+        config.put("batch", true);
+        return config;
+    }
+
+    @ApplicationScoped
+    public static class ConsumptionBean {
+
+        private final List<KafkaRecord<String, String>> kafka = new CopyOnWriteArrayList<>();
+
+        @Incoming("data")
+        public CompletionStage<Void> process(KafkaRecordBatch<String, String> input) {
+            kafka.addAll(input.getRecords());
+            return input.ack();
+        }
+
+        public List<KafkaRecord<String, String>> getKafkaRecords() {
+            return kafka;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaBatchConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaBatchConsumerTest.java
@@ -1,0 +1,136 @@
+package io.smallrye.reactive.messaging.kafka.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.Cancellable;
+import io.smallrye.reactive.messaging.kafka.CountKafkaCdiEvents;
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordBatch;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
+import io.smallrye.reactive.messaging.kafka.base.SingletonInstance;
+import io.smallrye.reactive.messaging.kafka.base.TopicHelpers;
+import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
+import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class ReactiveKafkaBatchConsumerTest extends ClientTestBase {
+
+    private final Semaphore assignSemaphore = new Semaphore(partitions);
+    private final List<Cancellable> subscriptions = new ArrayList<>();
+    private KafkaSource<Integer, String> source;
+
+    @AfterEach
+    public void tearDown() {
+        cancelSubscriptions();
+        source.closeQuietly();
+    }
+
+    @BeforeEach
+    public void init() {
+        topic = TopicHelpers.createNewTopic("test-" + UUID.randomUUID().toString(), partitions);
+        resetMessages();
+    }
+
+    private void cancelSubscriptions() {
+        subscriptions.forEach(Cancellable::cancel);
+        subscriptions.clear();
+    }
+
+    @Test
+    public void testReception() throws Exception {
+        Multi<IncomingKafkaRecordBatch<Integer, String>> stream = createSource().getBatchStream();
+        sendReceive(stream, 0, 100, 0, 100, 50);
+    }
+
+    private void sendReceive(Multi<IncomingKafkaRecordBatch<Integer, String>> stream,
+            int sendStartIndex, int sendCount,
+            int receiveStartIndex, int receiveCount, int batchCount) throws Exception {
+
+        CountDownLatch latch = new CountDownLatch(batchCount);
+        subscribe(stream, latch);
+        if (sendCount > 0) {
+            sendMessages(sendStartIndex, sendCount);
+        }
+        waitForMessages(latch);
+        checkConsumedMessages(receiveStartIndex, receiveCount);
+    }
+
+    public KafkaSource<Integer, String> createSource() {
+        String groupId = UUID.randomUUID().toString();
+        MapBasedConfig config = createConsumerConfig(groupId)
+                .put("topic", topic)
+                .put("batch", true);
+
+        return createSource(config, groupId);
+    }
+
+    public KafkaSource<Integer, String> createSource(MapBasedConfig config, String groupId) {
+        SingletonInstance<KafkaConsumerRebalanceListener> listeners = new SingletonInstance<>(groupId,
+                getKafkaConsumerRebalanceListenerAwaitingAssignation());
+
+        source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config),
+                listeners, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
+        return source;
+    }
+
+    private KafkaConsumerRebalanceListener getKafkaConsumerRebalanceListenerAwaitingAssignation() {
+        return new KafkaConsumerRebalanceListener() {
+            @Override
+            public void onPartitionsAssigned(Consumer<?, ?> consumer,
+                    Collection<TopicPartition> partitions) {
+                ReactiveKafkaBatchConsumerTest.this.onPartitionsAssigned(partitions);
+            }
+        };
+    }
+
+    private void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+        assertThat(topic).isEqualTo(partitions.iterator().next().topic());
+        assignSemaphore.release(partitions.size());
+    }
+
+    private void waitForMessages(CountDownLatch latch) throws InterruptedException {
+        if (!latch.await(receiveTimeoutMillis, TimeUnit.MILLISECONDS)) {
+            fail(latch.getCount() + " messages not received, received=" + count(receivedMessages) + " : "
+                    + receivedMessages);
+        }
+    }
+
+    private void subscribe(Multi<IncomingKafkaRecordBatch<Integer, String>> stream, CountDownLatch... latches)
+            throws Exception {
+        Cancellable cancellable = stream
+                .onItem().invoke(record -> {
+                    onReceive(record);
+                    for (CountDownLatch latch : latches) {
+                        latch.countDown();
+                    }
+                })
+                .subscribe().with(ignored -> {
+                    // Ignored.
+                });
+        subscriptions.add(cancellable);
+        waitFoPartitionAssignment();
+    }
+
+    private void waitFoPartitionAssignment() throws InterruptedException {
+        assertTrue("Partitions not assigned",
+                assignSemaphore.tryAcquire(sessionTimeoutMillis + 1000, TimeUnit.MILLISECONDS));
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaConsumerTest.java
@@ -12,13 +12,10 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.*;
@@ -913,36 +910,6 @@ public class ReactiveKafkaConsumerTest extends ClientTestBase {
         sendMessages(startIndex, count);
         waitForMessages(latch);
         checkConsumedMessages(startIndex, count);
-    }
-
-    private void sendMessages(int startIndex, int count) throws Exception {
-        sendMessages(IntStream.range(0, count).mapToObj(i -> createProducerRecord(startIndex + i, true)));
-    }
-
-    private void sendMessages(int startIndex, int count, String broker) throws Exception {
-        sendMessages(IntStream.range(0, count).mapToObj(i -> new ProducerRecord<>(topic, 0, i, "Message " + i)), broker);
-    }
-
-    private void sendMessages(Stream<? extends ProducerRecord<Integer, String>> records) throws Exception {
-        try (KafkaProducer<Integer, String> producer = new KafkaProducer<>(producerProps())) {
-            List<Future<?>> futures = records.map(producer::send).collect(Collectors.toList());
-
-            for (Future<?> future : futures) {
-                future.get(5, TimeUnit.SECONDS);
-            }
-        }
-    }
-
-    private void sendMessages(Stream<? extends ProducerRecord<Integer, String>> records, String broker) throws Exception {
-        Map<String, Object> configs = producerProps();
-        System.out.println("Sending to broker " + broker);
-        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, broker);
-        try (KafkaProducer<Integer, String> producer = new KafkaProducer<>(configs)) {
-            List<Future<?>> futures = records.map(producer::send).collect(Collectors.toList());
-            for (Future<?> future : futures) {
-                future.get(5, TimeUnit.SECONDS);
-            }
-        }
     }
 
     public KafkaSource<Integer, String> createSource() {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/BatchCommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/BatchCommitStrategiesTest.java
@@ -1,0 +1,415 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import static io.smallrye.reactive.messaging.kafka.base.MockKafkaUtils.injectMockConsumer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.util.TypeLiteral;
+
+import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.kafka.*;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordBatchMetadata;
+import io.smallrye.reactive.messaging.kafka.base.WeldTestBase;
+import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.mutiny.core.Vertx;
+
+public class BatchCommitStrategiesTest extends WeldTestBase {
+
+    private static final String TOPIC = "my-topic";
+
+    public Vertx vertx;
+    private MockConsumer<String, String> consumer;
+    private KafkaSource<String, String> source;
+
+    @BeforeEach
+    public void initializing() {
+        vertx = Vertx.vertx();
+        consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    }
+
+    @AfterEach
+    void closing() {
+        if (source != null) {
+            source.closeQuietly();
+        }
+        vertx.closeAndAwait();
+    }
+
+    @Test
+    void testLatestCommitStrategy() {
+        MapBasedConfig config = commonConfiguration()
+                .with("commit-strategy", "latest")
+                .with("client.id", UUID.randomUUID().toString());
+        source = new KafkaSource<>(vertx, "my-group",
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getBatchStream().subscribe().with(list::add);
+
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp1 = new TopicPartition(TOPIC, 1);
+        TopicPartition tp2 = new TopicPartition(TOPIC, 2);
+        Map<TopicPartition, Long> beginning = new HashMap<>();
+        beginning.put(tp0, 0L);
+        beginning.put(tp1, 0L);
+        beginning.put(tp2, 0L);
+        consumer.updateBeginningOffsets(beginning);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Arrays.asList(tp0, tp1, tp2));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v0"));
+        });
+
+        await().until(() -> list.size() == 1);
+        assertThat(list).hasSize(1);
+
+        list.get(0).ack().toCompletableFuture().join();
+
+        Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp0));
+        assertThat(committed.get(tp0).offset()).isEqualTo(1);
+
+        consumer.schedulePollTask(() -> {
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, "k", "v1"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, "k", "v2"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 3, "k", "v3"));
+        });
+
+        await().until(() -> list.size() == 2);
+
+        Message<?> message = list.get(1);
+        message.ack().toCompletableFuture().join();
+        committed = consumer.committed(Collections.singleton(tp0));
+        assertThat(committed.get(tp0).offset()).isEqualTo(4);
+
+        // latest commit strategy, 3 is not acked, but offset 4 got committed.
+
+        // Do not change anything.
+        list.get(1).ack().toCompletableFuture().join();
+        committed = consumer.committed(Collections.singleton(tp0));
+        assertThat(committed.get(tp0).offset()).isEqualTo(4);
+
+        consumer.schedulePollTask(() -> {
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 1, 0, "k", "v4"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 2, 0, "k", "v5"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 1, 1, "k", "v6"));
+        });
+
+        await().until(() -> list.size() == 3);
+
+        list.get(2).ack().toCompletableFuture().join();
+        committed = consumer.committed(new HashSet<>(Arrays.asList(tp0, tp1, tp2)));
+        assertThat(committed.get(tp0).offset()).isEqualTo(4);
+        assertThat(committed.get(tp1).offset()).isEqualTo(2);
+        assertThat(committed.get(tp2).offset()).isEqualTo(1);
+    }
+
+    @Test
+    void testThrottledStrategy() {
+        MapBasedConfig config = commonConfiguration()
+                .with("commit-strategy", "throttled")
+                .with("auto.commit.interval.ms", 100);
+        source = new KafkaSource<>(vertx, "my-group",
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getBatchStream()
+                .subscribe().with(list::add);
+
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+        consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v0"));
+        });
+
+        await().until(() -> list.size() == 1);
+        assertThat(list).hasSize(1);
+
+        list.get(0).ack().toCompletableFuture().join();
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp));
+            assertThat(committed.get(tp)).isNotNull();
+            assertThat(committed.get(tp).offset()).isEqualTo(1);
+        });
+
+        consumer.schedulePollTask(() -> {
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, "k", "v1"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, "k", "v2"));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 3, "k", "v3"));
+        });
+
+        await().until(() -> list.size() == 2);
+
+        list.get(1).ack().toCompletableFuture().join();
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp));
+            assertThat(committed.get(tp)).isNotNull();
+            assertThat(committed.get(tp).offset()).isEqualTo(4);
+        });
+
+    }
+
+    @RepeatedTest(10)
+    void testThrottledStrategyWithManyRecords() {
+        MapBasedConfig config = commonConfiguration()
+                .with("client.id", UUID.randomUUID().toString())
+                .with("commit-strategy", "throttled")
+                .with("auto.offset.reset", "earliest")
+                .with("auto.commit.interval.ms", 100);
+        source = new KafkaSource<>(vertx, "my-group",
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new CopyOnWriteArrayList<>();
+        source.getBatchStream()
+                .subscribe().with(list::add);
+
+        TopicPartition p0 = new TopicPartition(TOPIC, 0);
+        TopicPartition p1 = new TopicPartition(TOPIC, 1);
+        Map<TopicPartition, Long> offsets = new HashMap<>();
+        offsets.put(p0, 0L);
+        offsets.put(p1, 5L);
+        consumer.updateBeginningOffsets(offsets);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(offsets.keySet());
+            source.getCommitHandler().partitionsAssigned(offsets.keySet());
+        });
+        for (int i = 0; i < 500; i++) {
+            int j = i;
+            consumer.schedulePollTask(() -> {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, j, "k", "v0-" + j));
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 1, j, "r", "v1-" + j));
+            });
+        }
+
+        // Expected number of messages: 500 messages in each partition minus the [0..5) messages from p1
+        int expected = 500 * 2 - 5;
+        await().until(() -> list.stream().map(IncomingKafkaRecordBatch.class::cast)
+                .mapToLong(r -> r.getRecords().size()).sum() == expected);
+
+        list.forEach(m -> m.ack().toCompletableFuture().join());
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(offsets.keySet());
+            assertThat(committed.get(p0)).isNotNull();
+            assertThat(committed.get(p0).offset()).isEqualTo(500);
+            assertThat(committed.get(p1)).isNotNull();
+            assertThat(committed.get(p1).offset()).isEqualTo(500);
+        });
+
+        for (int i = 0; i < 1000; i++) {
+            int j = i;
+            consumer.schedulePollTask(() -> {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 500 + j, "k", "v0-" + (500 + j)));
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 1, 500 + j, "k", "v1-" + (500 + j)));
+            });
+        }
+
+        int expected2 = expected + 1000 * 2;
+        await().until(() -> list.stream().map(IncomingKafkaRecordBatch.class::cast)
+                .mapToLong(r -> r.getRecords().size()).sum() == expected2);
+
+        list.forEach(m -> m.ack().toCompletableFuture().join());
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .untilAsserted(() -> {
+                    Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(offsets.keySet());
+                    assertThat(committed.get(p0)).isNotNull();
+                    assertThat(committed.get(p0).offset()).isEqualTo(1500);
+                    assertThat(committed.get(p1)).isNotNull();
+                    assertThat(committed.get(p1).offset()).isEqualTo(1500);
+                });
+
+        List<String> payloads = list.stream().map(m -> (List<String>) m.getPayload())
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+        for (int i = 0; i < 1500; i++) {
+            assertThat(payloads).contains("v0-" + i);
+        }
+        for (int i = 5; i < 1500; i++) {
+            assertThat(payloads).contains("v1-" + i);
+        }
+    }
+
+    @Test
+    void testThrottledStrategyWithTooManyUnackedMessages() {
+        MapBasedConfig config = commonConfiguration()
+                .with("client.id", UUID.randomUUID().toString())
+                .with("commit-strategy", "throttled")
+                .with("auto.offset.reset", "earliest")
+                .with("health-enabled", true)
+                .with("throttled.unprocessed-record-max-age.ms", 1000)
+                .with("auto.commit.interval.ms", 100);
+        source = new KafkaSource<>(vertx, "my-group",
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new CopyOnWriteArrayList<>();
+        source.getBatchStream()
+                .subscribe().with(list::add);
+
+        TopicPartition p0 = new TopicPartition(TOPIC, 0);
+        TopicPartition p1 = new TopicPartition(TOPIC, 1);
+        Map<TopicPartition, Long> offsets = new HashMap<>();
+        offsets.put(p0, 0L);
+        offsets.put(p1, 5L);
+        consumer.updateBeginningOffsets(offsets);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(offsets.keySet());
+            source.getCommitHandler().partitionsAssigned(offsets.keySet());
+        });
+        for (int i = 0; i < 500; i++) {
+            int j = i;
+            consumer.schedulePollTask(() -> {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, j, "k", "v0-" + j));
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 1, j, "r", "v1-" + j));
+            });
+        }
+
+        // Expected number of messages: 500 messages in each partition minus the [0..5) messages from p1
+        int expected = 500 * 2 - 5;
+        await().until(() -> list.stream().map(IncomingKafkaRecordBatch.class::cast)
+                .mapToLong(r -> r.getRecords().size()).sum() == expected);
+
+        // Ack first 10 records
+        int count = 0;
+        for (Message<?> message : list) {
+            assertThat(message.getMetadata(IncomingKafkaRecordBatchMetadata.class)).isPresent();
+            if (count < 10) {
+                message.ack().toCompletableFuture().join();
+                count++;
+            }
+        }
+
+        // wait until health check is not ok
+        await().until(() -> {
+            HealthReport.HealthReportBuilder builder = HealthReport.builder();
+            source.isAlive(builder);
+            HealthReport r = builder.build();
+            return !r.isOk();
+        });
+
+        // build the health check again and get the report message
+        HealthReport.HealthReportBuilder builder = HealthReport.builder();
+        source.isAlive(builder);
+        String message = builder.build().getChannels().get(0).getMessage();
+        assertThat(message).contains("my-topic", "partition:0", "partition:1");
+    }
+
+    @Test
+    public void testWithRebalanceListenerMatchGivenName() {
+        addBeans(NamedRebalanceListener.class);
+        MapBasedConfig config = commonConfiguration();
+        config
+                .with("consumer-rebalance-listener.name", "mine")
+                .with("client.id", UUID.randomUUID().toString());
+        source = new KafkaSource<>(vertx, "my-group",
+                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
+
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getBatchStream()
+                .subscribe().with(list::add);
+
+        Map<TopicPartition, Long> offsets = new HashMap<>();
+        offsets.put(new TopicPartition(TOPIC, 0), 0L);
+        offsets.put(new TopicPartition(TOPIC, 1), 0L);
+        consumer.updateBeginningOffsets(offsets);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+            consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v"));
+        });
+
+        await().until(() -> list.size() == 1);
+        assertThat(list).hasSize(1);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 1)));
+            ConsumerRecord<String, String> record = new ConsumerRecord<>(TOPIC, 1, 0, "k", "v");
+            consumer.addRecord(record);
+        });
+
+        await().until(() -> list.size() == 2);
+        assertThat(list).hasSize(2);
+    }
+
+    private MapBasedConfig commonConfiguration() {
+        return new MapBasedConfig()
+                .with("channel-name", "channel")
+                .with("graceful-shutdown", false)
+                .with("topic", TOPIC)
+                .with("health-enabled", false)
+                .with("tracing-enabled", false)
+                .with("batch", true)
+                .with("value.deserializer", StringDeserializer.class.getName());
+    }
+
+    public Instance<KafkaConsumerRebalanceListener> getConsumerRebalanceListeners() {
+        return getBeanManager().createInstance().select(KafkaConsumerRebalanceListener.class);
+    }
+
+    public Instance<DeserializationFailureHandler<?>> getDeserializationFailureHandlers() {
+        return getBeanManager().createInstance().select(
+                new TypeLiteral<DeserializationFailureHandler<?>>() {
+                });
+    }
+
+    @ApplicationScoped
+    @Identifier("mine")
+    public static class NamedRebalanceListener implements KafkaConsumerRebalanceListener {
+
+        @Override
+        public void onPartitionsAssigned(Consumer<?, ?> consumer,
+                Collection<TopicPartition> partitions) {
+
+        }
+
+        @Override
+        public void onPartitionsRevoked(Consumer<?, ?> consumer,
+                Collection<TopicPartition> partitions) {
+
+        }
+
+    }
+
+    @ApplicationScoped
+    @Identifier("mine")
+    public static class SameNameRebalanceListener extends NamedRebalanceListener
+            implements KafkaConsumerRebalanceListener {
+
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/BatchCommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/BatchCommitStrategiesTest.java
@@ -141,7 +141,8 @@ public class BatchCommitStrategiesTest extends WeldTestBase {
         consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
 
         consumer.schedulePollTask(() -> {
-            consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+            consumer.rebalance(Collections.singletonList(tp));
+            source.getCommitHandler().partitionsAssigned(Collections.singletonList(tp));
             consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v0"));
         });
 
@@ -323,7 +324,7 @@ public class BatchCommitStrategiesTest extends WeldTestBase {
         HealthReport.HealthReportBuilder builder = HealthReport.builder();
         source.isAlive(builder);
         String message = builder.build().getChannels().get(0).getMessage();
-        assertThat(message).contains("my-topic", "partition:0", "partition:1");
+        assertThat(message).contains("my-topic-0", "my-topic-1");
     }
 
     @Test
@@ -349,7 +350,9 @@ public class BatchCommitStrategiesTest extends WeldTestBase {
         consumer.updateBeginningOffsets(offsets);
 
         consumer.schedulePollTask(() -> {
-            consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+            TopicPartition tp = new TopicPartition(TOPIC, 0);
+            consumer.rebalance(Collections.singletonList(tp));
+            source.getCommitHandler().partitionsAssigned(Collections.singletonList(tp));
             consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v"));
         });
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/converters/ConsumerRecordsConverterTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/converters/ConsumerRecordsConverterTest.java
@@ -1,0 +1,98 @@
+package io.smallrye.reactive.messaging.kafka.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+
+class ConsumerRecordsConverterTest extends KafkaTestBase {
+
+    @Test
+    public void testBeanUsingConverter() {
+        KafkaMapBasedConfig.Builder builder = KafkaMapBasedConfig.builder("mp.messaging.incoming.data");
+        builder.put("value.deserializer", StringDeserializer.class.getName());
+        builder.put("auto.offset.reset", "earliest");
+        builder.put("topic", topic);
+        builder.put("batch", true);
+
+        addBeans(ConsumerRecordsConverter.class);
+        MyBean bean = runApplication(builder.build(), MyBean.class);
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceStrings(10, null,
+                () -> new ProducerRecord<>(topic, counter.get() % 2 == 0 ? "key" : "k", "v-" + counter.incrementAndGet()));
+
+        await().until(() -> bean.list().stream().mapToInt(ConsumerRecords::count).sum() == 10);
+
+        List<ConsumerRecord<String, String>> consumerRecords = bean.list().stream()
+                .flatMap(r -> StreamSupport.stream(r.records(topic).spliterator(), false))
+                .collect(Collectors.toList());
+
+        assertThat(consumerRecords).hasSize(10).allSatisfy(r -> {
+            assertThat(r.value()).startsWith("v-");
+            assertThat(r.key()).startsWith("k");
+            if (!r.key().equalsIgnoreCase("key")) {
+                assertThat(r.key()).isEqualTo("k");
+            }
+        });
+    }
+
+    @Test
+    public void testBeanUsingConverterWithNullKeyAndValue() {
+        KafkaMapBasedConfig.Builder builder = KafkaMapBasedConfig.builder("mp.messaging.incoming.data");
+        builder.put("value.deserializer", StringDeserializer.class.getName());
+        builder.put("auto.offset.reset", "earliest");
+        builder.put("topic", topic);
+        builder.put("batch", true);
+
+        addBeans(ConsumerRecordsConverter.class);
+        MyBean bean = runApplication(builder.build(), MyBean.class);
+
+        usage.produceStrings(10, null,
+                () -> new ProducerRecord<>(topic, null, null));
+
+        await().until(() -> bean.list().stream().mapToInt(ConsumerRecords::count).sum() == 10);
+
+        List<ConsumerRecord<String, String>> consumerRecords = bean.list().stream()
+                .flatMap(r -> StreamSupport.stream(r.records(topic).spliterator(), false))
+                .collect(Collectors.toList());
+
+        assertThat(consumerRecords).hasSize(10).allSatisfy(r -> {
+            assertThat(r.value()).isNull();
+            assertThat(r.value()).isNull();
+        });
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+
+        private final List<ConsumerRecords<String, String>> records = new CopyOnWriteArrayList<>();
+
+        @Incoming("data")
+        public void consume(ConsumerRecords<String, String> record) {
+            this.records.add(record);
+        }
+
+        public List<ConsumerRecords<String, String>> list() {
+            return records;
+        }
+
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/PerformanceBatchConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/PerformanceBatchConsumerTest.java
@@ -1,0 +1,233 @@
+package io.smallrye.reactive.messaging.kafka.perf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.kafka.KafkaConnector;
+import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.KafkaTestBase;
+import io.smallrye.reactive.messaging.kafka.base.KafkaUsage;
+
+public class PerformanceBatchConsumerTest extends KafkaTestBase {
+
+    public static final int TIMEOUT_IN_SECONDS = 400;
+    public static final int COUNT = 10_000;
+
+    public static String topic = UUID.randomUUID().toString();
+    private static ArrayList<String> expected;
+
+    @BeforeAll
+    static void insertRecords() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicLong count = new AtomicLong();
+        KafkaUsage usage = new KafkaUsage();
+        usage.produceStrings(COUNT, latch::countDown,
+                () -> new ProducerRecord<>(topic, "key", Long.toString(count.getAndIncrement())));
+        expected = new ArrayList<>();
+        for (int i = 0; i < COUNT; i++) {
+            expected.add(Long.toString(i));
+        }
+        latch.await();
+    }
+
+    @Test
+    public void testWithPostAckLatest() {
+        // To speed up a bit this test we reduce the polling timeout, the 1 second by default means that the commit
+        // are all delayed by 1 second. So we set the poll-timeout to 10ms
+
+        MyConsumerUsingPostAck application = runApplication(new KafkaMapBasedConfig()
+                .with("mp.messaging.incoming.data.connector", KafkaConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.topic", topic)
+                .with("mp.messaging.incoming.data.graceful-shutdown", false)
+                .with("mp.messaging.incoming.data.tracing-enabled", false)
+                .with("mp.messaging.incoming.data.cloud-events", false)
+                .with("mp.messaging.incoming.data.pause-if-no-requests", false)
+                .with("mp.messaging.incoming.data.commit-strategy", "latest")
+                .with("mp.messaging.incoming.data.bootstrap.servers", getBootstrapServers())
+                .with("mp.messaging.incoming.data.auto.offset.reset", "earliest")
+                .with("mp.messaging.incoming.data.poll-timeout", 5)
+                .with("mp.messaging.incoming.data.value.deserializer", StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.data.key.deserializer", StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.data.batch", true),
+                MyConsumerUsingPostAck.class);
+        long start = System.currentTimeMillis();
+        await()
+                .atMost(Duration.ofSeconds(TIMEOUT_IN_SECONDS))
+                .until(() -> application.getCount() == COUNT);
+
+        long end = System.currentTimeMillis();
+
+        assertThat(application.get()).containsExactlyElementsOf(expected);
+
+        System.out.println("Post-Ack / Latest - Estimate: " + (end - start) + " ms");
+    }
+
+    @Test
+    public void testWithPostAckThrottled() {
+        MyConsumerUsingPostAck application = runApplication(new KafkaMapBasedConfig()
+                .with("mp.messaging.incoming.data.connector", KafkaConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.topic", topic)
+                .with("mp.messaging.incoming.data.graceful-shutdown", false)
+                .with("mp.messaging.incoming.data.tracing-enabled", false)
+                .with("mp.messaging.incoming.data.pause-if-no-requests", false)
+                .with("mp.messaging.incoming.data.cloud-events", false)
+                .with("mp.messaging.incoming.data.commit-strategy", "throttled")
+                .with("mp.messaging.incoming.data.bootstrap.servers", getBootstrapServers())
+                .with("mp.messaging.incoming.data.auto.offset.reset", "earliest")
+                .with("mp.messaging.incoming.data.value.deserializer", StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.data.key.deserializer", StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.data.batch", true),
+                MyConsumerUsingPostAck.class);
+        long start = System.currentTimeMillis();
+        await()
+                .atMost(Duration.ofSeconds(TIMEOUT_IN_SECONDS))
+                .until(() -> application.getCount() == COUNT);
+
+        long end = System.currentTimeMillis();
+
+        assertThat(application.get()).containsExactlyElementsOf(expected);
+
+        System.out.println("Post-Ack / Throttled - Estimate: " + (end - start) + " ms");
+    }
+
+    @Test
+    public void testWithNoAck() {
+        MyConsumerUsingNoAck application = runApplication(new KafkaMapBasedConfig()
+                .with("mp.messaging.incoming.data.connector", KafkaConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.topic", topic)
+                .with("mp.messaging.incoming.data.graceful-shutdown", false)
+                .with("mp.messaging.incoming.data.enable.auto.commit", true)
+                .with("mp.messaging.incoming.data.pause-if-no-requests", false)
+                .with("mp.messaging.incoming.data.tracing-enabled", false)
+                .with("mp.messaging.incoming.data.cloud-events", false)
+                .with("mp.messaging.incoming.data.bootstrap.servers", getBootstrapServers())
+                .with("mp.messaging.incoming.data.auto.offset.reset", "earliest")
+                .with("mp.messaging.incoming.data.value.deserializer", StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.data.key.deserializer", StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.data.batch", true),
+                MyConsumerUsingNoAck.class);
+        long start = System.currentTimeMillis();
+        await()
+                .atMost(Duration.ofSeconds(TIMEOUT_IN_SECONDS))
+                .until(() -> application.getCount() == COUNT);
+
+        long end = System.currentTimeMillis();
+
+        assertThat(application.get()).containsExactlyElementsOf(expected);
+
+        System.out.println("Ignored acknowledgement (auto-commit, no-ack) - Estimate: " + (end - start) + " ms");
+    }
+
+    @Test
+    public void testWithAutoCommitWithPostAck() {
+        MyConsumerUsingPostAck application = runApplication(new KafkaMapBasedConfig()
+                .with("mp.messaging.incoming.data.connector", KafkaConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.topic", topic)
+                .with("mp.messaging.incoming.data.graceful-shutdown", false)
+                .with("mp.messaging.incoming.data.enable.auto.commit", true)
+                .with("mp.messaging.incoming.data.pause-if-no-requests", false)
+                .with("mp.messaging.incoming.data.tracing-enabled", false)
+                .with("mp.messaging.incoming.data.cloud-events", false)
+                .with("mp.messaging.incoming.data.bootstrap.servers", getBootstrapServers())
+                .with("mp.messaging.incoming.data.auto.offset.reset", "earliest")
+                .with("mp.messaging.incoming.data.value.deserializer", StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.data.key.deserializer", StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.data.batch", true),
+                MyConsumerUsingPostAck.class);
+        long start = System.currentTimeMillis();
+        await()
+                .atMost(Duration.ofSeconds(TIMEOUT_IN_SECONDS))
+                .until(() -> application.getCount() == COUNT);
+
+        long end = System.currentTimeMillis();
+        assertThat(application.get()).containsExactlyElementsOf(expected);
+        System.out.println("Ignored acknowledgement (auto-commit, post-ack) - Estimate: " + (end - start) + " ms");
+    }
+
+    @Test
+    public void testWithIgnoreAck() {
+        MyConsumerUsingPostAck application = runApplication(new KafkaMapBasedConfig()
+                .with("mp.messaging.incoming.data.bootstrap.servers", getBootstrapServers())
+                .with("mp.messaging.incoming.data.connector", KafkaConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.topic", topic)
+                .with("mp.messaging.incoming.data.graceful-shutdown", false)
+                .with("mp.messaging.incoming.data.pause-if-no-requests", false)
+                .with("mp.messaging.incoming.data.pattern", true)
+                .with("mp.messaging.incoming.data.value.deserializer", StringDeserializer.class.getName())
+                .with("mp.messaging.incoming.data.auto.offset.reset", "earliest")
+                .with("mp.messaging.incoming.data.auto.commit.interval.ms", 1000)
+                .with("mp.messaging.incoming.data.metadata.max.age.ms", 30000)
+                .with("mp.messaging.incoming.data.enable.auto.commit", true)
+                .with("mp.messaging.incoming.data.batch", true),
+                MyConsumerUsingPostAck.class);
+        long start = System.currentTimeMillis();
+        await()
+                .atMost(Duration.ofSeconds(TIMEOUT_IN_SECONDS))
+                .until(() -> application.getCount() == COUNT);
+
+        long end = System.currentTimeMillis();
+        assertThat(application.get()).containsExactlyElementsOf(expected);
+        System.out.println("Ignore with Auto-Commit - Estimate: " + (end - start) + " ms");
+    }
+
+    @ApplicationScoped
+    public static class MyConsumerUsingPostAck {
+
+        LongAdder count = new LongAdder();
+        List<String> list = new ArrayList<>();
+
+        @Incoming("data")
+        public void consume(List<String> message) {
+            list.addAll(message);
+            count.add(message.size());
+        }
+
+        public List<String> get() {
+            return list;
+        }
+
+        public long getCount() {
+            return count.longValue();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyConsumerUsingNoAck {
+
+        LongAdder count = new LongAdder();
+        List<String> list = new ArrayList<>();
+
+        @Incoming("data")
+        @Acknowledgment(Acknowledgment.Strategy.NONE)
+        public void consume(List<String> message) {
+            list.addAll(message);
+            count.add(message.size());
+        }
+
+        public long getCount() {
+            return count.longValue();
+        }
+
+        public List<String> get() {
+            return list;
+        }
+    }
+
+}


### PR DESCRIPTION
Activated with `mp.messaging.incoming.$channel.batch=true`.

Allows incoming channels to consume messages in batch with following types: 
- `List<Payload>`
- `Message<List<Payload>>`
- `KafkaRecordBatch<Key, Payload>`
- `ConsumerRecords<Key, Payload>`

On `ack` applies the configured commit strategy for records with the last offset per partition.
On `nack` applies the configured failure strategy for all messages inside the record batch.

Adds `max-queue-size-factor` configuration for adjusting the max queue size for records waiting to be processed, using `max.poll.records` * `max-queue-size-factor`, for example by default a maximum of 500 * 2 = 1000 records will be queued.
In batch mode `max.poll.records` is considered `1` for calculating the max number of queued batch records (`ConsumerRecords`).

Closes #1214

