### PR TITLE
Fail by default on deserialization issues

### DIFF
--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -133,6 +133,10 @@ Type: _string_ | false |
 
 Type: _string_ | false | 
 
+| *fail-on-deserialization-failure* | When no deserialization failure handler is set and a deserialization failure happens, report the failure and mark the application as unhealthy. If set to `false` and a deserialization failure happens, a `null` value is forwarded.
+
+Type: _boolean_ | false | `true`
+
 | *graceful-shutdown* | Whether or not a graceful shutdown should be attempted when the application terminates.
 
 Type: _boolean_ | false | `true`

--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -201,8 +201,6 @@ public void consume(String v) {
 
 Because deserialization happens before creating a `Message`, the failure strategy presented above cannot be applied.
 However, when a deserialization failure occurs, you can intercept it and provide a fallback value.
-If you don't, `null` will be used as fallback value.
-
 To achieve this, create a CDI bean implementing the {javadoc-base}/io/smallrye/reactive/messaging/kafka/DeserializationFailureHandler.html[DeserializationFailureHandler<T>] interface:
 
 [source, java]
@@ -228,8 +226,11 @@ Then, in the connector configuration, specify the following attribute:
 * `mp.messaging.incoming.$channel.value-deserialization-failure-handler`: name of the bean handling deserialization failures happening for the record's value,
 
 The handler is called with the record's topic, a boolean indicating whether the failure happened on a key, the class name of the deserializer that throws the exception, the corrupted data, the exception, and the records headers augmented with headers describing the failure (which ease the write to a dead letter).
-The handler can return `null` (which would be as if there were no handlers).
-However, if the handler throws an exception, the application would be marked unhealthy.
+The handler can return `null`.
+
+If you don't configure a deserialization failure handlers and a deserialization failure happens, the application is marked unhealthy.
+You can also ignore the failure, which will log the exception and produce a `null` value.
+To enable this behavior, set the `mp.messaging.incoming.$channel.fail-on-deserialization-failure` attribute to `false`.
 
 === Receiving Cloud Events
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -1,5 +1,6 @@
 package io.smallrye.reactive.messaging.kafka;
 
+import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.INCOMING;
 import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.OUTGOING;
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
@@ -87,6 +88,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "consumer-rebalance-listener.name", type = "string", direction = Direction.INCOMING, description = "The name set in `@Identifier` of a bean that implements `io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener`. If set, this rebalance listener is applied to the consumer.")
 @ConnectorAttribute(name = "key-deserialization-failure-handler", type = "string", direction = Direction.INCOMING, description = "The name set in `@Identifier` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing keys are delegated to this handler which may provide a fallback value.")
 @ConnectorAttribute(name = "value-deserialization-failure-handler", type = "string", direction = Direction.INCOMING, description = "The name set in `@Identifier` of a bean that implements `io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler`. If set, deserialization failure happening when deserializing values are delegated to this handler which may provide a fallback value.")
+@ConnectorAttribute(name = "fail-on-deserialization-failure", type = "boolean", direction = INCOMING, description = "When no deserialization failure handler is set and a deserialization failure happens, report the failure and mark the application as unhealthy. If set to `false` and a deserialization failure happens, a `null` value is forwarded.", defaultValue = "true")
 @ConnectorAttribute(name = "graceful-shutdown", type = "boolean", direction = Direction.INCOMING, description = "Whether or not a graceful shutdown should be attempted when the application terminates.", defaultValue = "true")
 @ConnectorAttribute(name = "poll-timeout", type = "int", direction = Direction.INCOMING, description = "The polling timeout in milliseconds. When polling records, the poll will wait at most that duration before returning records. Default is 1000ms", defaultValue = "1000")
 @ConnectorAttribute(name = "pause-if-no-requests", type = "boolean", direction = Direction.INCOMING, description = "Whether the polling must be paused when the application does not request items and resume when it does. This allows implementing back-pressure based on the application capacity. Note that polling is not stopped, but will not retrieve any records when paused.", defaultValue = "true")

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ConfigurationCleaner.java
@@ -59,6 +59,7 @@ public class ConfigurationCleaner {
             "consumer-rebalance-listener.name",
             "key-deserialization-failure-handler",
             "value-deserialization-failure-handler",
+            "fail-on-deserialization-failure",
             "graceful-shutdown",
 
             // Remove most common attributes, may have been configured from the default config

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -171,7 +171,6 @@ public class KafkaSource<K, V> {
             log.failureReportedDuringRebalance(topics, failure);
             return;
         }
-
         log.failureReported(topics, failure);
         // Don't keep all the failures, there are only there for reporting.
         if (failures.size() == 10) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
@@ -66,9 +66,9 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
         }
 
         Deserializer<K> keyDeserializer = new DeserializerWrapper<>(keyDeserializerCN, true,
-                getDeserializationHandler(true, failureHandlers), source);
+                getDeserializationHandler(true, failureHandlers), source, config.getFailOnDeserializationFailure());
         Deserializer<V> valueDeserializer = new DeserializerWrapper<>(valueDeserializerCN, false,
-                getDeserializationHandler(false, failureHandlers), source);
+                getDeserializationHandler(false, failureHandlers), source, config.getFailOnDeserializationFailure());
 
         // Configure the underlying deserializers
         keyDeserializer.configure(kafkaConfiguration, true);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/DeserializationFailureHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/DeserializationFailureHandlerTest.java
