### PR TITLE
Recreate a sender when the link is closed by the remote party.

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -65,6 +65,7 @@ import io.vertx.mutiny.amqp.AmqpClient;
 import io.vertx.mutiny.amqp.AmqpReceiver;
 import io.vertx.mutiny.amqp.AmqpSender;
 import io.vertx.mutiny.core.Vertx;
+import io.vertx.proton.ProtonSender;
 
 @ApplicationScoped
 @Connector(AmqpConnector.CONNECTOR_NAME)
@@ -256,34 +257,41 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
         String link = oc.getLinkName().orElseGet(oc::getChannel);
         ConnectionHolder holder = new ConnectionHolder(client, oc, getVertx());
 
-        Uni<AmqpSender> getSender = Uni.createFrom().item(sender.get())
-                .onItem().ifNull().switchTo(() -> {
+        Uni<AmqpSender> getSender = Uni.createFrom().deferred(() -> {
 
-                    // If we already have a sender, use it.
-                    AmqpSender current = sender.get();
-                    if (current != null && !current.connection().isDisconnected()) {
-                        return Uni.createFrom().item(current);
-                    }
+            // If we already have a sender, use it.
+            AmqpSender current = sender.get();
+            if (current != null && !current.connection().isDisconnected()) {
+                if (isLinkOpen(current)) {
+                    return Uni.createFrom().item(current);
+                } else {
+                    // link closed, close the sender, and recreate one.
+                    current.closeAndForget();
+                }
+            }
 
-                    return holder.getOrEstablishConnection()
-                            .onItem().transformToUni(connection -> {
-                                boolean anonymous = oc.getUseAnonymousSender()
-                                        .orElseGet(() -> ConnectionHolder.supportAnonymousRelay(connection));
+            return holder.getOrEstablishConnection()
+                    .onItem().transformToUni(connection -> {
+                        boolean anonymous = oc.getUseAnonymousSender()
+                                .orElseGet(() -> ConnectionHolder.supportAnonymousRelay(connection));
 
-                                if (anonymous) {
-                                    return connection.createAnonymousSender();
-                                } else {
-                                    return connection.createSender(configuredAddress,
-                                            new AmqpSenderOptions()
-                                                    .setLinkName(link)
-                                                    .setCapabilities(getClientCapabilities(oc)));
-                                }
-                            })
-                            .onItem().invoke(s -> {
-                                sender.set(s);
-                                opened.put(oc.getChannel(), true);
-                            });
-                })
+                        if (anonymous) {
+                            return connection.createAnonymousSender();
+                        } else {
+                            return connection.createSender(configuredAddress,
+                                    new AmqpSenderOptions()
+                                            .setLinkName(link)
+                                            .setCapabilities(getClientCapabilities(oc)));
+                        }
+                    })
+                    .onItem().invoke(s -> {
+                        AmqpSender orig = sender.getAndSet(s);
+                        if (orig != null) { // Close the previous one if any.
+                            orig.closeAndForget();
+                        }
+                        opened.put(oc.getChannel(), true);
+                    });
+        })
                 // If the downstream cancels or on failure, drop the sender.
                 .onFailure().invoke(t -> {
                     sender.set(null);
@@ -308,6 +316,14 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
                     opened.put(oc.getChannel(), false);
                 })
                 .ignore();
+    }
+
+    private boolean isLinkOpen(AmqpSender current) {
+        ProtonSender sender = current.getDelegate().unwrap();
+        if (sender == null) {
+            return false;
+        }
+        return sender.isOpen();
     }
 
     public List<String> getClientCapabilities(AmqpConnectorCommonConfiguration configuration) {


### PR DESCRIPTION
Before sending a message, retrieve the sender. If already created, verify that the connection is still open **and** that the link is still open. Indeed, Azure Service Hub closes the link (but keeps the connection opened).
In this case, we close the sender and recreate one.

~~This PR contains a hack waiting for https://github.com/vert-x3/vertx-amqp-client/pull/78.~~ Method shipped with Vert.x 4.2.5. 

Fix #1588.