### PR TITLE
Fix message converters on injected channels

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ChannelProducer.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ChannelProducer.java
@@ -63,10 +63,10 @@ public class ChannelProducer {
             if (payloadType == null) {
                 return cast(getPublisher(injectionPoint));
             } else {
-                return cast(convert(getPublisher(injectionPoint), converters, payloadType));
+                return cast(convert(getPublisher(injectionPoint), converters, getRawTypeIfParameterized(payloadType)));
             }
         } else {
-            return cast(convert(getPublisher(injectionPoint), converters, first)
+            return cast(convert(getPublisher(injectionPoint), converters, getRawTypeIfParameterized(first))
                     .onItem().call(m -> Uni.createFrom().completionStage(m.ack()))
                     .onItem().transform(Message::getPayload)
                     .broadcast().toAllSubscribers());
@@ -232,6 +232,13 @@ public class ChannelProducer {
             }
         }
         return null;
+    }
+
+    private Type getRawTypeIfParameterized(Type type) {
+        if (type instanceof ParameterizedType) {
+            return ((ParameterizedType) type).getRawType();
+        }
+        return type;
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
#1484 did not work with the current `ConsumerRecord<Key, Value>` converter which is a parameterized type.
This change calls the message converters with the raw type instead of parameterized.