### PR TITLE
Fix the check for topic creation

### DIFF
--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/TopicsCompanion.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/TopicsCompanion.java
@@ -102,7 +102,10 @@ public class TopicsCompanion {
                 .map(topics -> topics.get(topic));
     }
 
-    private boolean checkIfTheTopicIsCreated(String topic, Map<String, TopicDescription> description) {
+    boolean checkIfTheTopicIsCreated(String topic, Map<String, TopicDescription> description) {
+        if (description == null) {
+            return false;
+        }
         TopicDescription td = description.get(topic);
         if (td == null) {
             return false;
@@ -116,6 +119,14 @@ public class TopicsCompanion {
         }
         return true;
     }
+    //
+    //    boolean checkIfTheTopicIsCreated(String topic, Map<String, TopicDescription> description) {
+    //        return Optional.ofNullable(description)
+    //                .map(topics -> topics.get(topic))
+    //                .map(td -> td.partitions().stream()
+    //                        .allMatch(partition -> partition.leader() != null && partition.leader().id() >= 0))
+    //                .orElse(false);
+    //    }
 
     /**
      * @return the set of topic names

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/TopicsCompanion.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/TopicsCompanion.java
@@ -3,17 +3,14 @@ package io.smallrye.reactive.messaging.kafka.companion;
 import static io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion.toUni;
 
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartitionInfo;
 
 import io.smallrye.mutiny.Uni;
 
@@ -94,9 +91,30 @@ public class TopicsCompanion {
         return Uni.createFrom().item(this::describeAll)
                 .repeat()
                 .withDelay(Duration.ofMillis(1000))
-                .whilst(topics -> retries.incrementAndGet() < 10 && !topics.containsKey(topic))
+                .until(topics -> {
+                    if (retries.incrementAndGet() >= 10) {
+                        throw new IllegalStateException("Max number of attempts reached, the topic "
+                                + topic + " was not created after 10 attempts");
+                    }
+                    return !checkIfTheTopicIsCreated(topic, topics);
+                })
                 .toUni()
                 .map(topics -> topics.get(topic));
+    }
+
+    private boolean checkIfTheTopicIsCreated(String topic, Map<String, TopicDescription> description) {
+        TopicDescription td = description.get(topic);
+        if (td == null) {
+            return false;
+        }
+        // The topic is created, check that each partition has a leader
+        List<TopicPartitionInfo> partitions = td.partitions();
+        for (TopicPartitionInfo partition : partitions) {
+            if (partition.leader() == null || partition.leader().id() < 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaBatchConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaBatchConsumerTest.java
@@ -9,10 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.Cancellable;
-import io.smallrye.reactive.messaging.kafka.CountKafkaCdiEvents;
-import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordBatch;
-import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
-import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
+import io.smallrye.reactive.messaging.kafka.*;
 import io.smallrye.reactive.messaging.kafka.base.SingletonInstance;
 import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
@@ -44,7 +41,7 @@ public class ReactiveKafkaBatchConsumerTest extends ClientTestBase {
             int sendStartIndex, int sendCount,
             int receiveStartIndex, int receiveCount, int batchCount) throws Exception {
 
-        CountDownLatch latch = new CountDownLatch(batchCount);
+        CountDownLatch latch = new CountDownLatch(sendCount);
         subscribeBatch(stream, latch);
         if (sendCount > 0) {
             sendMessages(sendStartIndex, sendCount);
@@ -77,7 +74,9 @@ public class ReactiveKafkaBatchConsumerTest extends ClientTestBase {
                 .onItem().invoke(record -> {
                     onReceive(record);
                     for (CountDownLatch latch : latches) {
-                        latch.countDown();
+                        for (KafkaRecord<Integer, String> ignored : record.getRecords()) {
+                            latch.countDown();
+                        }
                     }
                 })
                 .subscribe().with(ignored -> {

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
@@ -120,7 +120,7 @@ public class OutgoingRabbitMQMetadata {
             headers.put(header, value);
             return this;
         }
-        
+
         /**
          * Adds the message headers to the metadata.
          *


### PR DESCRIPTION
- It now verifies that the topic is created and each partition has a leader.
- Also fix a rebalance listener called with an empty list.
