### PR TITLE
WIP: Fix rebalance issue on load with multiple consumers

### DIFF
--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -101,7 +101,7 @@ Type: _string_ | false | `fail`
 
 Type: _string_ | false | 
 
-| *throttled.unprocessed-record-max-age.ms* | While using the `throttled` commit-strategy, specify the max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy.
+| *throttled.unprocessed-record-max-age.ms* | While using the `throttled` commit-strategy, specify the max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy. Setting this attribute to 0 disables this monitoring.
 
 Type: _int_ | false | `60000`
 

--- a/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
+++ b/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
@@ -104,10 +104,10 @@ public class JmsConnector implements IncomingConnectorFactory, OutgoingConnector
             log.warn(
                     "Please add one of the additional mapping modules (-jsonb or -jackson) to be able to (de)serialize JSON messages.");
         } else if (jsonMapper.isAmbiguous()) {
-            // FIXME: is it sensible? Quarkus should not allow for starting with ambiguous providers available.
             log.warn(
                     "Please select only one of the additional mapping modules (-jsonb or -jackson) to be able to (de)serialize JSON messages.");
-            this.jsonMapping = jsonMapper.stream().findFirst().get();
+            this.jsonMapping = jsonMapper.stream().findFirst()
+                    .orElseThrow(() -> new RuntimeException("Unable to find JSON Mapper"));
         } else {
             this.jsonMapping = jsonMapper.get();
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -81,7 +81,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "auto.offset.reset", type = "string", direction = Direction.INCOMING, description = "What to do when there is no initial offset in Kafka.Accepted values are earliest, latest and none", defaultValue = "latest")
 @ConnectorAttribute(name = "failure-strategy", type = "string", direction = Direction.INCOMING, description = "Specify the failure strategy to apply when a message produced from a record is acknowledged negatively (nack). Values can be `fail` (default), `ignore`, or `dead-letter-queue`", defaultValue = "fail")
 @ConnectorAttribute(name = "commit-strategy", type = "string", direction = Direction.INCOMING, description = "Specify the commit strategy to apply when a message produced from a record is acknowledged. Values can be `latest`, `ignore` or `throttled`. If `enable.auto.commit` is true then the default is `ignore` otherwise it is `throttled`")
-@ConnectorAttribute(name = "throttled.unprocessed-record-max-age.ms", type = "int", direction = Direction.INCOMING, description = "While using the `throttled` commit-strategy, specify the max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy.", defaultValue = "60000")
+@ConnectorAttribute(name = "throttled.unprocessed-record-max-age.ms", type = "int", direction = Direction.INCOMING, description = "While using the `throttled` commit-strategy, specify the max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy. Setting this attribute to 0 disables this monitoring.", defaultValue = "60000")
 @ConnectorAttribute(name = "dead-letter-queue.topic", type = "string", direction = Direction.INCOMING, description = "When the `failure-strategy` is set to `dead-letter-queue` indicates on which topic the record is sent. Defaults is `dead-letter-topic-$channel`")
 @ConnectorAttribute(name = "dead-letter-queue.key.serializer", type = "string", direction = Direction.INCOMING, description = "When the `failure-strategy` is set to `dead-letter-queue` indicates the key serializer to use. If not set the serializer associated to the key deserializer is used")
 @ConnectorAttribute(name = "dead-letter-queue.value.serializer", type = "string", direction = Direction.INCOMING, description = "When the `failure-strategy` is set to `dead-letter-queue` indicates the value serializer to use. If not set the serializer associated to the value deserializer is used")
