### PR TITLE
Clear queue of kafka records from revoked partitions

### DIFF
--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -99,7 +99,7 @@ However, it reduces the risk of duplicates.
 * `ignore` performs no commit.
 This strategy is the default strategy when the consumer is explicitly configured with `enable.auto.commit` to `true`.
 It delegates the offset commit to the Kafka client.
-When `enable.auto.commit` is `true` this strategy DOES NOT guarantee at-least-once delivery.
+When `enable.auto.commit` is `true` this strategy **DOES NOT** guarantee at-least-once delivery.
 However, if the processing failed between two commits, messages received after the commit and before the failure will be re-processed.
 
 IMPORTANT: The Kafka connector disables the Kafka _auto commit_ if not explicitly enabled.

--- a/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
+++ b/documentation/src/main/doc/modules/kafka/pages/inbound.adoc
@@ -99,7 +99,7 @@ However, it reduces the risk of duplicates.
 * `ignore` performs no commit.
 This strategy is the default strategy when the consumer is explicitly configured with `enable.auto.commit` to `true`.
 It delegates the offset commit to the Kafka client.
-This strategy provides _at-least-once delivery_ if the channel processes the message without performing any asynchronous operations and when `enable.auto.commit` is set to `true`.
+When `enable.auto.commit` is `true` this strategy DOES NOT guarantee at-least-once delivery.
 However, if the processing failed between two commits, messages received after the commit and before the failure will be re-processed.
 
 IMPORTANT: The Kafka connector disables the Kafka _auto commit_ if not explicitly enabled.

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaIgnoreCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaIgnoreCommit.java
@@ -10,8 +10,7 @@ import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
  *
  * This handler is the default when `enable.auto.commit` is `true`.
  *
- * When `enable.auto.commit` is `true` this strategy provides at-least-once delivery
- * if the channel processes the message without performing any asynchronous processing.
+ * When `enable.auto.commit` is `true` this strategy DOES NOT guarantee at-least-once delivery.
  *
  * To use set `commit-strategy` to `ignore`.
  */

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -224,6 +224,8 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
      * @return the map of partition -> offset that can be committed.
      */
     private Map<TopicPartition, Long> clearLesserSequentiallyProcessedOffsetsAndReturnLargestOffsetMapping() {
+        cleanupPartitionOffsetStore();
+
         Map<TopicPartition, Long> offsetsMapping = new HashMap<>();
         for (Map.Entry<TopicPartition, OffsetStore> entry : new HashSet<>(offsetStores.entrySet())) {
             if (assignments.contains(entry.getKey())) {
@@ -362,7 +364,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
         }
 
         void received(long offset) {
-            if (offset >= lastProcessedOffset) {
+            if (offset > lastProcessedOffset) {
                 this.receivedOffsets.offer(OffsetReceivedAt.received(offset));
                 unProcessedTotal.incrementAndGet();
             } else {
@@ -399,7 +401,6 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
                 }
             }
 
-            cleanupPartitionOffsetStore();
             removeReceivedOffsetsFromLastProcessedOffset();
 
             return -1;

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -229,7 +229,7 @@ public interface KafkaLogging extends BasicLogger {
     @Message(id = 18250, value = "The configuration property '%s' is deprecated and is replaced by '%s'.")
     void deprecatedConfig(String deprecated, String replace);
 
-    @LogMessage(level = Logger.Level.INFO)
+    @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 18251, value = "Committed %s")
     void committed(Map<TopicPartition, OffsetAndMetadata> offsets);
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordBatchStream.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordBatchStream.java
@@ -1,6 +1,16 @@
 package io.smallrye.reactive.messaging.kafka.impl;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 
 import io.smallrye.mutiny.operators.AbstractMulti;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
@@ -12,6 +22,8 @@ public class KafkaRecordBatchStream<K, V> extends AbstractMulti<ConsumerRecords<
     private final ReactiveKafkaConsumer<K, V> client;
     private final KafkaConnectorIncomingConfiguration config;
     private final Context context;
+    private final Set<KafkaRecordStreamSubscription<K, V, ConsumerRecords<K, V>>> subscriptions = Collections
+            .newSetFromMap(new ConcurrentHashMap<>());
 
     public KafkaRecordBatchStream(ReactiveKafkaConsumer<K, V> client,
             KafkaConnectorIncomingConfiguration config, Context context) {
@@ -25,7 +37,35 @@ public class KafkaRecordBatchStream<K, V> extends AbstractMulti<ConsumerRecords<
         // Enqueue ConsumerRecords by batches, max poll records is considered 1
         KafkaRecordStreamSubscription<K, V, ConsumerRecords<K, V>> subscription = new KafkaRecordStreamSubscription<>(
                 client, config, subscriber, context, 1, (cr, q) -> q.offer(cr));
+        subscriptions.add(subscription);
         subscriber.onSubscribe(subscription);
+    }
+
+    void removeFromQueueRecordsFromTopicPartitions(Collection<TopicPartition> revokedPartitions) {
+        if (revokedPartitions.isEmpty()) {
+            return;
+        }
+        subscriptions
+                .forEach(s -> this.removeFromQueue(s, revokedPartitions));
+    }
+
+    private void removeFromQueue(KafkaRecordStreamSubscription<K, V, ConsumerRecords<K, V>> subscription,
+            Collection<TopicPartition> revokedPartitions) {
+        subscription.rewriteQueue(cr -> {
+            Map<TopicPartition, List<ConsumerRecord<K, V>>> records = new HashMap<>();
+            cr.partitions()
+                    .stream()
+                    .filter(t -> !revokedPartitions.contains(t))
+                    .forEach(t -> records.put(t, cr.records(t)));
+
+            if (!records.isEmpty()) {
+                // replace ConsumerRecords with the new one
+                return new ConsumerRecords<>(records);
+            } else {
+                // remove from the queue
+                return null;
+            }
+        });
     }
 
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordStreamSubscription.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordStreamSubscription.java
@@ -237,4 +237,8 @@ public class KafkaRecordStreamSubscription<K, V, T> implements Subscription {
         }
         return false;
     }
+
+    RecordQueue<T> getQueue() {
+        return queue;
+    }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
@@ -398,7 +398,8 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
         return paused.get();
     }
 
-    void removeFromQueueRecordsFromTopicPartitions(Collection<TopicPartition> partitions) {
-        this.stream.removeFromQueueRecordsFromTopicPartitions(partitions);
+    void removeFromQueueRecordsFromTopicPartitions(Collection<TopicPartition> revokedPartitions) {
+        this.stream.removeFromQueueRecordsFromTopicPartitions(revokedPartitions);
+        this.batchStream.removeFromQueueRecordsFromTopicPartitions(revokedPartitions);
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
@@ -397,4 +397,8 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     boolean isPaused() {
         return paused.get();
     }
+
+    void removeFromQueueRecordsFromTopicPartitions(Collection<TopicPartition> partitions) {
+        this.stream.removeFromQueueRecordsFromTopicPartitions(partitions);
+    }
 }


### PR DESCRIPTION
@cescoffier This work is based on the findings of this issue https://github.com/smallrye/smallrye-reactive-messaging/issues/1403

The jist of it is that it clears the stream's queue of records from revoked partitions. This greatly reduces dup and concurrent processing during a rebalance when replaying a topic.