### PR TITLE
Fix kafka broker extension

### DIFF
--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
@@ -150,7 +150,7 @@ public class ConsumerBuilder<K, V> implements ConsumerRebalanceListener, Closeab
      * @param valueDeserType the deserializer class for record values
      */
     public ConsumerBuilder(Map<String, Object> props, Duration kafkaApiTimeout,
-            Class<? extends Deserializer<K>> keyDeserType, Class<? extends Deserializer<V>> valueDeserType) {
+            Class<? extends Deserializer<?>> keyDeserType, Class<? extends Deserializer<?>> valueDeserType) {
         this.props = props;
         this.kafkaApiTimeout = kafkaApiTimeout;
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserType.getName());

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/KafkaCompanion.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/KafkaCompanion.java
@@ -193,8 +193,8 @@ public class KafkaCompanion implements AutoCloseable {
     }
 
     public <K, V> ConsumerBuilder<K, V> consumeWithDeserializers(
-            Class<? extends Deserializer<K>> keyDeserType,
-            Class<? extends Deserializer<V>> valueDeserType) {
+            Class<? extends Deserializer<?>> keyDeserType,
+            Class<? extends Deserializer<?>> valueDeserType) {
         return new ConsumerBuilder<>(getConsumerProperties(), kafkaApiTimeout, keyDeserType, valueDeserType);
     }
 
@@ -241,8 +241,8 @@ public class KafkaCompanion implements AutoCloseable {
     }
 
     public <K, V> ProducerBuilder<K, V> produceWithSerializers(
-            Class<? extends Serializer<K>> keySerializerType,
-            Class<? extends Serializer<V>> valueSerializerType) {
+            Class<? extends Serializer<?>> keySerializerType,
+            Class<? extends Serializer<?>> valueSerializerType) {
         return new ProducerBuilder<>(getProducerProperties(), kafkaApiTimeout, keySerializerType, valueSerializerType);
     }
 

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ProducerBuilder.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ProducerBuilder.java
@@ -96,8 +96,8 @@ public class ProducerBuilder<K, V> implements Closeable {
      * @param valueSerializerType the serializer class for record values
      */
     public ProducerBuilder(Map<String, Object> props, Duration kafkaApiTimeout,
-            Class<? extends Serializer<K>> keySerializerType,
-            Class<? extends Serializer<V>> valueSerializerType) {
+            Class<? extends Serializer<?>> keySerializerType,
+            Class<? extends Serializer<?>> valueSerializerType) {
         this.props = props;
         this.kafkaApiTimeout = kafkaApiTimeout;
         this.props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerType.getName());


### PR DESCRIPTION
- Fix for junit extension for Kafka broker, which creates a single broker for all the test suite
- KafkaCompanion producer and consumer creation accept untyped Serde classes for configuring generic Serde ex. avro