### PR TITLE
Fix merged config implementation 

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -4,13 +4,7 @@ import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Dire
 import static io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction.OUTGOING;
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
@@ -49,6 +43,7 @@ import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.health.HealthReporter;
 import io.smallrye.reactive.messaging.i18n.ProviderLogging;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaThrottledLatestProcessedCommit;
+import io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSink;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
 import io.vertx.mutiny.core.Vertx;
@@ -250,14 +245,26 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
         return sink.getSink();
     }
 
-    private Config merge(Config passedCfg, Map<String, Object> defaultKafkaCfg) {
+    protected static Config merge(Config passedCfg, Map<String, Object> defaultKafkaCfg) {
         return new Config() {
             @SuppressWarnings("unchecked")
             @Override
             public <T> T getValue(String propertyName, Class<T> propertyType) {
-                T passedCgfValue = passedCfg.getValue(propertyName, propertyType);
+                T passedCgfValue = passedCfg.getOptionalValue(propertyName, propertyType).orElse(null);
                 if (passedCgfValue == null) {
-                    return (T) defaultKafkaCfg.get(propertyName);
+                    Object o = defaultKafkaCfg.get(propertyName);
+                    if (o == null) {
+                        throw KafkaExceptions.ex.missingProperty(propertyName);
+                    }
+                    if (propertyType.isInstance(o)) {
+                        return (T) o;
+                    }
+                    if (o instanceof String) {
+                        Optional<Converter<T>> converter = passedCfg.getConverter(propertyType);
+                        return converter.map(conv -> conv.convert(o.toString()))
+                                .orElseThrow(() -> new NoSuchElementException(propertyName));
+                    }
+                    throw KafkaExceptions.ex.cannotConvertProperty(propertyName, o.getClass(), propertyType);
                 } else {
                     return passedCgfValue;
                 }
@@ -273,8 +280,18 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
             public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
                 Optional<T> passedCfgValue = passedCfg.getOptionalValue(propertyName, propertyType);
                 if (!passedCfgValue.isPresent()) {
-                    T defaultValue = (T) defaultKafkaCfg.get(propertyName);
-                    return Optional.ofNullable(defaultValue);
+                    Object o = defaultKafkaCfg.get(propertyName);
+                    if (o == null) {
+                        return Optional.empty();
+                    }
+                    if (propertyType.isInstance(o)) {
+                        return Optional.of((T) o);
+                    }
+                    if (o instanceof String) {
+                        Optional<Converter<T>> converter = passedCfg.getConverter(propertyType);
+                        return converter.map(conv -> conv.convert(o.toString()));
+                    }
+                    return Optional.empty();
                 } else {
                     return passedCfgValue;
                 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaExceptions.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaExceptions.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.kafka.i18n;
 
+import java.util.NoSuchElementException;
+
 import javax.enterprise.inject.AmbiguousResolutionException;
 import javax.enterprise.inject.UnsatisfiedResolutionException;
 
@@ -58,4 +60,10 @@ public interface KafkaExceptions {
 
     @Message(id = 18013, value = "Cannot configure the Kafka producer for channel `%s` - the `mp.messaging.outgoing.%s.value.serializer` property is missing")
     IllegalArgumentException missingValueSerializer(String channel, String channelAgain);
+
+    @Message(id = 18014, value = "The config property '%s' is required but it could not be found in any config source")
+    NoSuchElementException missingProperty(String propertyName);
+
+    @Message(id = 18015, value = "Cannot convert property '%s' of type %s to %s")
+    NoSuchElementException cannotConvertProperty(String propertyName, Class<?> type, Class<?> targetType);
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaConfigMergeTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaConfigMergeTest.java
@@ -1,0 +1,73 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class KafkaConfigMergeTest {
+
+    @Test
+    public void testConfigMerge() {
+        Map<String, Object> globalMap = new HashMap<>();
+        globalMap.put("a", "string");
+        globalMap.put("b", 23);
+        globalMap.put("c", "some-value");
+
+        Map<String, String> conf = new HashMap<>();
+        globalMap.put("d", "string");
+        globalMap.put("e", 23);
+        globalMap.put("c", "some-value-from-conf");
+
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDefaultSources()
+                .withSources(new ConfigSource() {
+                    @Override
+                    public Set<String> getPropertyNames() {
+                        return conf.keySet();
+                    }
+
+                    @Override
+                    public String getValue(String propertyName) {
+                        return conf.get(propertyName);
+                    }
+
+                    @Override
+                    public String getName() {
+                        return "internal";
+                    }
+                }).build();
+
+        Config merged = KafkaConnector.merge(config, globalMap);
+        assertThat(merged.getValue("a", String.class)).isEqualTo("string");
+        assertThat(merged.getOptionalValue("a", String.class)).contains("string");
+        assertThat(merged.getValue("b", Integer.class)).isEqualTo(23);
+        assertThat(merged.getOptionalValue("b", Integer.class)).contains(23);
+
+        assertThat(merged.getValue("d", String.class)).isEqualTo("string");
+        assertThat(merged.getOptionalValue("d", String.class)).contains("string");
+        assertThat(merged.getValue("e", Integer.class)).isEqualTo(23);
+        assertThat(merged.getOptionalValue("e", Integer.class)).contains(23);
+
+        assertThat(merged.getValue("c", String.class)).isEqualTo("some-value-from-conf");
+        assertThat(merged.getOptionalValue("c", String.class)).contains("some-value-from-conf");
+
+        assertThatThrownBy(() -> merged.getValue("missing", String.class)).isInstanceOf(NoSuchElementException.class);
+        assertThatThrownBy(() -> merged.getValue("missing", Integer.class)).isInstanceOf(NoSuchElementException.class);
+        assertThat(merged.getOptionalValue("missing", String.class)).isEmpty();
+        assertThat(merged.getOptionalValue("missing", Integer.class)).isEmpty();
+
+        assertThatThrownBy(() -> merged.getValue("a", Integer.class)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> merged.getValue("d", Integer.class)).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
Not great but fix #1406.

It fixes the Config implementation used in the Kafka connector when merging the Connector config (channel) and the global configuration. 
