### PR TITLE
Add SSL support to the RabbitMQ connector and document hosted solution configuration

### DIFF
--- a/documentation/src/main/doc/modules/ROOT/nav.adoc
+++ b/documentation/src/main/doc/modules/ROOT/nav.adoc
@@ -62,6 +62,13 @@
 *** xref:mqtt:mqtt.adoc#mqtt-outbound[Sending MQTT Messages]
 *** xref:mqtt-server:mqtt-server.adoc#[Exposing an MQTT server]
 
+** xref:rabbitmq:rabbitmq.adoc[RabbitMQ]
+*** xref:rabbitmq:rabbitmq.adoc#rabbitmq-installation[Using the connector]
+*** xref:rabbitmq:rabbitmq.adoc#rabbitmq-inbound[Receiving Messages from RabbitMQ]
+*** xref:rabbitmq:rabbitmq.adoc#rabbitmq-outbound[Sending Messages to RabbitMQ]
+*** xref:rabbitmq:rabbitmq.adoc#rabbitmq-health[Health Check]
+*** xref:rabbitmq:rabbitmq.adoc#rabbitmq-cloud[Connecting to managed instances]
+
 * xref:emitter/emitter.adoc[Emitters and Channels]
 ** xref:emitter/emitter.adoc#emitter-payloads[Sending payloads]
 ** xref:emitter/emitter.adoc#emitter-messages[Sending messages]

--- a/documentation/src/main/doc/modules/amqp/pages/rabbitmq.adoc
+++ b/documentation/src/main/doc/modules/amqp/pages/rabbitmq.adoc
@@ -32,3 +32,5 @@ mp.messaging.outgoing.generated-price.use-anonymous-sender=false
 ----
 
 As a consequence, it's not possible to change the destination dynamically (using message metadata) when using RabbitMQ.
+
+Alternatively, you can use the xref:rabbitmq:rabbitmq.adoc[RabbitMQ connector].

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-incoming.adoc
@@ -27,6 +27,30 @@ _(rabbitmq-port)_ | The broker port
 
 Type: _int_ | false | `5672`
 
+| *ssl*
+
+_(rabbitmq-ssl)_ | Whether or not the connection should use SSL
+
+Type: _boolean_ | false | `false`
+
+| *trust-all*
+
+_(rabbitmq-trust-all)_ | Whether to skip trust certificate verification
+
+Type: _boolean_ | false | `false`
+
+| *trust-store-path*
+
+_(rabbitmq-trust-store-path)_ | The path to a JKS trust store
+
+Type: _string_ | false | 
+
+| *trust-store-password*
+
+_(rabbitmq-trust-store-password)_ | The password of the JKS trust store
+
+Type: _string_ | false | 
+
 | *connection-timeout* | The TCP connection timeout (ms); 0 is interpreted as no timeout
 
 Type: _int_ | false | `60000`
@@ -79,7 +103,9 @@ Type: _int_ | false | `60`
 
 Type: _boolean_ | false | `false`
 
-| *virtual-host* | The virtual host to use when connecting to the broker
+| *virtual-host*
+
+_(rabbitmq-virtual-host)_ | The virtual host to use when connecting to the broker
 
 Type: _string_ | false | `/`
 

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-outgoing.adoc
@@ -101,6 +101,12 @@ Type: _int_ | false | `2047`
 
 Type: _int_ | false | `60`
 
+| *ssl*
+
+_(rabbitmq-ssl)_ | Whether or not the connection should use SSL
+
+Type: _boolean_ | false | `false`
+
 | *tracing.attribute-headers* | A comma-separated list of headers that should be recorded as span attributes. Relevant only if tracing.enabled=true
 
 Type: _string_ | false | ``
@@ -108,6 +114,24 @@ Type: _string_ | false | ``
 | *tracing.enabled* | Whether tracing is enabled (default) or disabled
 
 Type: _boolean_ | false | `true`
+
+| *trust-all*
+
+_(rabbitmq-trust-all)_ | Whether to skip trust certificate verification
+
+Type: _boolean_ | false | `false`
+
+| *trust-store-password*
+
+_(rabbitmq-trust-store-password)_ | The password of the JKS trust store
+
+Type: _string_ | false | 
+
+| *trust-store-path*
+
+_(rabbitmq-trust-store-path)_ | The path to a JKS trust store
+
+Type: _string_ | false | 
 
 | *use-nio* | Whether usage of NIO Sockets is enabled
 
@@ -123,7 +147,9 @@ _(rabbitmq-username)_ | The username used to authenticate to the broker
 
 Type: _string_ | false | 
 
