### PR TITLE
PubSubConnector correct message type

### DIFF
--- a/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubConnector.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubConnector.java
@@ -179,6 +179,8 @@ public class PubSubConnector implements IncomingConnectorFactory, OutgoingConnec
     private static PubsubMessage buildMessage(final Message<?> message) {
         if (message instanceof PubSubMessage) {
             return ((PubSubMessage) message).getMessage();
+        } else if (message.getPayload() instanceof PubSubMessage) {
+            return ((PubSubMessage) message.getPayload()).getMessage();
         } else {
             return PubsubMessage.newBuilder()
                     .setData(ByteString.copyFromUtf8(message.getPayload().toString()))

--- a/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubConnector.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubConnector.java
@@ -181,6 +181,8 @@ public class PubSubConnector implements IncomingConnectorFactory, OutgoingConnec
             return ((PubSubMessage) message).getMessage();
         } else if (message.getPayload() instanceof PubSubMessage) {
             return ((PubSubMessage) message.getPayload()).getMessage();
+        } else if (message.getPayload() instanceof PubsubMessage) {
+            return ((PubsubMessage) message.getPayload());
         } else {
             return PubsubMessage.newBuilder()
                     .setData(ByteString.copyFromUtf8(message.getPayload().toString()))


### PR DESCRIPTION
This allows users of the `smallrye-gcp-pubsub` to send their own `com.google.pubsub.v1.PubsubMessage`

In theory, the initial code should handle this scenario, but the condition `message instanceof PubSubMessage` is never true, because form very initial phase in the emitter process, the message is transformed into `Message<T>`, regardless of the initial type:

`io.smallrye.reactive.messaging.providers.extension.EmitterImpl` -> `(Message.of(payload, Metadata.empty()`
``` 
public synchronized CompletionStage<Void> send(T payload) {
        if (payload == null) {
            throw ProviderExceptions.ex.illegalArgumentForNullValue();
        } else {
            CompletableFuture<Void> future = new CompletableFuture();
            this.emit(Message.of(payload, Metadata.empty(), () -> {
                future.complete((Object)null);
                return CompletableFuture.completedFuture((Object)null);
            }, (reason) -> {
                future.completeExceptionally(reason);
                return CompletableFuture.completedFuture((Object)null);
            }));
            return future;
        }
    }
```


So, my change will extract the `com.google.pubsub.v1.PubsubMessage` from the `Message<T>`, even if it is sent as `com.google.pubsub.v1.PubsubMessage` or as the connector's wrapper `io.smallrye.reactive.messaging.gcp.pubsub.PubSubMessage`.