### PR TITLE
Forward headers through camel message processor

### DIFF
--- a/documentation/src/main/doc/modules/camel/examples/processor/CamelProcessor.java
+++ b/documentation/src/main/doc/modules/camel/examples/processor/CamelProcessor.java
@@ -1,0 +1,18 @@
+package processor;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CamelProcessor {
+
+    @Incoming("mynatssubject")
+    @Outgoing("mykafkatopic")
+    public byte[] process(byte[] message) {
+        // do some logic
+        return message;
+    }
+
+}

--- a/documentation/src/main/doc/modules/camel/pages/camel.adoc
+++ b/documentation/src/main/doc/modules/camel/pages/camel.adoc
@@ -19,6 +19,7 @@ URI format and parameters are listed on the component documentation, such as the
 include::installation.adoc[]
 include::inbound.adoc[]
 include::outbound.adoc[]
+include::processor.adoc[]
 include::use-camel-api.adoc[]
 
 

--- a/documentation/src/main/doc/modules/camel/pages/processor.adoc
+++ b/documentation/src/main/doc/modules/camel/pages/processor.adoc
@@ -1,0 +1,31 @@
+[#camel-processor]
+== The processor pattern using Camel
+
+Using the processor pattern, you can consume on a channel using a Camel component, and produce on a channel using another Camel component.
+In that case, the headers present in the incoming metadata will be forwarded in the outgoing metadata.
+
+=== Example
+
+Let's imagine you want to read messages from a Nats subject, process it and produce a message on a Kafka topic.
+
+[source]
+----
+mp.messaging.incoming.mynatssubject.connector=smallrye-camel       # <1>
+mp.messaging.incoming.mynatssubject.endpoint-uri=nats:mynatssubject # <2>
+mp.messaging.outgoing.mykafkatopic.connector=smallrye-camel       # <3>
+mp.messaging.outgoing.mykafkatopic.endpoint-uri=kafka:mykafkatopic # <4>
+
+camel.component.nats.servers=127.0.0.1:5555 # <5>
+camel.component.kafka.brokers=127.0.0.1:9092 # <6>
+----
+1. Sets the connector for the `mynatssubject` channel
+2. Configures the `endpoint-uri` for nats subject
+3. Sets the connector for the `mykafkatopic` channel
+4. Configures the `endpoint-uri` for the kafka topic
+5. Sets the URL of the nats server to use
+6. Sets the URL of a kafka broker to use
+
+[source, java]
+----
+include::example$processor/CamelProcessor.java[]
+----

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,8 @@
     <yasson.version>1.0.8</yasson.version>
 
     <jandex-maven-plugin.version>1.2.1</jandex-maven-plugin.version>
+
+    <nats-embedded.version>1.1.0</nats-embedded.version>
   </properties>
 
   <modules>

--- a/smallrye-reactive-messaging-camel/pom.xml
+++ b/smallrye-reactive-messaging-camel/pom.xml
@@ -59,6 +59,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-nats</artifactId>
+      <version>${camel.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>np.com.madanpokharel.embed</groupId>
+      <artifactId>nats-embedded</artifactId>
+      <version>${nats-embedded.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-connector-attribute-processor</artifactId>
       <version>${project.version}</version>

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithSimpleCamelProcessor.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithSimpleCamelProcessor.java
@@ -1,0 +1,22 @@
+package io.smallrye.reactive.messaging.camel.outgoing;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class BeanWithSimpleCamelProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BeanWithSimpleCamelProcessor.class);
+
+    @Incoming("in")
+    @Outgoing("out")
+    public byte[] extract(byte[] value) {
+        LOG.info("Received message {}", value);
+        return value;
+    }
+
+}

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/OutgoingCamelTest.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/OutgoingCamelTest.java
@@ -2,14 +2,34 @@ package io.smallrye.reactive.messaging.camel.outgoing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.Exchange;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.smallrye.reactive.messaging.camel.CamelConnector;
 import io.smallrye.reactive.messaging.camel.CamelTestBase;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import np.com.madanpokharel.embed.nats.EmbeddedNatsConfig;
+import np.com.madanpokharel.embed.nats.EmbeddedNatsServer;
+import np.com.madanpokharel.embed.nats.NatsServerConfig;
+import np.com.madanpokharel.embed.nats.NatsVersion;
+import np.com.madanpokharel.embed.nats.ServerType;
 
 public class OutgoingCamelTest extends CamelTestBase {
 
+    private static final Logger LOG = LoggerFactory.getLogger(OutgoingCamelTest.class);
     private static final String DESTINATION = "seda:camel";
+    private static final String HEADER_VALUE = "value";
+    private static final String HEADER_KEY = "key";
 
     @Test
     public void testWithABeanDeclaringACamelPublisher() {
@@ -101,4 +121,57 @@ public class OutgoingCamelTest extends CamelTestBase {
         assertThat(bean.values()).contains("a", "b", "c", "d");
     }
 
+    @Test
+    void testWithBeanDeclaringASimpleProcessorThatForwardIncomingHeaders() throws Exception {
+        addClasses(BeanWithSimpleCamelProcessor.class);
+
+        EmbeddedNatsServer natsServer = startNats();
+        try {
+            addConfig(getNatsConfig());
+            initialize();
+
+            final CompletableFuture<Exchange> completableFuture = CompletableFuture
+                    .supplyAsync(
+                            () -> camelContext().createConsumerTemplate().receive("nats:out?servers=127.0.0.1:7656&connectionTimeout=60000", 5000));
+            camelContext().createProducerTemplate()
+                    .asyncRequestBodyAndHeader("nats:in?servers=127.0.0.1:7656&connectionTimeout=60000", "a", HEADER_KEY, HEADER_VALUE);
+
+            final Exchange exchange = completableFuture.get(60, TimeUnit.SECONDS);
+
+            assertEquals(new String((byte[]) exchange.getMessage().getBody()), "a");
+            assertNotNull(exchange.getMessage().getHeaders());
+            assertEquals(HEADER_VALUE, exchange.getMessage().getHeader(HEADER_KEY));
+        } finally {
+            if (natsServer != null) {
+                natsServer.stopServer();
+            }
+        }
+    }
+
+    private EmbeddedNatsServer startNats() throws Exception {
+        final EmbeddedNatsConfig config = new EmbeddedNatsConfig.Builder()
+                .withNatsServerConfig(
+                        new NatsServerConfig.Builder()
+                                .withServerType(ServerType.NATS)
+                                // use version that supports headers
+                                .withNatsVersion(new NatsVersion("v2.6.1"))
+                                .withPort(7656)
+                                .withHost("127.0.0.1")
+                                .build())
+                .build();
+        final EmbeddedNatsServer natsServer = new EmbeddedNatsServer(config);
+        natsServer.startServer();
+        return natsServer;
+    }
+
+    private MapBasedConfig getNatsConfig() {
+        final String inPrefix = "mp.messaging.incoming.in.";
+        final String outPrefix = "mp.messaging.outgoing.out.";
+        final Map<String, Object> config = new HashMap<>();
+        config.putIfAbsent(inPrefix + "endpoint-uri", "nats:in?servers=127.0.0.1:7656&connectionTimeout=60000");
+        config.putIfAbsent(outPrefix + "endpoint-uri", "nats:out?servers=127.0.0.1:7656&connectionTimeout=60000");
+        config.putIfAbsent(inPrefix + "connector", CamelConnector.CONNECTOR_NAME);
+        config.putIfAbsent(outPrefix + "connector", CamelConnector.CONNECTOR_NAME);
+        return new MapBasedConfig(config);
+    }
 }


### PR DESCRIPTION
Linked to https://github.com/smallrye/smallrye-reactive-messaging/issues/1458

I couldn't find a way to test the new feature as the only camel components supporting the consumer/producer pattern and headers are kafka and nats (in latest non released version), and I couldn't make an embedded server work in unit test along with the CamelTestBase framework.

If you have recommendations, don't hesitate to advise.