@@ -32,7 +32,7 @@ public class DeserializationFailureHandlerTest extends KafkaTestBase {
     static JsonObject fallbackForKey = new JsonObject().put("fallback", "key");
 
     @Test
-    void testWhenNoFailureHandlerIsSet() {
+    void testWhenNoFailureHandlerIsSetAndSkip() {
         MapBasedConfig config = new MapBasedConfig()
                 .with("mp.messaging.incoming.kafka.bootstrap.servers", getBootstrapServers())
                 .with("mp.messaging.incoming.kafka.connector", KafkaConnector.CONNECTOR_NAME)
@@ -41,7 +41,8 @@ public class DeserializationFailureHandlerTest extends KafkaTestBase {
                 .with("mp.messaging.incoming.kafka.auto.offset.reset", "earliest")
                 .with("mp.messaging.incoming.kafka.health-enabled", false)
                 .with("mp.messaging.incoming.kafka.value.deserializer", JsonObjectDeserializer.class.getName())
-                .with("mp.messaging.incoming.kafka.key.deserializer", JsonObjectDeserializer.class.getName());
+                .with("mp.messaging.incoming.kafka.key.deserializer", JsonObjectDeserializer.class.getName())
+                .with("mp.messaging.incoming.kafka.fail-on-deserialization-failure", false);
 
         addBeans(RecordConverter.class);
         MySink sink = runApplication(config, MySink.class);
@@ -58,6 +59,30 @@ public class DeserializationFailureHandlerTest extends KafkaTestBase {
                     assertThat(rec.value()).isNull();
                     assertThat(rec.key()).isEqualTo(key);
                 });
+    }
+
+    @Test
+    void testWhenNoFailureHandlerIsSetAndFail() {
+        MapBasedConfig config = new MapBasedConfig()
+                .with("mp.messaging.incoming.kafka.bootstrap.servers", getBootstrapServers())
+                .with("mp.messaging.incoming.kafka.connector", KafkaConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.kafka.graceful-shutdown", false)
+                .with("mp.messaging.incoming.kafka.topic", topic)
+                .with("mp.messaging.incoming.kafka.auto.offset.reset", "earliest")
+                .with("mp.messaging.incoming.kafka.health-enabled", true)
+                .with("mp.messaging.incoming.kafka.value.deserializer", JsonObjectDeserializer.class.getName())
+                .with("mp.messaging.incoming.kafka.key.deserializer", JsonObjectDeserializer.class.getName());
+
+        addBeans(RecordConverter.class);
+        runApplication(config, MySink.class);
+
+        // Fail for value
+        JsonObject key = new JsonObject().put("key", "key");
+        usage
+                .produce(UUID.randomUUID().toString(), 1, new JsonObjectSerializer(), new DoubleSerializer(),
+                        null, () -> new ProducerRecord<>(topic, key, 698745231.56));
+
+        await().until(() -> !getHealth().getLiveness().isOk());
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/KeyDeserializerConfigurationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/KeyDeserializerConfigurationTest.java
@@ -117,7 +117,8 @@ public class KeyDeserializerConfigurationTest extends KafkaTestBase {
     @Test
     public void testKeyDeserializationFailureWithDeserializerSet() {
         MapBasedConfig config = commonConsumerConfiguration()
-                .with("key.deserializer", JsonObjectDeserializer.class.getName());
+                .with("key.deserializer", JsonObjectDeserializer.class.getName())
+                .with("fail-on-deserialization-failure", false);
         source = new KafkaSource<>(vertx, "my-group",
                 new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);


### PR DESCRIPTION
Fix #1350 - When no deserialization failure handler is set and a deserialization issue happens, propagate the failure and mark the application unhealthy. 
Also add an attribute to ﻿produce `null`  instead of that behavior. Returning `null` is what is happening at the moment. 
