### PR TITLE
fix broken incoming header propagation

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
@@ -46,6 +46,17 @@ public class AmqpMessage<T> implements org.eclipse.microprofile.reactive.messagi
         this(delegate.getDelegate(), context, onNack, cloudEventEnabled, tracingEnabled);
     }
 
+    public AmqpMessage(io.vertx.mutiny.amqp.AmqpMessage delegate, Context context,
+            OutgoingAmqpMetadata amqpMetadata) {
+        this.message = delegate.getDelegate();
+        this.context = context;
+        this.amqpMetadata = null;
+        this.onNack = null;
+        //noinspection unchecked
+        this.payload = (T) convert(message);
+        this.metadata = Metadata.of(amqpMetadata);
+    }
+
     @SuppressWarnings("unchecked")
     public AmqpMessage(io.vertx.amqp.AmqpMessage msg, Context context, AmqpFailureHandler onNack,
             boolean cloudEventEnabled, Boolean tracingEnabled) {

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/OutgoingAmqpMessage.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/OutgoingAmqpMessage.java
@@ -12,13 +12,11 @@ import io.vertx.core.json.JsonObject;
 public class OutgoingAmqpMessage<T> extends AmqpMessage<T>
         implements org.eclipse.microprofile.reactive.messaging.Message<T> {
 
-    private final Metadata metadata;
-    private final OutgoingAmqpMetadata amqpMetadata;
+    private final OutgoingAmqpMetadata outgoingAmqpMetadata;
 
     public OutgoingAmqpMessage(io.vertx.mutiny.amqp.AmqpMessage message, OutgoingAmqpMetadata amqpMetadata) {
-        super(message, null, null, false, false);
-        this.amqpMetadata = amqpMetadata;
-        this.metadata = Metadata.of(amqpMetadata);
+        super(message, null, amqpMetadata);
+        this.outgoingAmqpMetadata = amqpMetadata;
     }
 
     @Override
@@ -28,52 +26,72 @@ public class OutgoingAmqpMessage<T> extends AmqpMessage<T>
 
     @Override
     public boolean isDurable() {
-        return amqpMetadata.isDurable();
+        return outgoingAmqpMetadata.isDurable();
     }
 
     @Override
     public int getPriority() {
-        return amqpMetadata.getPriority();
+        return outgoingAmqpMetadata.getPriority();
     }
 
     @Override
     public long getTtl() {
-        return amqpMetadata.getTtl();
+        return outgoingAmqpMetadata.getTtl();
     }
 
     @Override
     public Object getMessageId() {
-        return amqpMetadata.getMessageId();
+        return outgoingAmqpMetadata.getMessageId();
     }
 
     @Override
     public String getAddress() {
-        return amqpMetadata.getAddress();
+        return outgoingAmqpMetadata.getAddress();
     }
 
     @Override
     public String getGroupId() {
-        return amqpMetadata.getGroupId();
+        return outgoingAmqpMetadata.getGroupId();
     }
 
     @Override
     public String getContentType() {
-        return amqpMetadata.getContentType();
+        return outgoingAmqpMetadata.getContentType();
     }
 
     @Override
     public Object getCorrelationId() {
-        return amqpMetadata.getCorrelationId();
+        return outgoingAmqpMetadata.getCorrelationId();
     }
 
     @Override
     public String getContentEncoding() {
-        return amqpMetadata.getContentEncoding();
+        return outgoingAmqpMetadata.getContentEncoding();
+    }
+
+    @Override
+    public long getExpiryTime() {
+        return outgoingAmqpMetadata.getExpiryTime();
+    }
+
+    @Override
+    public long getCreationTime() {
+        return outgoingAmqpMetadata.getCreationTime();
+    }
+
+    @Override
+    public long getDeliveryCount() {
+        return 0;
+    }
+
+    @Override
+    public long getGroupSequence() {
+        return outgoingAmqpMetadata.getGroupSequence();
     }
 
     @Override
     public String getSubject() {
-        return amqpMetadata.getSubject();
+        return outgoingAmqpMetadata.getSubject();
     }
 
     @Override
@@ -98,6 +116,6 @@ public class OutgoingAmqpMessage<T> extends AmqpMessage<T>
 
     @Override
     public JsonObject getApplicationProperties() {
-        return amqpMetadata.getProperties();
+        return outgoingAmqpMetadata.getProperties();
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSourceHealth.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/health/KafkaSourceHealth.java
@@ -20,7 +20,6 @@ public class KafkaSourceHealth extends BaseHealth {
 
     private final KafkaAdmin admin;
     private final KafkaConnectorIncomingConfiguration config;
-    private final String channel;
     private final Metric metric;
     private final KafkaSource<?, ?> source;
     private final ReactiveKafkaConsumer<?, ?> client;
@@ -29,7 +28,6 @@ public class KafkaSourceHealth extends BaseHealth {
             ReactiveKafkaConsumer<?, ?> client) {
         super(config.getChannel());
         this.config = config;
-        this.channel = config.getChannel();
         this.source = source;
         this.client = client;
         if (config.getHealthReadinessTopicVerification().orElse(config.getHealthTopicVerificationEnabled())) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ce/KafkaCloudEventHelper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ce/KafkaCloudEventHelper.java
@@ -319,22 +319,26 @@ public class KafkaCloudEventHelper {
         return configuration.getCloudEventsDataContentType();
     }
 
-    private static List<Header> getHeaders(OutgoingKafkaRecordMetadata<?> outGoingMetadata,
+    private static List<Header> getHeaders(OutgoingKafkaRecordMetadata<?> outgoingMetadata,
             IncomingKafkaRecordMetadata<?, ?> incomingMetadata, RuntimeKafkaSinkConfiguration configuration) {
         List<Header> headers = new ArrayList<>();
 
-        // First incoming headers, so that they can be overriden by outgoing headers
+        // First incoming headers, so that they can be overridden by outgoing headers
         if (!isNotBlank(configuration.getPropagateHeaders()) && incomingMetadata != null
                 && incomingMetadata.getHeaders() != null) {
-            Set<String> incomingHeaders = Arrays.stream(configuration.getPropagateHeaders().split(",")).map(String::trim)
+            Set<String> headersToPropagate = Arrays.stream(configuration.getPropagateHeaders().split(","))
+                    .map(String::trim)
                     .collect(Collectors.toSet());
 
-            Arrays.stream(incomingMetadata.getHeaders().toArray())
-                    .filter(header -> incomingHeaders.contains(header))
-                    .forEach(headers::add);
+            for (Header header : incomingMetadata.getHeaders()) {
+                if (headersToPropagate.contains(header.key())) {
+                    headers.add(header);
+                }
+            }
         }
-        if (outGoingMetadata != null && outGoingMetadata.getHeaders() != null) {
-            outGoingMetadata.getHeaders().forEach(headers::add);
+
+        if (outgoingMetadata != null && outgoingMetadata.getHeaders() != null) {
+            outgoingMetadata.getHeaders().forEach(headers::add);
         }
         return headers;
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/BrokerRestartTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/BrokerRestartTest.java
@@ -97,7 +97,7 @@ public class BrokerRestartTest extends ClientTestBase {
             await().until(() -> !kafka.isRunning());
 
             assertThat(consumer.pause().await().indefinitely()).isNotEmpty();
-            assertThat(consumer.resume().await().indefinitely());
+            consumer.resume().await().indefinitely();
             assertThat(consumer.paused().await().indefinitely()).isEmpty();
         }
     }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/ExponentialBackoffDelayOptions.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/ExponentialBackoffDelayOptions.java
@@ -99,7 +99,7 @@ public class ExponentialBackoffDelayOptions implements ReconnectDelayOptions {
 
                 Duration delay = this.minimum;
                 if (this.count > 0) {
-                    delay = delay.plus(this.increment.multipliedBy((long) Math.pow(2, this.count - 1)));
+                    delay = delay.plus(this.increment.multipliedBy((long) Math.pow(2.0, this.count - 1.0)));
                 }
 
                 this.count += 1;

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/wiring/WiringBroadcastTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/wiring/WiringBroadcastTest.java
@@ -536,7 +536,7 @@ public class WiringBroadcastTest {
 
         assertThat(graph.hasWiringErrors()).isFalse();
         assertThat(graph.getWiringErrors()).hasSize(0);
-        assertThat(graph.isClosed());
+        assertThat(graph.isClosed()).isTrue();
 
         assertThat(graph.getInbound()).hasSize(1).allSatisfy(pc -> assertThat(pc.outgoing()).contains("a"));
         assertThat(graph.getOutbound()).hasSize(2);


### PR DESCRIPTION
- Fix header propagation when using Cloud Event (with Kafka)
- Avoid having incoming metadata in the AMQP outgoing message
- Fix assertions and small improvements.
