### PR TITLE
small improvements to Kafka documentation

### DIFF
--- a/documentation/src/main/doc/modules/kafka/pages/client-service.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/client-service.adoc
@@ -1,5 +1,5 @@
 [#kafka-client-service]
-=== KafkaClientService
+== KafkaClientService
 
 For advanced use cases, SmallRye Reactive Messaging provides a bean of type `KafkaClientService` that you can inject:
 

--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -272,11 +272,17 @@ If the record is a structured Cloud Event, the created Message's payload is the 
 
 The `partitionkey` attribute is mapped to the record's key if any.
 
+include::consumer-rebalance-listener.adoc[]
 
 === Configuration Reference
 
 include::connectors:partial$META-INF/connector/smallrye-kafka-incoming.adoc[]
 
-You can also pass any property supported by the https://vertx.io/docs/vertx-kafka-client/java/[Vert.x Kafka client] as attribute.
+You can also pass any property supported by the underlying https://kafka.apache.org/documentation/#consumerconfigs[Kafka consumer].
 
-include::consumer-rebalance-listener.adoc[]
+For example, to configure the `max.poll.records` property, use:
+
+[source,properties]
+----
+mp.messaging.incoming.[channel].max.poll.records=1000
+----

--- a/documentation/src/main/doc/modules/kafka/pages/kafka.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/kafka.adoc
@@ -3,8 +3,6 @@
 The Kafka connector adds support for Kafka to Reactive Messaging.
 With it you can receive Kafka Records as well as write `message` into Kafka.
 
-The Kafka Connector is based on the https://vertx.io/docs/vertx-kafka-client/java/[Vert.x Kafka Client].
-
 == Introduction
 
 https://kafka.apache.org/[Apache Kafka] is a popular distributed streaming platform.
@@ -25,6 +23,5 @@ include::outbound.adoc[]
 include::default-configuration.adoc[]
 include::avro-configuration.adoc[]
 include::health.adoc[]
-include::consumer-rebalance-listener.adoc[]
 include::client-service.adoc[]
 include::kerberos.adoc[]

--- a/documentation/src/main/doc/modules/kafka/pages/kerberos.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/kerberos.adoc
@@ -1,5 +1,5 @@
 [#kafka-kerberos]
-=== Kerberos authentication
+== Kerberos authentication
 
 When using https://en.wikipedia.org/wiki/Kerberos_(protocol)[Kerberos] authentication, you need to configure the connector with:
 

--- a/documentation/src/main/doc/modules/kafka/pages/outbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/outbound.adoc
@@ -187,4 +187,11 @@ Any possible metadata attached through `Message<ProducerRecord<K, V>>` are ignor
 
 include::connectors:partial$META-INF/connector/smallrye-kafka-outgoing.adoc[]
 
-You can also pass any property supported by the https://vertx.io/docs/vertx-kafka-client/java/[Vert.x Kafka client].
+You can also pass any property supported by the underlying https://kafka.apache.org/documentation/#producerconfigs[Kafka producer].
+
+For example, to configure the `batch.size` property, use:
+
+[source,properties]
+----
+mp.messaging.outgoing.[channel].batch.size=32768
+----


### PR DESCRIPTION
- the Kafka connector is no longer based on the Vert.x Kafka client
- add examples of passing other Kafka configuration properties,
  both for consumer and producer
- remove duplicate insertion of the rebalance listener section,
  the section is now only present once