### PR TITLE
Adding support to null value to headers comming from RabbitMQ

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
@@ -33,9 +33,8 @@ public class IncomingRabbitMQMetadata {
 
         // Ensure the message headers are cast appropriately
         final Map<String, Object> incomingHeaders = message.properties().getHeaders();
-        headers = (incomingHeaders != null) ? incomingHeaders.entrySet().stream().collect(Collectors.toMap(
-                Map.Entry::getKey,
-                e -> mapValue(e.getValue())))
+        headers = (incomingHeaders != null) ? incomingHeaders.entrySet().stream()
+                .collect(HashMap::new, (m,e)->m.put(e.getKey(), mapValue(e.getValue())), HashMap::putAll)
                 : new HashMap<>();
     }
 

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTest.java
@@ -1,0 +1,137 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import com.rabbitmq.client.BasicProperties;
+import com.rabbitmq.client.Envelope;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.rabbitmq.RabbitMQMessage;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class IncomingRabbitMQMetadataTest {
+
+    @Test
+    public void testHeaderWithNullValue(){
+        Map<String,Object> properties = new HashMap<>();
+        properties.put("header1", "value1");
+        properties.put("header2", null);
+
+        DummyRabbitMQMessage message = new DummyRabbitMQMessage(new DummyBasicProperties(properties));
+
+        IncomingRabbitMQMetadata incomingRabbitMQMetadata = new IncomingRabbitMQMetadata(message);
+
+        Assert.assertEquals("value1", incomingRabbitMQMetadata.getHeaders().get("header1"));
+        Assert.assertTrue( incomingRabbitMQMetadata.getHeaders().containsKey("header2"));
+        Assert.assertNull( incomingRabbitMQMetadata.getHeaders().get("header2"));
+
+    }
+
+    class DummyRabbitMQMessage implements RabbitMQMessage{
+        protected BasicProperties properties;
+
+        DummyRabbitMQMessage(BasicProperties properties){
+            this.properties = properties;
+        }
+
+        @Override
+        public Buffer body() {
+            return null;
+        }
+
+        @Override
+        public String consumerTag() {
+            return null;
+        }
+
+        @Override
+        public Envelope envelope() {
+            return null;
+        }
+
+        @Override
+        public BasicProperties properties() {
+            return this.properties;
+        }
+
+        @Override
+        public Integer messageCount() {
+            return null;
+        }
+    }
+
+    class DummyBasicProperties implements BasicProperties{
+        protected Map<String, Object> headers;
+
+        DummyBasicProperties(Map<String, Object> headers){
+            this.headers = headers;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public String getContentEncoding() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getHeaders() {
+            return headers;
+        }
+
+        @Override
+        public Integer getDeliveryMode() {
+            return null;
+        }
+
+        @Override
+        public Integer getPriority() {
+            return null;
+        }
+
+        @Override
+        public String getCorrelationId() {
+            return null;
+        }
+
+        @Override
+        public String getReplyTo() {
+            return null;
+        }
+
+        @Override
+        public String getExpiration() {
+            return null;
+        }
+
+        @Override
+        public String getMessageId() {
+            return null;
+        }
+
+        @Override
+        public Date getTimestamp() {
+            return null;
+        }
+
+        @Override
+        public String getType() {
+            return null;
+        }
+
+        @Override
+        public String getUserId() {
+            return null;
+        }
+
+        @Override
+        public String getAppId() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Rhuan Rocha <rhuan080@gmail.com>

The RabbitMQ accepts a nullable value to headers, but the IncomingRabbitMQMetadata.java uses Collectors.toMap that is not nullable and returns an exception.

I wrote a unit test to it as well.