### PR TITLE
Fix health for connectors that have no channels

### DIFF
--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/HealthChecks.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/HealthChecks.java
@@ -4,6 +4,11 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 
 public class HealthChecks {
+    public static final HealthCheckResponse NOT_YET_INITIALIZED = HealthCheckResponse.builder()
+            .name("SmallRye Reactive Messaging - not yet initialized")
+            .down()
+            .build();
+
     public static HealthCheckResponse getHealthCheck(HealthReport report, String check) {
         HealthCheckResponseBuilder builder = HealthCheckResponse.builder()
                 .name("SmallRye Reactive Messaging - " + check)

--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheck.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheck.java
@@ -16,6 +16,10 @@ public class SmallRyeReactiveMessagingLivenessCheck implements HealthCheck {
 
     @Override
     public HealthCheckResponse call() {
+        if (!health.isInitialized()) {
+            return HealthChecks.NOT_YET_INITIALIZED;
+        }
+
         HealthReport report = health.getLiveness();
         return HealthChecks.getHealthCheck(report, "liveness check");
     }

--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingReadinessCheck.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingReadinessCheck.java
@@ -18,6 +18,10 @@ public class SmallRyeReactiveMessagingReadinessCheck implements HealthCheck {
 
     @Override
     public HealthCheckResponse call() {
+        if (!health.isInitialized()) {
+            return HealthChecks.NOT_YET_INITIALIZED;
+        }
+
         HealthReport report = health.getReadiness();
         return HealthChecks.getHealthCheck(report, "readiness check");
     }

--- a/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingStartupCheck.java
+++ b/smallrye-reactive-messaging-health/src/main/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingStartupCheck.java
@@ -18,6 +18,10 @@ public class SmallRyeReactiveMessagingStartupCheck implements HealthCheck {
 
     @Override
     public HealthCheckResponse call() {
+        if (!health.isInitialized()) {
+            return HealthChecks.NOT_YET_INITIALIZED;
+        }
+
         HealthReport report = health.getStartup();
         return HealthChecks.getHealthCheck(report, "startup check");
     }

--- a/smallrye-reactive-messaging-health/src/test/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheckTest.java
+++ b/smallrye-reactive-messaging-health/src/test/java/io/smallrye/reactive/messaging/health/SmallRyeReactiveMessagingLivenessCheckTest.java
@@ -23,17 +23,21 @@ public class SmallRyeReactiveMessagingLivenessCheckTest {
         initializer.addBeanClasses(HealthCenter.class, MyReporterA.class, MyReporterB.class,
                 SmallRyeReactiveMessagingLivenessCheck.class);
         SeContainer container = initializer.initialize();
-        SmallRyeReactiveMessagingLivenessCheck check = container.getBeanManager().createInstance()
-                .select(SmallRyeReactiveMessagingLivenessCheck.class, Liveness.Literal.INSTANCE).get();
+
+        SmallRyeReactiveMessagingLivenessCheck check = container.select(SmallRyeReactiveMessagingLivenessCheck.class,
+                Liveness.Literal.INSTANCE).get();
+
+        assertThat(check.call().getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+
+        HealthCenter healthCenter = container.select(HealthCenter.class).get();
+        healthCenter.markInitialized();
 
         assertThat(check.call().getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
         assertThat(check.call().getData().orElse(null)).containsExactly(entry("my-channel", "[OK]"));
 
-        MyReporterA a = container.getBeanManager().createInstance()
-                .select(MyReporterA.class, ConnectorLiteral.of("connector-a")).get();
+        MyReporterA a = container.select(MyReporterA.class, ConnectorLiteral.of("connector-a")).get();
 
-        MyReporterB b = container.getBeanManager().createInstance()
-                .select(MyReporterB.class, ConnectorLiteral.of("connector-b")).get();
+        MyReporterB b = container.select(MyReporterB.class, ConnectorLiteral.of("connector-b")).get();
 
         a.toggle();
 
@@ -50,8 +54,14 @@ public class SmallRyeReactiveMessagingLivenessCheckTest {
         SeContainerInitializer initializer = SeContainerInitializer.newInstance().disableDiscovery();
         initializer.addBeanClasses(HealthCenter.class, SmallRyeReactiveMessagingLivenessCheck.class);
         SeContainer container = initializer.initialize();
-        SmallRyeReactiveMessagingLivenessCheck check = container.getBeanManager().createInstance()
-                .select(SmallRyeReactiveMessagingLivenessCheck.class, Liveness.Literal.INSTANCE).get();
+
+        SmallRyeReactiveMessagingLivenessCheck check = container.select(SmallRyeReactiveMessagingLivenessCheck.class,
+                Liveness.Literal.INSTANCE).get();
+
+        assertThat(check.call().getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+
+        HealthCenter healthCenter = container.select(HealthCenter.class).get();
+        healthCenter.markInitialized();
 
         assertThat(check.call().getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
         assertThat(check.call().getData()).isEmpty();

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -306,36 +306,24 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     @Override
     public HealthReport getStartup() {
         HealthReport.HealthReportBuilder builder = HealthReport.builder();
-        if (sources.isEmpty() && sinks.isEmpty()) {
-            return builder.add("kafka-connector", false).build();
-        }
-
         for (KafkaSource<?, ?> source : sources) {
             source.isStarted(builder);
         }
-
         for (KafkaSink sink : sinks) {
             sink.isStarted(builder);
         }
-
         return builder.build();
     }
 
     @Override
     public HealthReport getReadiness() {
         HealthReport.HealthReportBuilder builder = HealthReport.builder();
-        if (sources.isEmpty() && sinks.isEmpty()) {
-            return builder.add("kafka-connector", false).build();
-        }
-
         for (KafkaSource<?, ?> source : sources) {
             source.isReady(builder);
         }
-
         for (KafkaSink sink : sinks) {
             sink.isReady(builder);
         }
-
         return builder.build();
 
     }
@@ -343,18 +331,12 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     @Override
     public HealthReport getLiveness() {
         HealthReport.HealthReportBuilder builder = HealthReport.builder();
-        if (sources.isEmpty() && sinks.isEmpty()) {
-            return builder.add("kafka-connector", false).build();
-        }
-
         for (KafkaSource<?, ?> source : sources) {
             source.isAlive(builder);
         }
-
         for (KafkaSink sink : sinks) {
             sink.isAlive(builder);
         }
-
         return builder.build();
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
@@ -333,7 +333,7 @@ public class KafkaSink {
                 builder.add(configuration.getChannel(), true);
             }
         }
-        // If health is disable do not add anything to the builder.
+        // If health is disabled, do not add anything to the builder.
     }
 
     public void isReady(HealthReport.HealthReportBuilder builder) {
@@ -341,7 +341,7 @@ public class KafkaSink {
         if (health != null && this.configuration.getHealthReadinessEnabled()) {
             health.isReady(builder);
         }
-        // If health is disable do not add anything to the builder.
+        // If health is disabled, do not add anything to the builder.
     }
 
     public void isStarted(HealthReport.HealthReportBuilder builder) {
@@ -349,7 +349,7 @@ public class KafkaSink {
         if (health != null) {
             health.isStarted(builder);
         }
-        // If health is disable do not add anything to the builder.
+        // If health is disabled, do not add anything to the builder.
     }
 
     public void closeQuietly() {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -322,7 +322,7 @@ public class KafkaSource<K, V> {
             }
         }
 
-        // If health is disable do not add anything to the builder.
+        // If health is disabled, do not add anything to the builder.
     }
 
     public void isReady(HealthReport.HealthReportBuilder builder) {
@@ -330,7 +330,7 @@ public class KafkaSource<K, V> {
         if (health != null && configuration.getHealthReadinessEnabled()) {
             health.isReady(builder);
         }
-        // If health is disable do not add anything to the builder.
+        // If health is disabled, do not add anything to the builder.
     }
 
     public void isStarted(HealthReport.HealthReportBuilder builder) {
@@ -338,7 +338,7 @@ public class KafkaSource<K, V> {
         if (health != null) {
             health.isStarted(builder);
         }
-        // If health is disable do not add anything to the builder.
+        // If health is disabled, do not add anything to the builder.
     }
 
     /**

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/extension/MediatorManager.java
@@ -200,6 +200,8 @@ public class MediatorManager {
         }
 
         graph.materialize(registry);
+
+        health.markInitialized();
     }
 
 }


### PR DESCRIPTION
In case a connector is present (on classpath), it is always
instantiated. That is because connectors are CDI beans and they
are all injected into `ConfiguredChannelFactory`.

(Actually `ConfiguredChannelFactory` injects  implementations of
`IncomingConnectorFactory` and `OutgoingConnectorFactory`, but
those are typically connectors.)

For that reason, a connector may easily exist even if there are
no channels configured for it. Alternatively, channels may be
configured for a connector, but may all be disabled at runtime
via configuration.

In such case, health must not report "down", because this is
a perfectly normal situation (as we've just established).

The Kafka implementation of health used to check whether
at least one channel is present, and if not, its health
would report "down". This is to make sure that we don't
accidentally report "up" before the channels are correctly
initialized.

In this commit, we handle in-progress initialization globally,
by always returning "down" until `MediatorManager.start()`
finishes successfully. The connectors should no longer care
about this case and should only report health of their
existing channels.