### PR TITLE
Setup Revapi for tracking API changes

### DIFF
--- a/.github/CompatibilityUtils.java
+++ b/.github/CompatibilityUtils.java
@@ -1,0 +1,187 @@
+///usr/bin/env jbang "$0" "$@" ; exit $? # (1)
+//DEPS io.vertx:vertx-core:3.9.4
+//DEPS info.picocli:picocli:4.5.0
+
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+import java.nio.charset.*;
+import java.nio.file.*;
+
+import io.vertx.core.json.*;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.concurrent.Callable;
+
+import com.fasterxml.jackson.annotation.*;
+
+@Command(name = "compatibility", mixinStandardHelpOptions = true, version = "0.1",
+        description = "Compatibility Utils")
+class CompatibilityUtils implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Command among 'extract' and 'clear'")
+    private String command;
+
+    public static void main(String... args) {
+        int exitCode = new CommandLine(new CompatibilityUtils()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        List<File> files = getRevapiConfigFiles();
+        if (command.equalsIgnoreCase("extract")) {
+            List<Difference> differences = new ArrayList<>();
+            for (File f : files) {
+                System.out.println("\uD83D\uDD0E Found revapi.json file: " + f.getAbsolutePath());
+                JsonArray json = new JsonArray(read(f));
+                List<Difference> diff = extractDifferences(json);
+                differences.addAll(diff);
+
+            }
+            System.out.println("\uD83E\uDDEE " + differences.size() + " difference(s) found");
+            if (! differences.isEmpty()) {
+                writeDifferences(differences, new File("target/differences.md"));
+            }
+            return 0;
+        }
+
+        if (command.equalsIgnoreCase("clear")) {
+            for (File f : files) {
+                System.out.println("\uD83D\uDD0E Clearing differences from revapi.json file: " + f.getAbsolutePath());
+                JsonArray json = new JsonArray(read(f));
+                clearDifferences(f, json);
+            }
+            return 0;
+        }
+
+
+        return 1;
+    }
+
+    private void writeDifferences(List<Difference> diff, File file) {
+        if (file.isFile()) {
+            file.delete();
+        }
+        StringBuilder buffer = new StringBuilder();
+        buffer.append("### Breaking Changes\n\n");
+
+        for (Difference difference : diff) {
+            buffer.append("  * ").append(difference.toString()).append("\n");
+        }
+        buffer.append("\n");
+
+        try {
+            Files.writeString(file.toPath(), buffer.toString());
+            System.out.println("\uD83D\uDCBD File " + file.getAbsolutePath() + " written");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    static List<File> getRevapiConfigFiles() {
+        List<File> matches = new ArrayList<>();
+        File root = new File(System.getProperty("user.dir"));
+        File[] files = root.listFiles();
+        if (files == null) {
+            throw new IllegalStateException("Unable to read the file system");
+        } else {
+            for (File f : files) {
+                if (f.isDirectory()) {
+                    File maybe = new File(f, "revapi.json");
+                    if (maybe.isFile()) {
+                        matches.add(maybe);
+                    }
+                }
+            }
+        }
+        return matches;
+    }
+
+    static List<Difference> extractDifferences(JsonArray array) {
+        Optional<JsonArray> diff = array.stream()
+                .map(obj -> (JsonObject) obj)
+                .filter(json -> json.getString("extension").equals("revapi.differences"))
+                .map(json -> json.getJsonObject("configuration"))
+                .map(conf -> conf.getJsonArray("differences"))
+                .findFirst();
+
+        return diff
+                .map(objects ->
+                        objects.stream().map(obj -> (JsonObject) obj).map(json -> json.mapTo(Difference.class)).collect(Collectors.toList())
+                )
+                .orElse(Collections.emptyList());
+    }
+
+    static void clearDifferences(File file, JsonArray array) {
+        boolean updated = false;
+        for (Object obj : array) {
+            JsonObject json = (JsonObject) obj;
+            if ("revapi.differences".equalsIgnoreCase(json.getString("extension"))) {
+                JsonObject configuration = json.getJsonObject("configuration");
+                JsonArray differences = configuration.getJsonArray("differences");
+                if (differences != null  && ! differences.isEmpty()) {
+                    updated = true;
+                    configuration.remove("differences");
+                    configuration.put("differences", new JsonArray());
+                }
+            }
+        }
+
+        if (updated) {
+            System.out.println("\uD83D\uDCC1 Updating " + file.getAbsolutePath());
+            try {
+                Files.writeString(file.toPath(), array.encodePrettily());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+    }
+
+    static String read(File file) {
+        StringBuilder content = new StringBuilder();
+        try (Stream<String> stream = Files.lines(file.toPath(), StandardCharsets.UTF_8)) {
+            stream.forEach(s -> content.append(s).append("\n"));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return content.toString();
+    }
+
+    static boolean isNotBlank(String s) {
+        if (s == null) {
+            return false;
+        }
+        return !s.trim().isEmpty();
+    }
+
+    static class Difference {
+        public String code;
+        @JsonProperty("old")
+        public String oldMethod;
+        @JsonProperty("new")
+        public String newMethod;
+        public String justification;
+
+        @java.lang.Override
+        public java.lang.String toString() {
+            if (isNotBlank(oldMethod)  && isNotBlank(newMethod)) {
+                return "`" + oldMethod + "` updated to `" + newMethod + "`: _" + justification + "_";
+            }
+            if (isNotBlank(oldMethod)) {
+                return "`" + oldMethod + "` has been removed: _" + justification  + "_";
+            }
+            if (isNotBlank(newMethod)) {
+                return "`" + newMethod + "` has been introduced: _" + justification  + "_";
+            }
+
+            return  code + " " + justification;
+        }
+    }
+
+}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>smallrye-reactive-messaging-api</artifactId>
     <name>SmallRye Reactive Messaging : API</name>
 
+    <properties>
+      <revapi.skip>false</revapi.skip>
+    </properties>
+
     <dependencies>
         <!--
         This API does not depend on the upstream specification API as it's embedded.

--- a/api/revapi.json
+++ b/api/revapi.json
@@ -1,0 +1,59 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    {
+                        "matcher": "java-package",
+                        "match": "/io\\.smallrye\\.reactive\\.messaging(\\..+)?/"
+                    },
+                    {
+                        "matcher": "java-package",
+                        "match": "/org\\.eclipse\\.microprofile\\.reactive\\.messaging(\\..+)?/"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
     <slf4j-log4j12.version>1.7.33</slf4j-log4j12.version>
     <opencsv.version>5.6</opencsv.version>
     <strimzi-test-container.version>0.101.0</strimzi-test-container.version>
+
+    <revapi-maven-plugin.version>0.14.6</revapi-maven-plugin.version>
+    <revapi-java.version>0.26.1</revapi-java.version>
+    <revapi-reporter-json.version>0.4.5</revapi-reporter-json.version>
+    <revapi-reporter-text.version>0.14.5</revapi-reporter-text.version>
+    <revapi.skip>true</revapi.skip>
   </properties>
 
   <modules>
@@ -476,6 +482,42 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.revapi</groupId>
+          <artifactId>revapi-maven-plugin</artifactId>
+          <version>${revapi-maven-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.revapi</groupId>
+              <artifactId>revapi-java</artifactId>
+              <version>${revapi-java.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.revapi</groupId>
+              <artifactId>revapi-reporter-json</artifactId>
+              <version>${revapi-reporter-json.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.revapi</groupId>
+              <artifactId>revapi-reporter-text</artifactId>
+              <version>${revapi-reporter-text.version}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <id>check-compatibility</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <configuration>
+                <failSeverity>breaking</failSeverity>
+                <analysisConfigurationFiles>
+                  <file>${project.basedir}/revapi.json</file>
+                </analysisConfigurationFiles>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -511,6 +553,14 @@
         </executions>
         <configuration>
           <additionalOptions>-Xdoclint:none</additionalOptions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <!-- Do not compute compatibility on the documentation -->
+          <skip>${revapi.skip}</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/smallrye-reactive-messaging-amqp/pom.xml
+++ b/smallrye-reactive-messaging-amqp/pom.xml
@@ -13,6 +13,10 @@
 
   <name>SmallRye Reactive Messaging : Connector :: AMQP</name>
 
+  <properties>
+    <revapi.skip>false</revapi.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/smallrye-reactive-messaging-amqp/revapi.json
+++ b/smallrye-reactive-messaging-amqp/revapi.json
@@ -1,0 +1,55 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    "class io.smallrye.reactive.messaging.amqp.AmqpMessage",
+                    "class io.smallrye.reactive.messaging.amqp.OutgoingAmqpMessage",
+                    "class io.smallrye.reactive.messaging.amqp.IncomingAmqpMetadata",
+                    "class io.smallrye.reactive.messaging.amqp.OutgoingAmqpMetadata"
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-camel/pom.xml
+++ b/smallrye-reactive-messaging-camel/pom.xml
@@ -12,6 +12,10 @@
 
   <name>SmallRye Reactive Messaging : Connector :: Camel</name>
 
+  <properties>
+    <revapi.skip>false</revapi.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/smallrye-reactive-messaging-camel/revapi.json
+++ b/smallrye-reactive-messaging-camel/revapi.json
@@ -1,0 +1,54 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    "class io.smallrye.reactive.messaging.camel.CamelMessage",
+                    "class io.smallrye.reactive.messaging.camel.IncomingExchangeMetadata",
+                    "class io.smallrye.reactive.messaging.camel.OutgoingExchangeMetadata"
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-in-memory/pom.xml
+++ b/smallrye-reactive-messaging-in-memory/pom.xml
@@ -12,6 +12,10 @@
 
   <name>SmallRye Reactive Messaging : Connector :: In-memory</name>
 
+  <properties>
+    <revapi.skip>false</revapi.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/smallrye-reactive-messaging-in-memory/revapi.json
+++ b/smallrye-reactive-messaging-in-memory/revapi.json
@@ -1,0 +1,55 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    {
+                        "matcher": "java-package",
+                        "match": "/io\\.smallrye\\.reactive\\.messaging\\.providers\\.connectors(\\..+)?/"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-jms/pom.xml
+++ b/smallrye-reactive-messaging-jms/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <artemis.version>2.19.0</artemis.version>
+    <revapi.skip>false</revapi.skip>
   </properties>
 
   <dependencies>

--- a/smallrye-reactive-messaging-jms/revapi.json
+++ b/smallrye-reactive-messaging-jms/revapi.json
@@ -1,0 +1,56 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    "class io.smallrye.reactive.messaging.jms.IncomingJmsMessage",
+                    "class io.smallrye.reactive.messaging.jms.JmsMessageMetadata",
+                    "class io.smallrye.reactive.messaging.jms.JmsProperties",
+                    "class io.smallrye.reactive.messaging.jms.IncomingJmsMessageMetadata",
+                    "class io.smallrye.reactive.messaging.jms.OutgoingJmsMessageMetadata"
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-kafka-api/pom.xml
+++ b/smallrye-reactive-messaging-kafka-api/pom.xml
@@ -13,6 +13,10 @@
 
   <name>SmallRye Reactive Messaging : Connector :: Kafka User API</name>
 
+  <properties>
+    <revapi.skip>false</revapi.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/smallrye-reactive-messaging-kafka-api/revapi.json
+++ b/smallrye-reactive-messaging-kafka-api/revapi.json
@@ -1,0 +1,55 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    {
+                        "matcher": "java-package",
+                        "match": "/io\\.smallrye\\.reactive\\.messaging\\.kafka\\.api(\\..+)?/"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-kafka-test-companion/pom.xml
+++ b/smallrye-reactive-messaging-kafka-test-companion/pom.xml
@@ -13,6 +13,10 @@
 
   <name>SmallRye Reactive Messaging : Connector :: Kafka Testing Companion</name>
 
+  <properties>
+    <revapi.skip>false</revapi.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/smallrye-reactive-messaging-kafka-test-companion/revapi.json
+++ b/smallrye-reactive-messaging-kafka-test-companion/revapi.json
@@ -1,0 +1,65 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    {
+                        "matcher": "java-package",
+                        "match": "/io\\.smallrye\\.reactive\\.messaging\\.kafka\\.companion(\\..+)?/"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+                {
+                    "code": "java.class.removed",
+                    "old": "class io.smallrye.reactive.messaging.kafka.companion.RecordsSubscriber<T, SELF extends io.smallrye.reactive.messaging.kafka.companion.RecordsSubscriber<T, SELF>>",
+                    "justification": "RecordsSubscriber should not be public"
+                },
+                {
+                    "code": "java.method.removed",
+                    "old": "method org.apache.kafka.common.Uuid io.strimzi.test.container.StrimziKafkaContainer::randomUuid() @ io.smallrye.reactive.messaging.kafka.companion.test.ProxiedStrimziKafkaContainer",
+                    "justification": "Method removed upstream, use org.apache.kafka.common.Uuid::randomUuid"
+                }
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/RecordsSubscriber.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/RecordsSubscriber.java
@@ -27,7 +27,7 @@ import io.smallrye.mutiny.subscription.MultiSubscriber;
  *
  * @param <T> the type of the records
  */
-public class RecordsSubscriber<T, SELF extends RecordsSubscriber<T, SELF>> implements MultiSubscriber<T>, Iterable<T> {
+class RecordsSubscriber<T, SELF extends RecordsSubscriber<T, SELF>> implements MultiSubscriber<T>, Iterable<T> {
 
     /**
      * The default timeout used by {@code await} method.

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/TopicsTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/TopicsTest.java
@@ -5,7 +5,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -13,6 +13,10 @@
 
   <name>SmallRye Reactive Messaging : Connector :: Kafka</name>
 
+  <properties>
+    <revapi.skip>false</revapi.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/smallrye-reactive-messaging-kafka/revapi.json
+++ b/smallrye-reactive-messaging-kafka/revapi.json
@@ -1,0 +1,55 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    {
+                        "matcher": "java-package",
+                        "match": "io.smallrye.reactive.messaging.kafka"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-mqtt/pom.xml
+++ b/smallrye-reactive-messaging-mqtt/pom.xml
@@ -13,6 +13,10 @@
 
   <name>SmallRye Reactive Messaging : Connector :: MQTT</name>
 
+  <properties>
+    <revapi.skip>false</revapi.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/smallrye-reactive-messaging-mqtt/revapi.json
+++ b/smallrye-reactive-messaging-mqtt/revapi.json
@@ -1,0 +1,53 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    "class io.smallrye.reactive.messaging.mqtt.SendingMqttMessage",
+                    "class io.smallrye.reactive.messaging.mqtt.ReceivingMqttMessage"
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-provider/pom.xml
+++ b/smallrye-reactive-messaging-provider/pom.xml
@@ -13,6 +13,10 @@
 
   <name>SmallRye Reactive Messaging : Provider</name>
 
+  <properties>
+    <revapi.skip>false</revapi.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>

--- a/smallrye-reactive-messaging-provider/revapi.json
+++ b/smallrye-reactive-messaging-provider/revapi.json
@@ -1,0 +1,82 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    "class io.smallrye.reactive.messaging.providers.PublisherDecorator",
+                    {
+                        "matcher": "java-package",
+                        "match": "io.smallrye.reactive.messaging.providers.connectors"
+                    },
+                    {
+                        "matcher": "java-package",
+                        "match": "io.smallrye.reactive.messaging.providers.locals"
+                    },
+                    {
+                        "matcher": "java-package",
+                        "match": "io.smallrye.reactive.messaging.providers.wiring"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+                {
+                    "code": "java.method.numberOfParametersChanged",
+                    "old": "method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.AbstractMediator::invokeBlocking(java.lang.Object[])",
+                    "new": "method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.AbstractMediator::invokeBlocking(org.eclipse.microprofile.reactive.messaging.Message<?>, java.lang.Object[])",
+                    "justification": "Message added to signature for running on duplicated context"
+                },
+                {
+                    "code": "java.method.numberOfParametersChanged",
+                    "old": "method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.ProcessorMediator::invokeBlocking(java.lang.Object[])",
+                    "new": "method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.ProcessorMediator::invokeBlocking(org.eclipse.microprofile.reactive.messaging.Message<?>, java.lang.Object[])",
+                    "justification": "Message added to signature for running on duplicated context"
+                },
+                {
+                    "code": "java.method.numberOfParametersChanged",
+                    "old": "method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry::executeWork(io.smallrye.mutiny.Uni<T>, java.lang.String, boolean)",
+                    "new": "method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry::executeWork(io.vertx.mutiny.core.Context, io.smallrye.mutiny.Uni<T>, java.lang.String, boolean)",
+                    "justification": "Context added to signature for running on duplicated context"
+                }
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
@@ -206,7 +206,7 @@ public class Wiring {
         void materialize(ChannelRegistry registry);
     }
 
-    interface PublishingComponent extends Component {
+    public interface PublishingComponent extends Component {
         boolean broadcast();
 
         int getRequiredNumberOfSubscribers();
@@ -226,7 +226,7 @@ public class Wiring {
         }
     }
 
-    interface ConsumingComponent extends Component {
+    public interface ConsumingComponent extends Component {
 
         @Override
         default boolean isUpstreamResolved() {

--- a/smallrye-reactive-messaging-rabbitmq/pom.xml
+++ b/smallrye-reactive-messaging-rabbitmq/pom.xml
@@ -13,6 +13,9 @@
 
   <name>SmallRye Reactive Messaging : Connector :: RabbitMQ</name>
 
+  <properties>
+    <revapi.skip>false</revapi.skip>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/smallrye-reactive-messaging-rabbitmq/revapi.json
+++ b/smallrye-reactive-messaging-rabbitmq/revapi.json
@@ -1,0 +1,54 @@
+[
+    {
+        "extension": "revapi.java",
+        "id": "java",
+        "configuration": {
+            "missing-classes": {
+                "behavior": "report",
+                "ignoreMissingAnnotations": false
+            }
+        }
+    },
+    {
+        "extension": "revapi.filter",
+        "configuration": {
+            "elements": {
+                "include": [
+                    "class io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage",
+                    "class io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMetadata",
+                    "class io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata"
+                ]
+            }
+        }
+    },
+    {
+        "extension": "revapi.differences",
+        "id": "breaking-changes",
+        "configuration": {
+            "criticality": "highlight",
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "differences": [
+            ]
+        }
+    },
+    {
+        "extension": "revapi.reporter.json",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "target/compatibility.json",
+            "indent": true,
+            "append": false,
+            "keepEmptyFile": true
+        }
+    },
+    {
+        "extension": "revapi.reporter.text",
+        "configuration": {
+            "minSeverity": "POTENTIALLY_BREAKING",
+            "minCriticality": "documented",
+            "output": "out"
+        }
+    }
+]

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
@@ -34,7 +34,7 @@ public class IncomingRabbitMQMetadata {
         // Ensure the message headers are cast appropriately
         final Map<String, Object> incomingHeaders = message.properties().getHeaders();
         headers = (incomingHeaders != null) ? incomingHeaders.entrySet().stream()
-                .collect(HashMap::new, (m,e)->m.put(e.getKey(), mapValue(e.getValue())), HashMap::putAll)
+                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), mapValue(e.getValue())), HashMap::putAll)
                 : new HashMap<>();
     }
 

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTest.java
@@ -1,21 +1,23 @@
 package io.smallrye.reactive.messaging.rabbitmq;
 
-import com.rabbitmq.client.BasicProperties;
-import com.rabbitmq.client.Envelope;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.rabbitmq.RabbitMQMessage;
-import org.junit.Assert;
-import org.junit.jupiter.api.Test;
-
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import com.rabbitmq.client.BasicProperties;
+import com.rabbitmq.client.Envelope;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.rabbitmq.RabbitMQMessage;
+
 public class IncomingRabbitMQMetadataTest {
 
     @Test
-    public void testHeaderWithNullValue(){
-        Map<String,Object> properties = new HashMap<>();
+    public void testHeaderWithNullValue() {
+        Map<String, Object> properties = new HashMap<>();
         properties.put("header1", "value1");
         properties.put("header2", null);
 
@@ -24,15 +26,15 @@ public class IncomingRabbitMQMetadataTest {
         IncomingRabbitMQMetadata incomingRabbitMQMetadata = new IncomingRabbitMQMetadata(message);
 
         Assert.assertEquals("value1", incomingRabbitMQMetadata.getHeaders().get("header1"));
-        Assert.assertTrue( incomingRabbitMQMetadata.getHeaders().containsKey("header2"));
-        Assert.assertNull( incomingRabbitMQMetadata.getHeaders().get("header2"));
+        Assert.assertTrue(incomingRabbitMQMetadata.getHeaders().containsKey("header2"));
+        Assert.assertNull(incomingRabbitMQMetadata.getHeaders().get("header2"));
 
     }
 
-    class DummyRabbitMQMessage implements RabbitMQMessage{
+    class DummyRabbitMQMessage implements RabbitMQMessage {
         protected BasicProperties properties;
 
-        DummyRabbitMQMessage(BasicProperties properties){
+        DummyRabbitMQMessage(BasicProperties properties) {
             this.properties = properties;
         }
 
@@ -62,10 +64,10 @@ public class IncomingRabbitMQMetadataTest {
         }
     }
 
-    class DummyBasicProperties implements BasicProperties{
+    class DummyBasicProperties implements BasicProperties {
         protected Map<String, Object> headers;
 
-        DummyBasicProperties(Map<String, Object> headers){
+        DummyBasicProperties(Map<String, Object> headers) {
             this.headers = headers;
         }
 


### PR DESCRIPTION
Manual release process to include extracting breaking changes to release description and clearing them on post-release.

Tracked modules:
- API : packages _org.eclipse.microprofile.reactive.messaging.*_ and _io.smallrye.reactive.messaging.*_
- provider : packages _io.smallrye.reactive.messaging.providers_, _io.smallrye.reactive.messaging.providers.connectors_, _io.smallrye.reactive.messaging.providers.locals_, _io.smallrye.reactive.messaging.providers.wiring_
- in-memory : packages _io.smallrye.reactive.messaging.providers.connectors.*_
- kafka-api : packages _io.smallrye.reactive.messaging.kafka.api_
- kafka : package _io.smallrye.reactive.messaging.kafka_
- kafka-test-companion : packages _io.smallrye.reactive.messaging.kafka.companion.*_
- amqp : class _AmqpMessage_, _OutgoingAmqpMessage_, _IncomingAmqpMetadata_, _OutgoingAmqpMetadata_
- rabbitmq : class _IncomingRabbitMQMessage_, _IncomingRabbitMQMetadata_, _OutgoingRabbitMQMetadata_
- mqtt : class _SendingMqttMessage_ and _ReceivingMqttMessage_
- camel : class _CamelMessage_, _IncomingExchangeMetadata_, _OutgoingExchangeMetadata_
- jms : class _IncomingJmsMessage_, _JmsMessageMetadata_, _JmsProperties_, _IncomingJmsMessageMetadata_, _OutgoingJmsMessageMetadata_

Current breaking changes between 3.14.1 and 3.15.0 are :

  * `method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.AbstractMediator::invokeBlocking(java.lang.Object[])` updated to `method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.AbstractMediator::invokeBlocking(org.eclipse.microprofile.reactive.messaging.Message<?>, java.lang.Object[])`: _Message added to signature for running on duplicated context_
  * `method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.ProcessorMediator::invokeBlocking(java.lang.Object[])` updated to `method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.ProcessorMediator::invokeBlocking(org.eclipse.microprofile.reactive.messaging.Message<?>, java.lang.Object[])`: _Message added to signature for running on duplicated context_
  * `method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry::executeWork(io.smallrye.mutiny.Uni<T>, java.lang.String, boolean)` updated to `method <T> io.smallrye.mutiny.Uni<T> io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry::executeWork(io.vertx.mutiny.core.Context, io.smallrye.mutiny.Uni<T>, java.lang.String, boolean)`: _Context added to signature for running on duplicated context_
  * `class io.smallrye.reactive.messaging.kafka.companion.RecordsSubscriber<T, SELF extends io.smallrye.reactive.messaging.kafka.companion.RecordsSubscriber<T, SELF>>` has been removed: _RecordsSubscriber should not be public_
  * `method org.apache.kafka.common.Uuid io.strimzi.test.container.StrimziKafkaContainer::randomUuid() @ io.smallrye.reactive.messaging.kafka.companion.test.ProxiedStrimziKafkaContainer` has been removed: _Method removed upstream, use org.apache.kafka.common.Uuid::randomUuid_