@@ -360,10 +360,10 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     }
 
     public Set<String> getConsumerChannels() {
-        return sources.stream().map(s -> s.getChannel()).collect(Collectors.toSet());
+        return sources.stream().map(KafkaSource::getChannel).collect(Collectors.toSet());
     }
 
     public Set<String> getProducerChannels() {
-        return sinks.stream().map(s -> s.getChannel()).collect(Collectors.toSet());
+        return sinks.stream().map(KafkaSink::getChannel).collect(Collectors.toSet());
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.TopicPartition;
 
+import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
 
 public interface KafkaCommitHandler {
@@ -31,8 +32,8 @@ public interface KafkaCommitHandler {
 
     }
 
-    default <K, V> IncomingKafkaRecord<K, V> received(IncomingKafkaRecord<K, V> record) {
-        return record;
+    default <K, V> Uni<IncomingKafkaRecord<K, V>> received(IncomingKafkaRecord<K, V> record) {
+        return Uni.createFrom().item(record);
     }
 
     default void terminate(boolean graceful) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -229,7 +229,7 @@ public interface KafkaLogging extends BasicLogger {
     @Message(id = 18250, value = "The configuration property '%s' is deprecated and is replaced by '%s'.")
     void deprecatedConfig(String deprecated, String replace);
 
-    @LogMessage(level = Logger.Level.DEBUG)
+    @LogMessage(level = Logger.Level.INFO)
     @Message(id = 18251, value = "Committed %s")
     void committed(Map<TopicPartition, OffsetAndMetadata> offsets);
 
@@ -248,4 +248,8 @@ public interface KafkaLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 18255, value = "Received a record from topic-partition '%s' at offset %d, while the last committed offset is %d - Ignoring record")
     void receivedOutdatedOffset(TopicPartition topicPartition, long offset, long lastCommitted);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18256, value = "Initialize record store for topic-partition '%s' at position %d.")
+    void initializeStoreAtPosition(TopicPartition topicPartition, long position);
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
@@ -381,4 +381,14 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     boolean isPaused() {
         return paused.get();
     }
+
+    public Uni<Long> getLastCommittedOffset(TopicPartition topicPartition) {
+        return runOnPollingThread(c -> {
+            OffsetAndMetadata committed = c.committed(Collections.singleton(topicPartition)).get(topicPartition);
+            if (committed == null) {
+                return -1L;
+            }
+            return committed.offset();
+        });
+    }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -175,6 +175,7 @@ public class CommitStrategiesTest extends WeldTestBase {
         list.get(0).ack().toCompletableFuture().join();
 
         await().untilAsserted(() -> {
+            System.out.println(consumer.position(tp));
             Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp));
             assertThat(committed.get(tp)).isNotNull();
             assertThat(committed.get(tp).offset()).isEqualTo(1);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -164,6 +164,8 @@ public class CommitStrategiesTest extends WeldTestBase {
 
         consumer.schedulePollTask(() -> {
             consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+            // The mock consumer does not call the rebalance callback - we must do it explicitly
+            source.getCommitHandler().partitionsAssigned(Collections.singletonList(new TopicPartition(TOPIC, 0)));
             consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v0"));
         });
 
@@ -349,7 +351,7 @@ public class CommitStrategiesTest extends WeldTestBase {
 
         HealthReport r = report.get();
         String message = r.getChannels().get(0).getMessage();
-        assertThat(message).contains("my-topic", "partition:1", "9");
+        assertThat(message).contains("my-topic-1", "9");
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/DeprecatedCommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/DeprecatedCommitStrategiesTest.java
@@ -372,7 +372,7 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
 
         HealthReport r = report.get();
         String message = r.getChannels().get(0).getMessage();
-        assertThat(message).contains("my-topic", "partition:1", "9");
+        assertThat(message).contains("my-topic-1", "9");
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
@@ -153,6 +153,7 @@ public class KafkaCommitHandlerTest extends KafkaTestBase {
         MapBasedConfig config = newCommonConfigForSource()
                 .with("client.id", UUID.randomUUID().toString())
                 .with("group.id", "test-source-with-throttled-latest-processed-commit")
+                .with("auto.offset.reset", "earliest")
                 .with("value.deserializer", IntegerDeserializer.class.getName())
                 .with("commit-strategy", "throttled")
                 .with("throttled.unprocessed-record-max-age.ms", 100);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/RebalanceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/RebalanceTest.java
@@ -110,7 +110,7 @@ public class RebalanceTest extends WeldTestBase {
                         new ConsumerRecord<>(TOPIC, 1, i, "r", "v1-" + i),
                         source.getCommitHandler(),
                         null, false, false);
-                source.getCommitHandler().received(r);
+                source.getCommitHandler().received(r).subscribeAsCompletionStage();
             }
         });
 

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -7,10 +7,7 @@ import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions.ex
 import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 import static java.time.Duration.ofSeconds;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
@@ -315,9 +312,10 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
                 .setVirtualHost(config.getVirtualHost());
 
         // JKS TrustStore
-        if (config.getTrustStorePath().isPresent()) {
+        Optional<String> trustStorePath = config.getTrustStorePath();
+        if (trustStorePath.isPresent()) {
             JksOptions jks = new JksOptions();
-            jks.setPath(config.getTrustStorePath().get());
+            jks.setPath(trustStorePath.get());
             config.getTrustStorePassword().ifPresent(jks::setPassword);
             rabbitMQClientConfig.setTrustStoreOptions(jks);
         }


### PR DESCRIPTION
- Fix client id generation when using multiple consumer (using the partitions attribute)
- Extend description of the throttled.unprocessed-record-max-age.ms attribute to indicate how to disable the monitoring.
- Improve tracking and cleanup of the throttled commit strategy
