### PR TITLE
Make getWorker overridable

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/connectors/WorkerPoolRegistry.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/connectors/WorkerPoolRegistry.java
@@ -95,7 +95,7 @@ public class WorkerPoolRegistry {
         }
     }
 
-    private WorkerExecutor getWorker(String workerName) {
+    public WorkerExecutor getWorker(String workerName) {
         Objects.requireNonNull(workerName, msg.workerNameNotSpecified());
 
         if (workerExecutors.containsKey(workerName)) {


### PR DESCRIPTION
This fixes the broker integration in Quarkus (there is still something to do in Quarkus, but very minor).