### PR TITLE
Syncs RabbitMQ incoming/outgoing metadata & message

### DIFF
--- a/documentation/src/main/java/rabbitmq/inbound/RabbitMQMetadataExample.java
+++ b/documentation/src/main/java/rabbitmq/inbound/RabbitMQMetadataExample.java
@@ -18,7 +18,7 @@ public class RabbitMQMetadataExample {
             final Optional<String> contentEncoding = meta.getContentEncoding();
             final Optional<String> contentType = meta.getContentType();
             final Optional<String> correlationId = meta.getCorrelationId();
-            final Optional<ZonedDateTime> creationTime = meta.getCreationTime(ZoneId.systemDefault());
+            final Optional<ZonedDateTime> timestamp = meta.getTimestamp(ZoneId.systemDefault());
             final Optional<Integer> priority = meta.getPriority();
             final Optional<String> replyTo = meta.getReplyTo();
             final Optional<String> userId = meta.getUserId();

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessage.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessage.java
@@ -139,40 +139,64 @@ public class IncomingRabbitMQMessage<T> implements ContextAwareMessage<T> {
         return body.getBytes();
     }
 
-    public Optional<Integer> getPriority() {
-        return rabbitMQMetadata.getPriority();
-    }
-
-    public Optional<String> getReplyTo() {
-        return rabbitMQMetadata.getReplyTo();
-    }
-
-    public Optional<String> getUserId() {
-        return rabbitMQMetadata.getUserId();
-    }
-
-    public Optional<String> getMessageId() {
-        return rabbitMQMetadata.getId();
-    }
-
-    public Optional<ZonedDateTime> getCreationTime(final ZoneId zoneId) {
-        return rabbitMQMetadata.getCreationTime(zoneId);
+    public Map<String, Object> getHeaders() {
+        return rabbitMQMetadata.getHeaders();
     }
 
     public Optional<String> getContentType() {
         return rabbitMQMetadata.getContentType();
     }
 
-    public Optional<String> getCorrelationId() {
-        return rabbitMQMetadata.getCorrelationId();
-    }
-
     public Optional<String> getContentEncoding() {
         return rabbitMQMetadata.getContentEncoding();
     }
 
-    public Map<String, Object> getHeaders() {
-        return rabbitMQMetadata.getHeaders();
+    public Optional<Integer> getDeliveryMode() {
+        return rabbitMQMetadata.getDeliveryMode();
+    }
+
+    public Optional<Integer> getPriority() {
+        return rabbitMQMetadata.getPriority();
+    }
+
+    public Optional<String> getCorrelationId() {
+        return rabbitMQMetadata.getCorrelationId();
+    }
+
+    public Optional<String> getReplyTo() {
+        return rabbitMQMetadata.getReplyTo();
+    }
+
+    public Optional<String> getExpiration() {
+        return rabbitMQMetadata.getExpiration();
+    }
+
+    public Optional<String> getMessageId() {
+        return rabbitMQMetadata.getMessageId();
+    }
+
+    public Optional<ZonedDateTime> getTimestamp(final ZoneId zoneId) {
+        return rabbitMQMetadata.getTimestamp(zoneId);
+    }
+
+    public Optional<String> getType() {
+        return rabbitMQMetadata.getType();
+    }
+
+    public Optional<String> getUserId() {
+        return rabbitMQMetadata.getUserId();
+    }
+
+    public Optional<String> getAppId() {
+        return rabbitMQMetadata.getAppId();
+    }
+
+    /**
+     * @deprecated Use getTimestamp()
+     */
+    @Deprecated
+    public Optional<ZonedDateTime> getCreationTime(final ZoneId zoneId) {
+        return rabbitMQMetadata.getTimestamp(zoneId);
     }
 
     public io.vertx.mutiny.rabbitmq.RabbitMQMessage getRabbitMQMessage() {

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
@@ -123,43 +123,14 @@ public class IncomingRabbitMQMetadata {
     }
 
     /**
-     * The absolute time when this message was created, expressed as a {@link ZonedDateTime}
-     * with respect to the supplied {@link ZoneId}.
+     * The delivery-mode property.
      * <p>
      * Stored in the message properties.
      *
-     * @param zoneId the {@link ZoneId} representing the time zone in which the timestamp is to be interpreted
-     * @return an {@link Optional} containing the date and time, which may be empty if no timestamp was received
+     * @return an {@link Optional} containing the delivery-mode, which may be empty if no delivery-mode was received
      */
-    public Optional<ZonedDateTime> getCreationTime(final ZoneId zoneId) {
-        final Optional<Date> timestamp = Optional.ofNullable(message.properties().getTimestamp());
-        return timestamp.map(t -> ZonedDateTime.ofInstant(t.toInstant(), zoneId));
-    }
-
-    /**
-     * The message-id, if set, uniquely identifies a message within the message system.
-     * The message producer is usually responsible for setting the message-id in such a way that it is assured to be
-     * globally unique. A broker may discard a message as a duplicate if the value of the message-id matches that of a
-     * previously received message sent to the same node.
-     * <p>
-     * Stored in the message properties.
-     *
-     * @return an {@link Optional} containing the message-id, which may be empty if no message-id was received
-     */
-    public Optional<String> getId() {
-        return Optional.ofNullable(message.properties().getMessageId());
-    }
-
-    /**
-     * The identity of the user responsible for producing the message.
-     * The client sets this value, and it may be authenticated by intermediaries.
-     * <p>
-     * Stored in the message properties.
-     *
-     * @return an {@link Optional} containing the user-id, which may be empty if no user-id was received
-     */
-    public Optional<String> getUserId() {
-        return Optional.ofNullable(message.properties().getUserId());
+    public Optional<Integer> getDeliveryMode() {
+        return Optional.ofNullable(message.properties().getDeliveryMode());
     }
 
     /**
@@ -175,6 +146,17 @@ public class IncomingRabbitMQMetadata {
     }
 
     /**
+     * This is a client-specific id that can be used to mark or identify messages between clients.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the correlation-id, which may be empty if no correlation-id was received
+     */
+    public Optional<String> getCorrelationId() {
+        return Optional.ofNullable(message.properties().getCorrelationId());
+    }
+
+    /**
      * The address of the node to send replies to.
      * <p>
      * Stored in the message properties.
@@ -186,14 +168,111 @@ public class IncomingRabbitMQMetadata {
     }
 
     /**
-     * This is a client-specific id that can be used to mark or identify messages between clients.
+     * The expiration property.
      * <p>
      * Stored in the message properties.
      *
-     * @return an {@link Optional} containing the correlation-id, which may be empty if no correlation-id was received
+     * @return an {@link Optional} containing the expiration, which may be empty if no expiration was received
      */
-    public Optional<String> getCorrelationId() {
-        return Optional.ofNullable(message.properties().getCorrelationId());
+    public Optional<String> getExpiration() {
+        return Optional.ofNullable(message.properties().getExpiration());
+    }
+
+    /**
+     * The message-id, if set, uniquely identifies a message within the message system.
+     * The message producer is usually responsible for setting the message-id in such a way that it is assured to be
+     * globally unique. A broker may discard a message as a duplicate if the value of the message-id matches that of a
+     * previously received message sent to the same node.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the message-id, which may be empty if no message-id was received
+     */
+    public Optional<String> getMessageId() {
+        return Optional.ofNullable(message.properties().getMessageId());
+    }
+
+    /**
+     * The absolute time when this message was created, expressed as a {@link ZonedDateTime}
+     * with respect to the supplied {@link ZoneId}.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @param zoneId the {@link ZoneId} representing the time zone in which the timestamp is to be interpreted
+     * @return an {@link Optional} containing the date and time, which may be empty if no timestamp was received
+     */
+    public Optional<ZonedDateTime> getTimestamp(final ZoneId zoneId) {
+        final Optional<Date> timestamp = Optional.ofNullable(message.properties().getTimestamp());
+        return timestamp.map(t -> ZonedDateTime.ofInstant(t.toInstant(), zoneId));
+    }
+
+    /**
+     * The type property.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the type, which may be empty if no type was received
+     */
+    public Optional<String> getType() {
+        return Optional.ofNullable(message.properties().getType());
+    }
+
+    /**
+     * The identity of the user responsible for producing the message.
+     * The client sets this value, and it may be authenticated by intermediaries.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the user-id, which may be empty if no user-id was received
+     */
+    public Optional<String> getUserId() {
+        return Optional.ofNullable(message.properties().getUserId());
+    }
+
+    /**
+     * The identity of the application responsible for producing the message.
+     * The client sets this value, and it may be authenticated by intermediaries.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @return an {@link Optional} containing the app-id, which may be empty if no app-id was received
+     */
+    public Optional<String> getAppId() {
+        return Optional.ofNullable(message.properties().getAppId());
+    }
+
+    /**
+     * The absolute time when this message was created, expressed as a {@link ZonedDateTime}
+     * with respect to the supplied {@link ZoneId}.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @deprecated Use getTimestamp()
+     *
+     * @param zoneId the {@link ZoneId} representing the time zone in which the timestamp is to be interpreted
+     * @return an {@link Optional} containing the date and time, which may be empty if no timestamp was received
+     */
+    @Deprecated
+    public Optional<ZonedDateTime> getCreationTime(final ZoneId zoneId) {
+        final Optional<Date> timestamp = Optional.ofNullable(message.properties().getTimestamp());
+        return timestamp.map(t -> ZonedDateTime.ofInstant(t.toInstant(), zoneId));
+    }
+
+    /**
+     * The message-id, if set, uniquely identifies a message within the message system.
+     * The message producer is usually responsible for setting the message-id in such a way that it is assured to be
+     * globally unique. A broker may discard a message as a duplicate if the value of the message-id matches that of a
+     * previously received message sent to the same node.
+     * <p>
+     * Stored in the message properties.
+     *
+     * @deprecated Use getMessageId()
+     *
+     * @return an {@link Optional} containing the message-id, which may be empty if no message-id was received
+     */
+    @Deprecated
+    public Optional<String> getId() {
+        return Optional.ofNullable(message.properties().getMessageId());
     }
 
     /**

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
@@ -25,16 +25,16 @@ public class OutgoingRabbitMQMetadata {
     private String clusterId;
     private String routingKey;
 
+    public Map<String, Object> getHeaders() {
+        return headers;
+    }
+
     public String getContentType() {
         return contentType;
     }
 
     public String getContentEncoding() {
         return contentEncoding;
-    }
-
-    public Map<String, Object> getHeaders() {
-        return headers;
     }
 
     public Integer getDeliveryMode() {

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMetadataTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMetadataTest.java
@@ -1,0 +1,126 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Optional;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.junit.jupiter.api.Test;
+
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Envelope;
+
+import io.smallrye.reactive.messaging.rabbitmq.RabbitMQMessageConverter.OutgoingRabbitMQMessage;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.rabbitmq.RabbitMQMessage;
+
+public class RabbitMQMetadataTest {
+
+    @Test
+    void testIncomingMetadata() {
+        ZonedDateTime timestamp = ZonedDateTime.now().truncatedTo(MILLIS);
+
+        RabbitMQMessage message = new RabbitMQMessage() {
+            @Override
+            public Buffer body() {
+                return Buffer.buffer(new byte[] { 1, 2, 3, 4, 5 });
+            }
+
+            @Override
+            public String consumerTag() {
+                return "123";
+            }
+
+            @Override
+            public Envelope envelope() {
+                return new Envelope(1, false, "test-exchange", "test-key");
+            }
+
+            @Override
+            public com.rabbitmq.client.BasicProperties properties() {
+                return new BasicProperties.Builder()
+                        .userId("test-user")
+                        .appId("tests")
+                        .contentType("text/plain")
+                        .contentEncoding("utf8")
+                        .correlationId("req-123")
+                        .deliveryMode(11)
+                        .expiration("1000")
+                        .priority(100)
+                        .messageId("12345")
+                        .replyTo("test-source")
+                        .timestamp(Date.from(timestamp.toInstant()))
+                        .type("test-type")
+                        .build();
+            }
+
+            @Override
+            public Integer messageCount() {
+                return 5;
+            }
+        };
+
+        IncomingRabbitMQMetadata incoming = new IncomingRabbitMQMetadata(message);
+        assertThat(incoming.getUserId()).isEqualTo(Optional.of("test-user"));
+        assertThat(incoming.getAppId()).isEqualTo(Optional.of("tests"));
+        assertThat(incoming.getContentType()).isEqualTo(Optional.of("text/plain"));
+        assertThat(incoming.getContentEncoding()).isEqualTo(Optional.of("utf8"));
+        assertThat(incoming.getCorrelationId()).isEqualTo(Optional.of("req-123"));
+        assertThat(incoming.getDeliveryMode()).isEqualTo(Optional.of(11));
+        assertThat(incoming.getExpiration()).isEqualTo(Optional.of("1000"));
+        assertThat(incoming.getPriority()).isEqualTo(Optional.of(100));
+        assertThat(incoming.getMessageId()).isEqualTo(Optional.of("12345"));
+        assertThat(incoming.getReplyTo()).isEqualTo(Optional.of("test-source"));
+        assertThat(incoming.getTimestamp(timestamp.getZone())).isEqualTo(Optional.of(timestamp));
+        assertThat(incoming.getType()).isEqualTo(Optional.of("test-type"));
+    }
+
+    @Test
+    void testOutgoingMetadata() {
+        ZonedDateTime timestamp = ZonedDateTime.now().truncatedTo(MILLIS);
+
+        OutgoingRabbitMQMetadata metadata = OutgoingRabbitMQMetadata.builder()
+                .withUserId("test-user")
+                .withAppId("tests")
+                .withContentType("text/plain")
+                .withContentEncoding("utf8")
+                .withCorrelationId("req-123")
+                .withDeliveryMode(11)
+                .withExpiration("1000")
+                .withPriority(100)
+                .withMessageId("12345")
+                .withReplyTo("test-source")
+                .withTimestamp(timestamp)
+                .withType("test-type")
+                .build();
+
+        OutgoingRabbitMQMessage message = RabbitMQMessageConverter.convert(
+                Message.of("", Metadata.of(metadata)),
+                "test",
+                "#",
+                Optional.empty(),
+                false,
+                emptyList());
+
+        com.rabbitmq.client.BasicProperties props = message.getProperties();
+
+        assertThat(props.getUserId()).isEqualTo("test-user");
+        assertThat(props.getAppId()).isEqualTo("tests");
+        assertThat(props.getContentType()).isEqualTo("text/plain");
+        assertThat(props.getContentEncoding()).isEqualTo("utf8");
+        assertThat(props.getCorrelationId()).isEqualTo("req-123");
+        assertThat(props.getDeliveryMode()).isEqualTo(11);
+        assertThat(props.getExpiration()).isEqualTo("1000");
+        assertThat(props.getPriority()).isEqualTo(100);
+        assertThat(props.getMessageId()).isEqualTo("12345");
+        assertThat(props.getReplyTo()).isEqualTo("test-source");
+        assertThat(props.getTimestamp()).isEqualTo(Date.from(timestamp.toInstant()));
+        assertThat(props.getType()).isEqualTo("test-type");
+    }
+
+}


### PR DESCRIPTION
Adds the missing `appId`, `deliveryMode`, `expirattion`, and `type` message properties to `IncomingRabbitMQMetadata`; these were already present in `OutgoingRabbitMQMetadata`.

Renames `id` to `messageId` and `creationTime` to `timestamp` to match the names in RabbitMQ and `OutgoingRabbitMQMetadata`. The renamed values were left in place and deprecated.

Note: