### PR TITLE
Improve Emitter error handling

### DIFF
--- a/documentation/src/main/doc/modules/ROOT/pages/emitter/emitter.adoc
+++ b/documentation/src/main/doc/modules/ROOT/pages/emitter/emitter.adoc
@@ -99,6 +99,25 @@ emitted by the emitter are ignored.
 * `OnOverflow.Strategy.LATEST` - keeps only the latest value, dropping any previous value if the downstream can't keep up.
 * `OnOverflow.Strategy.NONE` - ignore the back-pressure signals letting the downstream consumer to implement a strategy.
 
+=== Defensive emission
+
+Having an emitter injected into your code does not guarantee that someone is ready to consume the message.
+For example, a subscriber may be connecting to a remote broker.
+If there are no subscribers, using the `send` method will throw an exception.
+
+The `emitter.hasRequests()` method indicates that a subscriber subscribes to the channel and requested items.
+So, you can wrap your emission with:
+
+[source, java]
+----
+if (emitter.hasRequests()) {
+    emitter.send("hello");
+}
+----
+
+If you use the `OnOverflow.Strategy.DROP`, you can use the `send` method even with no subscribers nor demands.
+The message will be nacked immediately.
+
 [#streams]
 == Retrieving channels
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/helpers/NoStackTraceException.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/helpers/NoStackTraceException.java
@@ -1,0 +1,17 @@
+package io.smallrye.reactive.messaging.helpers;
+
+/**
+ * An exception that does not capture the stack trace.
+ * Useful to nack messages without having to have to capture the stack trace.
+ */
+public class NoStackTraceException extends Exception {
+
+    public NoStackTraceException(String msg) {
+        super(msg);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderExceptions.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/i18n/ProviderExceptions.java
@@ -110,8 +110,10 @@ public interface ProviderExceptions {
     @Message(id = 26, value = "The emitter encountered a failure while emitting")
     IllegalStateException illegalStateForEmitterWhileEmitting(@Cause Throwable throwable);
 
-    @Message(id = 27, value = "No subscriber found for the channel %s")
-    IllegalStateException illegalStateForNoSubscriber(String name);
+    @Message(id = 27, value = "Cannot send a message, there is no subscriber found for the channel '%s'. " +
+            "Before calling `send`, you can verify there is a subscriber and demands using `emitter.hasRequests()`. " +
+            "Alternatively, you can add `@OnOverflow(OnOverflow.Strategy.DROP)` on the emitter.")
+    IllegalStateException noEmitterForChannel(String name);
 
     @Message(id = 28, value = "The subscription to %s has been cancelled")
     IllegalStateException illegalStateForCancelledSubscriber(String name);

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/InjectionWithoutSubscriberTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/InjectionWithoutSubscriberTest.java
@@ -1,0 +1,250 @@
+package io.smallrye.reactive.messaging.inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.smallrye.reactive.messaging.helpers.NoStackTraceException;
+
+public class InjectionWithoutSubscriberTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testWithoutSubscriber() {
+        addBeanClass(AppWithChannel.class);
+        AppWithChannel app = installInitializeAndGet(AppWithChannel.class);
+
+        List<String> list = new CopyOnWriteArrayList<>();
+        assertThat(app.emitter().hasRequests()).isFalse();
+        assertThatThrownBy(() -> app.emitter().send("hello"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no subscriber");
+
+        assertThatThrownBy(() -> app.emitter().send(Message.of("test",
+                () -> CompletableFuture.completedFuture(null),
+                t -> CompletableFuture.completedFuture(null))))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("no subscriber");
+
+        app.channel().subscribe().with(list::add);
+
+        assertThat(app.emitter().hasRequests()).isTrue();
+        app.emitter().send("hello").toCompletableFuture().join();
+        app.emitter().send("hello").toCompletableFuture().join();
+        app.emitter().send("hello").toCompletableFuture().join();
+
+        assertThat(list).hasSize(3);
+
+    }
+
+    @Test
+    public void testWithoutSubscriberWithMutinyEmitter() {
+        addBeanClass(MutinyAppWithChannel.class);
+        MutinyAppWithChannel app = installInitializeAndGet(MutinyAppWithChannel.class);
+
+        List<String> list = new CopyOnWriteArrayList<>();
+        assertThat(app.emitter().hasRequests()).isFalse();
+        assertThatThrownBy(() -> app.emitter().send("hello").await().indefinitely())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no subscriber");
+
+        AtomicBoolean acked = new AtomicBoolean();
+        AtomicBoolean nacked = new AtomicBoolean();
+        app.emitter().send(Message.of("test",
+                () -> {
+                    acked.set(true);
+                    return CompletableFuture.completedFuture(null);
+                },
+                t -> {
+                    nacked.set(true);
+                    return CompletableFuture.completedFuture(null);
+                }));
+        assertThat(acked).isFalse();
+        assertThat(nacked).isTrue();
+
+        app.channel().subscribe().with(list::add);
+
+        assertThat(app.emitter().hasRequests()).isTrue();
+        app.emitter().send("hello").await().indefinitely();
+        app.emitter().send("hello").await().indefinitely();
+        app.emitter().send("hello").await().indefinitely();
+
+        assertThat(list).hasSize(3);
+
+    }
+
+    @Test
+    public void testWithoutSubscriberButDropOverflow() {
+        addBeanClass(AppWithChannelAndOverflow.class);
+        AppWithChannelAndOverflow app = installInitializeAndGet(AppWithChannelAndOverflow.class);
+
+        List<String> list = new CopyOnWriteArrayList<>();
+        assertThat(app.emitter().hasRequests()).isFalse();
+
+        app.emitter().send("ok");
+
+        assertThatThrownBy(() -> app.emitter().send("fail because of nack").toCompletableFuture().join())
+                .hasCauseInstanceOf(NoStackTraceException.class)
+                .hasMessageContaining("Unable to process message");
+
+        AtomicBoolean acked = new AtomicBoolean();
+        AtomicBoolean nacked = new AtomicBoolean();
+        app.emitter().send(Message.of("test",
+                () -> {
+                    acked.set(true);
+                    return CompletableFuture.completedFuture(null);
+                },
+                t -> {
+                    nacked.set(true);
+                    return CompletableFuture.completedFuture(null);
+                }));
+        assertThat(acked).isFalse();
+        assertThat(nacked).isTrue();
+
+        app.channel().subscribe().with(list::add);
+
+        assertThat(app.emitter().hasRequests()).isTrue();
+        app.emitter().send("hello").toCompletableFuture().join();
+        app.emitter().send("hello").toCompletableFuture().join();
+        app.emitter().send("hello").toCompletableFuture().join();
+
+        assertThat(list).hasSize(3);
+
+    }
+
+    @Test
+    public void testWithoutSubscriberButDropOverflowAndUsingMutinyEmitter() {
+        addBeanClass(MutinyAppWithChannelAndOverflow.class);
+        MutinyAppWithChannelAndOverflow app = installInitializeAndGet(MutinyAppWithChannelAndOverflow.class);
+
+        List<String> list = new CopyOnWriteArrayList<>();
+        assertThat(app.emitter().hasRequests()).isFalse();
+
+        app.emitter().send("ok");
+
+        assertThatThrownBy(() -> app.emitter().send("fail because of nack").await().indefinitely())
+                .hasCauseInstanceOf(NoStackTraceException.class)
+                .hasMessageContaining("Unable to process message");
+
+        AtomicBoolean acked = new AtomicBoolean();
+        AtomicBoolean nacked = new AtomicBoolean();
+        app.emitter().send(Message.of("test",
+                () -> {
+                    acked.set(true);
+                    return CompletableFuture.completedFuture(null);
+                },
+                t -> {
+                    nacked.set(true);
+                    return CompletableFuture.completedFuture(null);
+                }));
+        assertThat(acked).isFalse();
+        assertThat(nacked).isTrue();
+
+        app.channel().subscribe().with(list::add);
+
+        assertThat(app.emitter().hasRequests()).isTrue();
+        app.emitter().send("hello").await().indefinitely();
+        app.emitter().send("hello").await().indefinitely();
+        app.emitter().send("hello").await().indefinitely();
+
+        assertThat(list).hasSize(3);
+
+    }
+
+    @ApplicationScoped
+    public static class AppWithChannel {
+
+        @Inject
+        @Channel("foo")
+        Emitter<String> emitter;
+
+        @Inject
+        @Channel("foo")
+        Multi<String> channel;
+
+        public Multi<String> channel() {
+            return channel;
+        }
+
+        public Emitter<String> emitter() {
+            return emitter;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MutinyAppWithChannel {
+
+        @Inject
+        @Channel("foo")
+        MutinyEmitter<String> emitter;
+
+        @Inject
+        @Channel("foo")
+        Multi<String> channel;
+
+        public Multi<String> channel() {
+            return channel;
+        }
+
+        public MutinyEmitter<String> emitter() {
+            return emitter;
+        }
+    }
+
+    @ApplicationScoped
+    public static class AppWithChannelAndOverflow {
+
+        @Inject
+        @Channel("foo")
+        @OnOverflow(OnOverflow.Strategy.DROP)
+        Emitter<String> emitter;
+
+        @Inject
+        @Channel("foo")
+        Multi<String> channel;
+
+        public Multi<String> channel() {
+            return channel;
+        }
+
+        public Emitter<String> emitter() {
+            return emitter;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MutinyAppWithChannelAndOverflow {
+
+        @Inject
+        @Channel("foo")
+        @OnOverflow(OnOverflow.Strategy.DROP)
+        MutinyEmitter<String> emitter;
+
+        @Inject
+        @Channel("foo")
+        Multi<String> channel;
+
+        public Multi<String> channel() {
+            return channel;
+        }
+
+        public MutinyEmitter<String> emitter() {
+            return emitter;
+        }
+    }
+}


### PR DESCRIPTION
Also, when the emitter uses @OnOverflow(DROP), the message would be dropped anyway, so in this case, it nacks the message but does not throw an error.

This commit also documents the hasRequests method.

Related to https://github.com/quarkusio/quarkus/issues/19940