-| *virtual-host* | The virtual host to use when connecting to the broker
+| *virtual-host*
+
+_(rabbitmq-virtual-host)_ | The virtual host to use when connecting to the broker
 
 Type: _string_ | false | `/`
 

--- a/documentation/src/main/doc/modules/rabbitmq/pages/cloud.adoc
+++ b/documentation/src/main/doc/modules/rabbitmq/pages/cloud.adoc
@@ -1,0 +1,43 @@
+[#rabbitmq-cloud]
+== Connecting to managed instances
+
+This section describes the connector configuration to use managed RabbitMQ instances (hosted on the Cloud).
+
+=== Cloud AMQP
+
+To connect to an instance of RabbitMQ hosted on https://www.cloudamqp.com/[Cloud AMQP], use the following configuration:
+
+[source, properties]
+----
+rabbitmq-host=host-name
+rabbitmq-port=5671
+rabbitmq-username=user-name
+rabbitmq-password=password
+rabbitmq-virtual-host=user-name
+rabbitmq-ssl=true
+----
+
+You can extract the values from the AMQPS url displayed on the administration portal:
+[source]
+amqps://user-name:password@host/user-name
+
+=== Amazon MQ
+
+https://aws.amazon.com/amazon-mq/[Amazon MQ] can host RabbitMQ brokers (as well as AMQP 1.0 brokers).
+To connect to a RabbitMQ instance hosted on Amazon MQ, use the following configuration:
+
+[source, properties]
+----
+rabbitmq-host=host-name
+rabbitmq-port=5671
+rabbitmq-username=user-name
+rabbitmq-password=password
+rabbitmq-ssl=true
+----
+
+You can extract the host value from the AMQPS url displayed on the administration console:
+[source]
+amqps://foobarbaz.mq.us-east-2.amazonaws.com:5671
+
+The username and password are configured during the broker creation.
+

--- a/documentation/src/main/doc/modules/rabbitmq/pages/rabbitmq.adoc
+++ b/documentation/src/main/doc/modules/rabbitmq/pages/rabbitmq.adoc
@@ -20,6 +20,7 @@ include::installation.adoc[]
 include::inbound.adoc[]
 include::outbound.adoc[]
 include::health.adoc[]
+include::cloud.adoc[]
 
 
 

--- a/smallrye-reactive-messaging-rabbitmq/pom.xml
+++ b/smallrye-reactive-messaging-rabbitmq/pom.xml
@@ -74,6 +74,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
           <generatedSourcesDirectory>${project.build.directory}/generated-sources/</generatedSourcesDirectory>
           <annotationProcessors>
@@ -86,17 +87,6 @@
           </annotationProcessors>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <!-- Tests that require test-containers
-                 Enable with -Dtest-containers or -Ptest-containers -->
-            <exclude>**/RabbitMQTest.java</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
@@ -85,6 +85,10 @@ public class OutgoingRabbitMQMetadata {
         return routingKey;
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     /**
      * Allows the builder-style construction of {@link OutgoingRabbitMQMetadata}
      */
@@ -119,7 +123,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds an application id property to the metadata
-         * 
+         *
          * @param appId the application id
          * @return this {@link Builder}
          */
@@ -130,7 +134,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a content encoding property to the metadata
-         * 
+         *
          * @param contentEncoding the MIME content encoding
          * @return this {@link Builder}
          */
@@ -141,7 +145,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a cluster id property to the metadata
-         * 
+         *
          * @param clusterId the cluster id
          * @return this {@link Builder}
          */
@@ -152,7 +156,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a content type property to the metadata
-         * 
+         *
          * @param contentType the MIME content type
          * @return this {@link Builder}
          */
@@ -163,7 +167,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a correlation id property to the metadata
-         * 
+         *
          * @param correlationId the correlation id
          * @return this {@link Builder}
          */
@@ -174,7 +178,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a delivery mode property to the metadata
-         * 
+         *
          * @param deliveryMode the delivery mode; use 1 for non-persistent
          *        and 2 for persistent
          * @return this {@link Builder}
@@ -186,7 +190,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds an expiration property to the metadata
-         * 
+         *
          * @param expiration a string-valued representation of a time (ms)
          * @return this {@link Builder}
          */
@@ -197,7 +201,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a message id property to the metadata
-         * 
+         *
          * @param messageId the message id
          * @return this {@link Builder}
          */
@@ -208,7 +212,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a priority property to the metadata
-         * 
+         *
          * @param priority the priority (value between 0 and 9 inclusive)
          * @return this {@link Builder}
          */
@@ -219,7 +223,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a reply to property to the metadata
-         * 
+         *
          * @param replyTo the address to reply to the message
          * @return this {@link Builder}
          */
@@ -230,7 +234,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a routing key property to the metadata
-         * 
+         *
          * @param routingKey the routing key
          * @return this {@link Builder}
          */
@@ -241,7 +245,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a timestamp property to the metadata
-         * 
+         *
          * @param timestamp a {@link ZonedDateTime} representing the timestamp
          * @return this {@link Builder}
          */
@@ -252,7 +256,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a type property to the metadata
-         * 
+         *
          * @param type the type
          * @return this {@link Builder}
          */
@@ -263,7 +267,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Adds a user id property to the metadata
-         * 
+         *
          * @param userId the user id
          * @return this {@link Builder}
          */
@@ -274,7 +278,7 @@ public class OutgoingRabbitMQMetadata {
 
         /**
          * Returns the built {@link OutgoingRabbitMQMetadata}.
-         * 
+         *
          * @return the outgoing metadata
          */
         public OutgoingRabbitMQMetadata build() {

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
@@ -32,6 +33,8 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
     @AfterEach
     public void cleanup() {
         if (container != null) {
+            container.select(RabbitMQConnector.class, ConnectorLiteral.of(RabbitMQConnector.CONNECTOR_NAME)).get()
+                    .terminate(null);
             container.shutdown();
         }
 
@@ -66,6 +69,7 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
                 .put("mp.messaging.outgoing.sink.tracing.enabled", false)
                 .put("rabbitmq-username", username)
                 .put("rabbitmq-password", password)
+                .put("rabbitmq-reconnect-attempts", 0)
                 .write();
 
         container = weld.initialize();
@@ -121,6 +125,7 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
                 .put("mp.messaging.incoming.data.tracing.enabled", false)
                 .put("rabbitmq-username", username)
                 .put("rabbitmq-password", password)
+                .put("rabbitmq-reconnect-attempts", 0)
                 .write();
 
         container = weld.initialize();
@@ -226,6 +231,7 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
                 .put("mp.messaging.incoming.data.tracing.enabled", false)
                 .put("rabbitmq-username", username)
                 .put("rabbitmq-password", password)
+                .put("rabbitmq-reconnect-attempts", 0)
                 .write();
 
         container = weld.initialize();
@@ -337,6 +343,7 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
                 .put("mp.messaging.outgoing.sink.tracing.enabled", false)
                 .put("rabbitmq-username", username)
                 .put("rabbitmq-password", password)
+                .put("rabbitmq-reconnect-attempts", 0)
                 .write();
 
         container = weld.initialize();
@@ -365,6 +372,7 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
                 .put("mp.messaging.incoming.data.tracing-enabled", false)
                 .put("rabbitmq-username", username)
                 .put("rabbitmq-password", password)
+                .put("rabbitmq-reconnect-attempts", 0)
                 .write();
 
         weld.addBeanClass(ConsumptionBean.class);

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQUsage.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQUsage.java
@@ -49,7 +49,6 @@ public class RabbitMQUsage {
     private final static Logger LOGGER = Logger.getLogger(RabbitMQUsage.class);
     private final RabbitMQClient client;
     private final RabbitMQOptions options;
-    private final Vertx vertx;
     private final int managementPort;
 
     /**
@@ -64,7 +63,6 @@ public class RabbitMQUsage {
      */
     public RabbitMQUsage(final Vertx vertx, final String host, final int port, final int managementPort, final String user,
             final String pwd) {
-        this.vertx = vertx;
         this.managementPort = managementPort;
         this.options = new RabbitMQOptions().setHost(host).setPort(port).setUser(user).setPassword(pwd);
         this.client = RabbitMQClient.create(new Vertx(vertx.getDelegate()), options);
@@ -99,7 +97,7 @@ public class RabbitMQUsage {
                                         LOGGER.infof("Producer sent message %s", payload);
                                         done.countDown();
                                     },
-                                    ex -> ex.printStackTrace());
+                                    Throwable::printStackTrace);
                 }
             } catch (Exception e) {
                 LOGGER.error("Unable to send message", e);
@@ -214,7 +212,7 @@ public class RabbitMQUsage {
     /**
      * Returns the RabbitMQ JSON representation of the bindings between the
      * named exchange and queue..
-     * 
+     *
      * @param exchangeName the name of the exchange
      * @param queueName the name of the queue
      * @return a {@link JsonArray} of binding descriptions


### PR DESCRIPTION
Fix #1338

- Add support for SSL in the RabbitMQ connector
- Extend RabbitMQ configuration to cover the main RabbitMQ hosted solutions
