### PR TITLE
Implement method to insert all headers at once.

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
@@ -120,6 +120,17 @@ public class OutgoingRabbitMQMetadata {
             headers.put(header, value);
             return this;
         }
+        
+        /**
+         * Adds the message headers to the metadata.
+         *
+         * @param header the message headers
+         * @return this {@link Builder}
+         */
+        public Builder withHeaders(final Map<String, Object> header) {
+            headers.putAll(header);
+            return this;
+        }
 
         /**
          * Adds an application id property to the metadata


### PR DESCRIPTION
Hey @cescoffier as we spoke in Zulipchat, I propose to have a `withHeaders` method so we don't have to create a chain of `withHeader` to redirect incoming headers!

The ideia of having this method is to avoid creating a chain of `withHeader(String, Object)`, but a simple way to insert mutiple headers at once. 

Some scenarios may have something similar to this

```java
OutgoingRabbitMQMetadata metadata = new OutgoingRabbitMQMetadata.Builder()
                .withHeader("type", "invoice")
                .withHeader("currency", "CAD")
                // Other headers.
                .withHeader("country", "CA").build()
```

```java
Map<String, Object> headers = anotherRequest.getHeaders()
OutgoingRabbitMQMetadata metadata = new OutgoingRabbitMQMetadata.Builder()
                .withHeaders(headers);
```