### PR TITLE
Fix Kafka throttled commit strategy rebalance issue on load with multiple partitions

### DIFF
--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-kafka-incoming.adoc
@@ -101,7 +101,7 @@ Type: _string_ | false | `fail`
 
 Type: _string_ | false | 
 
-| [.no-hyphens]#*throttled.unprocessed-record-max-age.ms*# | While using the `throttled` commit-strategy, specify the max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy.
+| [.no-hyphens]#*throttled.unprocessed-record-max-age.ms*# | While using the `throttled` commit-strategy, specify the max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy. Setting this attribute to 0 disables this monitoring.
 
 Type: _int_ | false | `60000`
 

--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -287,3 +287,14 @@ For example, to configure the `max.poll.records` property, use:
 ----
 mp.messaging.incoming.[channel].max.poll.records=1000
 ----
+
+Some consumer client properties are configured to sensible default values:
+
+If not set, `reconnect.backoff.max.ms` is set to `10000` to avoid high load on disconnection.
+
+If not set, `key.deserializer` is set to `org.apache.kafka.common.serialization.StringDeserializer`.
+
+The consumer `client.id` is configured according to the number of clients to create using `mp.messaging.incoming.[channel].partitions` property.
+
+- If a `client.id` is provided, it is used as-is or suffixed with client index if `partitions` property is set.
+- If a `client.id` is not provided, it is generated as `kafka-consumer-[channel][-index]`.

--- a/documentation/src/main/doc/modules/kafka/pages/outbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/outbound.adoc
@@ -195,3 +195,11 @@ For example, to configure the `batch.size` property, use:
 ----
 mp.messaging.outgoing.[channel].batch.size=32768
 ----
+
+Some producer client properties are configured to sensible default values:
+
+If not set, `reconnect.backoff.max.ms` is set to `10000` to avoid high load on disconnection.
+
+If not set, `key.serializer` is set to `org.apache.kafka.common.serialization.StringSerializer`.
+
+If not set, producer `client.id` is generated as `kafka-producer-[channel]`.

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -81,7 +81,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "auto.offset.reset", type = "string", direction = Direction.INCOMING, description = "What to do when there is no initial offset in Kafka.Accepted values are earliest, latest and none", defaultValue = "latest")
 @ConnectorAttribute(name = "failure-strategy", type = "string", direction = Direction.INCOMING, description = "Specify the failure strategy to apply when a message produced from a record is acknowledged negatively (nack). Values can be `fail` (default), `ignore`, or `dead-letter-queue`", defaultValue = "fail")
 @ConnectorAttribute(name = "commit-strategy", type = "string", direction = Direction.INCOMING, description = "Specify the commit strategy to apply when a message produced from a record is acknowledged. Values can be `latest`, `ignore` or `throttled`. If `enable.auto.commit` is true then the default is `ignore` otherwise it is `throttled`")
-@ConnectorAttribute(name = "throttled.unprocessed-record-max-age.ms", type = "int", direction = Direction.INCOMING, description = "While using the `throttled` commit-strategy, specify the max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy.", defaultValue = "60000")
+@ConnectorAttribute(name = "throttled.unprocessed-record-max-age.ms", type = "int", direction = Direction.INCOMING, description = "While using the `throttled` commit-strategy, specify the max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy. Setting this attribute to 0 disables this monitoring.", defaultValue = "60000")
 @ConnectorAttribute(name = "dead-letter-queue.topic", type = "string", direction = Direction.INCOMING, description = "When the `failure-strategy` is set to `dead-letter-queue` indicates on which topic the record is sent. Defaults is `dead-letter-topic-$channel`")
 @ConnectorAttribute(name = "dead-letter-queue.key.serializer", type = "string", direction = Direction.INCOMING, description = "When the `failure-strategy` is set to `dead-letter-queue` indicates the key serializer to use. If not set the serializer associated to the key deserializer is used")
 @ConnectorAttribute(name = "dead-letter-queue.value.serializer", type = "string", direction = Direction.INCOMING, description = "When the `failure-strategy` is set to `dead-letter-queue` indicates the value serializer to use. If not set the serializer associated to the value deserializer is used")
