### PR TITLE
RabbitMQ dynamic credentials

### DIFF
--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-incoming.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-incoming.adoc
@@ -33,6 +33,12 @@ Type: _string_ | false |
 
 Type: _int_ | false | `60000`
 
+| [.no-hyphens]#*credentials-provider-name*#
+
+[.no-hyphens]#_(rabbitmq-credentials-provider-name)_# | The name of the RabbitMQ Credentials Provider bean used to provide dynamic credentials to the RabbitMQ client
+
+Type: _string_ | false | 
+
 | [.no-hyphens]#*dead-letter-exchange*# | A DLX to assign to the queue. Relevant only if auto-bind-dlq is true
 
 Type: _string_ | false | `DLX`

--- a/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-outgoing.adoc
+++ b/documentation/src/main/doc/modules/connectors/partials/META-INF/connector/smallrye-rabbitmq-outgoing.adoc
@@ -21,6 +21,12 @@ Type: _string_ | false |
 
 Type: _int_ | false | `60000`
 
+| [.no-hyphens]#*credentials-provider-name*#
+
+[.no-hyphens]#_(rabbitmq-credentials-provider-name)_# | The name of the RabbitMQ Credentials Provider bean used to provide dynamic credentials to the RabbitMQ client
+
+Type: _string_ | false | 
+
 | [.no-hyphens]#*default-routing-key*# | The default routing key to use when sending messages to the exchange
 
 Type: _string_ | false | ``

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ConnectionHolder.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ConnectionHolder.java
@@ -6,7 +6,6 @@ import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.smallrye.common.annotation.CheckReturnValue;
@@ -110,11 +109,6 @@ public class ConnectionHolder {
 
     public Vertx getVertx() {
         return vertx;
-    }
-
-    @SuppressWarnings("unused")
-    public synchronized void onFailure(Consumer<Throwable> callback) {
-        // As RabbitMQClient doesn't have a failure callback mechanism, there isn't much we can do here
     }
 
     @CheckReturnValue

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQClientHelper.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQClientHelper.java
@@ -1,12 +1,18 @@
 package io.smallrye.reactive.messaging.rabbitmq;
 
+import static com.rabbitmq.client.impl.DefaultCredentialsRefreshService.fixedTimeApproachingExpirationStrategy;
+import static com.rabbitmq.client.impl.DefaultCredentialsRefreshService.ratioRefreshDelayStrategy;
 import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions.ex;
 import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.literal.NamedLiteral;
+
+import com.rabbitmq.client.impl.CredentialsProvider;
+import com.rabbitmq.client.impl.DefaultCredentialsRefreshService;
 
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.i18n.ProviderLogging;
@@ -17,52 +23,52 @@ import io.vertx.rabbitmq.RabbitMQOptions;
 
 public class RabbitMQClientHelper {
 
+    private static final double CREDENTIALS_PROVIDER_REFRESH_DELAY_RATIO = 0.8;
+    private static final Duration CREDENTIALS_PROVIDER_APPROACH_EXPIRE_TIME = Duration.ofSeconds(1);
+
     private RabbitMQClientHelper() {
         // avoid direct instantiation.
     }
 
     static RabbitMQClient createClient(RabbitMQConnector connector, RabbitMQConnectorCommonConfiguration config,
-            Instance<RabbitMQOptions> instance) {
+            Instance<RabbitMQOptions> optionsInstances, Instance<CredentialsProvider> credentialsProviderInstances) {
         RabbitMQClient client;
         Optional<String> clientOptionsName = config.getClientOptionsName();
         Vertx vertx = connector.getVertx();
         if (clientOptionsName.isPresent()) {
-            client = createClientFromClientOptionsBean(vertx, instance, clientOptionsName.get());
+            client = createClientFromClientOptionsBean(vertx, optionsInstances, clientOptionsName.get());
         } else {
-            client = getClient(vertx, config);
+            client = getClient(vertx, config, credentialsProviderInstances);
         }
         connector.addClient(client);
         return client;
     }
 
-    static RabbitMQClient createClientFromClientOptionsBean(Vertx vertx, Instance<RabbitMQOptions> instance,
+    static RabbitMQClient createClientFromClientOptionsBean(Vertx vertx, Instance<RabbitMQOptions> options,
             String optionsBeanName) {
-        Instance<RabbitMQOptions> options = instance.select(Identifier.Literal.of(optionsBeanName));
+        options = options.select(Identifier.Literal.of(optionsBeanName));
         if (options.isUnsatisfied()) {
             // this `if` block should be removed when support for the `@Named` annotation is removed
-            options = instance.select(NamedLiteral.of(optionsBeanName));
+            options = options.select(NamedLiteral.of(optionsBeanName));
             if (!options.isUnsatisfied()) {
                 ProviderLogging.log.deprecatedNamed();
             }
         }
-        if (options.isUnsatisfied()) {
+        if (!options.isResolvable()) {
             throw ex.illegalStateFindingBean(RabbitMQOptions.class.getName(), optionsBeanName);
         }
         log.createClientFromBean(optionsBeanName);
         return RabbitMQClient.create(vertx, options.get());
     }
 
-    static RabbitMQClient getClient(Vertx vertx, RabbitMQConnectorCommonConfiguration config) {
+    static RabbitMQClient getClient(Vertx vertx, RabbitMQConnectorCommonConfiguration config,
+            Instance<CredentialsProvider> credentialsProviders) {
         try {
-            String username = config.getUsername().orElse(RabbitMQOptions.DEFAULT_USER);
-            String password = config.getPassword().orElse(RabbitMQOptions.DEFAULT_PASSWORD);
             String host = config.getHost();
             int port = config.getPort();
             log.brokerConfigured(host, port, config.getChannel());
 
             RabbitMQOptions options = new RabbitMQOptions()
-                    .setUser(username)
-                    .setPassword(password)
                     .setHost(host)
                     .setPort(port)
                     .setSsl(config.getSsl())
@@ -87,6 +93,39 @@ public class RabbitMQClientHelper {
                 jks.setPath(trustStorePath.get());
                 config.getTrustStorePassword().ifPresent(jks::setPassword);
                 options.setTrustStoreOptions(jks);
+            }
+
+            if (config.getCredentialsProviderName().isPresent()) {
+
+                String credentialsProviderName = config.getCredentialsProviderName().get();
+                credentialsProviders = credentialsProviders.select(Identifier.Literal.of(credentialsProviderName));
+                if (credentialsProviders.isUnsatisfied()) {
+                    // this `if` block should be removed when support for the `@Named` annotation is removed
+                    credentialsProviders = credentialsProviders.select(NamedLiteral.of(credentialsProviderName));
+                    if (!credentialsProviders.isUnsatisfied()) {
+                        ProviderLogging.log.deprecatedNamed();
+                    }
+                }
+                if (!credentialsProviders.isResolvable()) {
+                    throw ex.illegalStateFindingBean(CredentialsProvider.class.getName(), credentialsProviderName);
+                }
+
+                CredentialsProvider credentialsProvider = credentialsProviders.get();
+                options.setCredentialsProvider(credentialsProvider);
+
+                // To ease configuration, set up a "standard" refresh service
+                options.setCredentialsRefreshService(
+                        new DefaultCredentialsRefreshService(
+                                vertx.nettyEventLoopGroup(),
+                                ratioRefreshDelayStrategy(CREDENTIALS_PROVIDER_REFRESH_DELAY_RATIO),
+                                fixedTimeApproachingExpirationStrategy(CREDENTIALS_PROVIDER_APPROACH_EXPIRE_TIME)));
+            } else {
+
+                String username = config.getUsername().orElse(RabbitMQOptions.DEFAULT_USER);
+                String password = config.getPassword().orElse(RabbitMQOptions.DEFAULT_PASSWORD);
+
+                options.setUser(username);
+                options.setPassword(password);
             }
 
             return RabbitMQClient.create(vertx, options);

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -184,7 +184,6 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
             log.receiverError(t);
             processor.onError(t);
         });
-        holder.onFailure(processor::onError);
 
         return Multi.createFrom().deferred(
                 () -> {

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -35,6 +35,8 @@ import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.reactivestreams.Subscription;
 
+import com.rabbitmq.client.impl.CredentialsProvider;
+
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
@@ -85,6 +87,7 @@ import io.vertx.rabbitmq.RabbitMQPublisherOptions;
 @ConnectorAttribute(name = "use-nio", direction = INCOMING_AND_OUTGOING, description = "Whether usage of NIO Sockets is enabled", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "virtual-host", direction = INCOMING_AND_OUTGOING, description = "The virtual host to use when connecting to the broker", type = "string", defaultValue = "/", alias = "rabbitmq-virtual-host")
 @ConnectorAttribute(name = "client-options-name", direction = INCOMING_AND_OUTGOING, description = "The name of the RabbitMQ Client Option bean used to customize the RabbitMQ client configuration", type = "string", alias = "rabbitmq-client-options-name")
+@ConnectorAttribute(name = "credentials-provider-name", direction = INCOMING_AND_OUTGOING, description = "The name of the RabbitMQ Credentials Provider bean used to provide dynamic credentials to the RabbitMQ client", type = "string", alias = "rabbitmq-credentials-provider-name")
 
 // Exchange
 @ConnectorAttribute(name = "exchange.name", direction = INCOMING_AND_OUTGOING, description = "The exchange that messages are published to or consumed from. If not set, the channel name is used", type = "string")
@@ -153,6 +156,10 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
     @Any
     private Instance<RabbitMQOptions> clientOptions;
 
+    @Inject
+    @Any
+    private Instance<CredentialsProvider> credentialsProviders;
+
     RabbitMQConnector() {
         // used for proxies
     }
@@ -215,7 +222,7 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
         incomingChannelStatus.put(ic.getChannel(), ChannelStatus.INITIALISING);
 
         // Create a client
-        final RabbitMQClient client = RabbitMQClientHelper.createClient(this, ic, clientOptions);
+        final RabbitMQClient client = RabbitMQClientHelper.createClient(this, ic, clientOptions, credentialsProviders);
 
         final ConnectionHolder holder = new ConnectionHolder(client, ic, getVertx());
         final RabbitMQFailureHandler onNack = createFailureHandler(ic);
@@ -318,7 +325,7 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
         outgoingChannelStatus.put(oc.getChannel(), ChannelStatus.INITIALISING);
 
         // Create a client
-        final RabbitMQClient client = RabbitMQClientHelper.createClient(this, oc, clientOptions);
+        final RabbitMQClient client = RabbitMQClientHelper.createClient(this, oc, clientOptions, credentialsProviders);
 
         final ConnectionHolder holder = new ConnectionHolder(client, oc, getVertx());
         final Uni<RabbitMQPublisher> getSender = holder.getOrEstablishConnection()


### PR DESCRIPTION
Adds support for setting a RabbitMQ `CredentialsProvider` globally or on each incoming/outgoing connector.

This is an upstream change to support Vault based credentials for RabbitMQ in Quarkus.

~This is a WIP until https://github.com/vert-x3/vertx-rabbitmq-client/pull/143 is accepted & released.~