### PR TITLE
Poll interval timeout too short for polling retry of 1 second backoff

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -482,7 +482,7 @@ public class KafkaSourceTest extends KafkaTestBase {
          * Will use StartFromFifthOffsetFromLatestConsumerRebalanceListener
          */
         ConsumptionBeanWithoutAck bean = runWithoutAck(
-                myKafkaSourceConfigWithoutAck("fail-until-second-rebalance", true));
+                myKafkaSourceConfigWithoutAck("fail-until-second-rebalance", false));
         List<Integer> list = bean.getResults();
 
         await()

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceWithLegacyMetadataTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceWithLegacyMetadataTest.java
@@ -484,7 +484,7 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaTestBase {
          * Will use StartFromFifthOffsetFromLatestConsumerRebalanceListener
          */
         ConsumptionBeanWithoutAck bean = runWithoutAck(
-                myKafkaSourceConfigWithoutAck("fail-until-second-rebalance", true));
+                myKafkaSourceConfigWithoutAck("fail-until-second-rebalance", false));
         List<Integer> list = bean.getResults();
 
         await()


### PR DESCRIPTION
Fixes flaky test io.smallrye.reactive.messaging.kafka.KafkaSourceTest#testABeanConsumingTheKafkaMessagesStartingOnFifthOffsetFromLatestThatFailsUntilSecondRebalance