@@ -360,10 +360,10 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
     }
 
     public Set<String> getConsumerChannels() {
-        return sources.stream().map(s -> s.getChannel()).collect(Collectors.toSet());
+        return sources.stream().map(KafkaSource::getChannel).collect(Collectors.toSet());
     }
 
     public Set<String> getProducerChannels() {
-        return sinks.stream().map(s -> s.getChannel()).collect(Collectors.toSet());
+        return sinks.stream().map(KafkaSink::getChannel).collect(Collectors.toSet());
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.TopicPartition;
 
+import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
 
 public interface KafkaCommitHandler {
@@ -31,8 +32,8 @@ public interface KafkaCommitHandler {
 
     }
 
-    default <K, V> IncomingKafkaRecord<K, V> received(IncomingKafkaRecord<K, V> record) {
-        return record;
+    default <K, V> Uni<IncomingKafkaRecord<K, V>> received(IncomingKafkaRecord<K, V> record) {
+        return Uni.createFrom().item(record);
     }
 
     default void terminate(boolean graceful) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -229,7 +229,7 @@ public interface KafkaLogging extends BasicLogger {
     @Message(id = 18250, value = "The configuration property '%s' is deprecated and is replaced by '%s'.")
     void deprecatedConfig(String deprecated, String replace);
 
-    @LogMessage(level = Logger.Level.DEBUG)
+    @LogMessage(level = Logger.Level.INFO)
     @Message(id = 18251, value = "Committed %s")
     void committed(Map<TopicPartition, OffsetAndMetadata> offsets);
 
@@ -248,4 +248,8 @@ public interface KafkaLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 18255, value = "Received a record from topic-partition '%s' at offset %d, while the last committed offset is %d - Ignoring record")
     void receivedOutdatedOffset(TopicPartition topicPartition, long offset, long lastCommitted);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 18256, value = "Initialize record store for topic-partition '%s' at position %d.")
+    void initializeStoreAtPosition(TopicPartition topicPartition, long position);
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/PauseResumeTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/PauseResumeTest.java
@@ -83,9 +83,6 @@ public class PauseResumeTest extends WeldTestBase {
         // two messages in the buffer, first one is delivered
         await().until(() -> subscriber.getItems().size() == 1);
 
-        // 2 >= 2 (maxBufferSize) -> paused
-        await().until(() -> !consumer.paused().isEmpty());
-
         // request 1, delivered one more record
         subscriber.request(1);
         await().until(() -> subscriber.getItems().size() == 2);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/SourceBackPressureWithBrokerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/SourceBackPressureWithBrokerTest.java
@@ -71,8 +71,8 @@ public class SourceBackPressureWithBrokerTest extends KafkaTestBase {
         await().until(() -> bean.request(2));
 
         AtomicInteger counter = new AtomicInteger();
-        new Thread(() -> usage.produceStrings(10, null,
-                () -> new ProducerRecord<>(topic, "" + counter.getAndIncrement()))).start();
+        usage.produceStrings(10, null,
+                () -> new ProducerRecord<>(topic, "" + counter.getAndIncrement()));
 
         await().until(() -> list.size() == 2);
         await().until(() -> consumer.paused().await().atMost(Duration.ofSeconds(3)).size() > 0);
@@ -97,12 +97,10 @@ public class SourceBackPressureWithBrokerTest extends KafkaTestBase {
         List<String> list = bean.list();
         assertThat(list).isEmpty();
         AtomicInteger counter = new AtomicInteger();
-        new Thread(() -> usage.produceStrings(5, null,
-                () -> new ProducerRecord<>(topic, "" + counter.getAndIncrement()))).start();
+        usage.produceStrings(5, null,
+                () -> new ProducerRecord<>(topic, "" + counter.getAndIncrement()));
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 2);
-
-        await().until(() -> !consumer.paused().await().atMost(Duration.ofSeconds(3)).isEmpty());
 
         await()
                 .pollInterval(Duration.ofMillis(10))

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -164,6 +164,8 @@ public class CommitStrategiesTest extends WeldTestBase {
 
         consumer.schedulePollTask(() -> {
             consumer.rebalance(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+            // The mock consumer does not call the rebalance callback - we must do it explicitly
+            source.getCommitHandler().partitionsAssigned(Collections.singletonList(new TopicPartition(TOPIC, 0)));
             consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, "k", "v0"));
         });
 
@@ -349,7 +351,7 @@ public class CommitStrategiesTest extends WeldTestBase {
 
         HealthReport r = report.get();
         String message = r.getChannels().get(0).getMessage();
-        assertThat(message).contains("my-topic", "partition:1", "9");
+        assertThat(message).contains("my-topic-1", "9");
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/DeprecatedCommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/DeprecatedCommitStrategiesTest.java
@@ -372,7 +372,7 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
 
         HealthReport r = report.get();
         String message = r.getChannels().get(0).getMessage();
-        assertThat(message).contains("my-topic", "partition:1", "9");
+        assertThat(message).contains("my-topic-1", "9");
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/PartitionTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/PartitionTest.java
@@ -6,6 +6,7 @@ import static org.awaitility.Awaitility.await;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -28,7 +29,7 @@ import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 public class PartitionTest extends KafkaTestBase {
 
     @Test
-    public void testWithPartitions() {
+    public void testWithPartitions() throws InterruptedException {
         createTopic(topic, 3);
         String groupId = UUID.randomUUID().toString();
 
@@ -46,11 +47,14 @@ public class PartitionTest extends KafkaTestBase {
         AtomicInteger count = new AtomicInteger();
         int expected = 3000;
         Random random = new Random();
-        usage.produce(topic, expected, new StringSerializer(), new StringSerializer(), null, () -> {
+        CountDownLatch latch = new CountDownLatch(1);
+        usage.produce(topic, expected, new StringSerializer(), new StringSerializer(), latch::countDown, () -> {
             int value = count.getAndIncrement();
             int p = random.nextInt(3);
             return new ProducerRecord<>(topic, p, Integer.toString(p), Integer.toString(value));
         });
+
+        assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
 
         await()
                 .atMost(30, TimeUnit.SECONDS)
@@ -70,7 +74,7 @@ public class PartitionTest extends KafkaTestBase {
     }
 
     @Test
-    public void testWithMoreConsumersThanPartitions() {
+    public void testWithMoreConsumersThanPartitions() throws InterruptedException {
         createTopic(topic, 3);
         String groupId = UUID.randomUUID().toString();
         MapBasedConfig config = new MapBasedConfig()
@@ -87,11 +91,14 @@ public class PartitionTest extends KafkaTestBase {
         AtomicInteger count = new AtomicInteger();
         int expected = 3000;
         Random random = new Random();
-        usage.produce(topic, expected, new StringSerializer(), new StringSerializer(), null, () -> {
+        CountDownLatch latch = new CountDownLatch(1);
+        usage.produce(topic, expected, new StringSerializer(), new StringSerializer(), latch::countDown, () -> {
             int value = count.getAndIncrement();
             int p = random.nextInt(3);
             return new ProducerRecord<>(topic, p, Integer.toString(p), Integer.toString(value));
         });
+
+        assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
 
         await()
                 .atMost(30, TimeUnit.SECONDS)
@@ -111,7 +118,7 @@ public class PartitionTest extends KafkaTestBase {
     }
 
     @Test
-    public void testWithMorePartitionsThanConsumers() {
+    public void testWithMorePartitionsThanConsumers() throws InterruptedException {
         createTopic(topic, 3);
         String groupId = UUID.randomUUID().toString();
 
@@ -129,11 +136,14 @@ public class PartitionTest extends KafkaTestBase {
         AtomicInteger count = new AtomicInteger();
         int expected = 3000;
         Random random = new Random();
-        usage.produce(topic, expected, new StringSerializer(), new StringSerializer(), null, () -> {
+        CountDownLatch latch = new CountDownLatch(1);
+        usage.produce(topic, expected, new StringSerializer(), new StringSerializer(), latch::countDown, () -> {
             int value = count.getAndIncrement();
             int p = random.nextInt(3);
             return new ProducerRecord<>(topic, p, Integer.toString(p), Integer.toString(value));
         });
+
+        assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
 
         await()
                 .atMost(30, TimeUnit.SECONDS)

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/RebalanceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/RebalanceTest.java
@@ -110,7 +110,7 @@ public class RebalanceTest extends WeldTestBase {
                         new ConsumerRecord<>(TOPIC, 1, i, "r", "v1-" + i),
                         source.getCommitHandler(),
                         null, false, false);
-                source.getCommitHandler().received(r);
+                source.getCommitHandler().received(r).subscribeAsCompletionStage();
             }
         });
 


### PR DESCRIPTION
Throttled commit strategy for Kafka connector didn't pick up from where it left off after a rebalance between multiple consumers in a group.

With this PR
- Fix client id generation with multiple partitions
- Extend description of the throttled.unprocessed-record-max-age.ms attribute to indicate how to disable the monitoring.
- Fix elapsed time logging unprocessed messages waiting for acknowledgment for too long
- Improved logging for throttled commit strategy
- Offset store for throttled commit strategy uses `KafkaConsumer#committed` to receive the last committed offset for a partition. After a rebalance a consumer can receive records that are already processed (and committed). These duplicates need to be cleared from the offset store until the last processed record offset (committed offset - 1).
