### PR TITLE
Avoid initialising Weld without config

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/metrics/SmallRyeMetricDecoratorTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/metrics/SmallRyeMetricDecoratorTest.java
@@ -35,7 +35,8 @@ public class SmallRyeMetricDecoratorTest extends WeldTestBase {
 
     @Test
     void testOnlyMetricDecoratorAvailable() {
-        container = weld.initialize();
+        weld.addExtensions(MetricCdiInjectionExtension.class);
+        runApplication(config(), MetricsTestBean.class);
         Instance<PublisherDecorator> decorators = container.select(PublisherDecorator.class);
         assertThat(decorators).hasSize(1);
         assertThat(decorators.get()).isInstanceOf(MetricDecorator.class);


### PR DESCRIPTION
Caused test failures on CI, but strangely not local env.