### PR TITLE
Fix duration unit mismatch with RabbitMQ reconnect interval

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQClientHelper.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQClientHelper.java
@@ -4,6 +4,7 @@ import static com.rabbitmq.client.impl.DefaultCredentialsRefreshService.fixedTim
 import static com.rabbitmq.client.impl.DefaultCredentialsRefreshService.ratioRefreshDelayStrategy;
 import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions.ex;
 import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
+import static java.time.Duration.ofSeconds;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -24,7 +25,7 @@ import io.vertx.rabbitmq.RabbitMQOptions;
 public class RabbitMQClientHelper {
 
     private static final double CREDENTIALS_PROVIDER_REFRESH_DELAY_RATIO = 0.8;
-    private static final Duration CREDENTIALS_PROVIDER_APPROACH_EXPIRE_TIME = Duration.ofSeconds(1);
+    private static final Duration CREDENTIALS_PROVIDER_APPROACH_EXPIRE_TIME = ofSeconds(1);
 
     private RabbitMQClientHelper() {
         // avoid direct instantiation.
@@ -76,7 +77,7 @@ public class RabbitMQClientHelper {
                     .setAutomaticRecoveryEnabled(config.getAutomaticRecoveryEnabled())
                     .setAutomaticRecoveryOnInitialConnection(config.getAutomaticRecoveryOnInitialConnection())
                     .setReconnectAttempts(config.getReconnectAttempts())
-                    .setReconnectInterval(config.getReconnectInterval())
+                    .setReconnectInterval(ofSeconds(config.getReconnectInterval()).toMillis())
                     .setConnectionTimeout(config.getConnectionTimeout())
                     .setHandshakeTimeout(config.getHandshakeTimeout())
                     .setIncludeProperties(config.getIncludeProperties())

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -336,9 +336,8 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
                 .onItem().transformToUni(connection -> Uni.createFrom().item(RabbitMQPublisher.create(getVertx(), connection,
                         new RabbitMQPublisherOptions()
                                 .setReconnectAttempts(oc.getReconnectAttempts())
-                                .setReconnectInterval(oc.getReconnectInterval())
-                                .setMaxInternalQueueSize(
-                                        oc.getMaxOutgoingInternalQueueSize().orElse(Integer.MAX_VALUE)))))
+                                .setReconnectInterval(ofSeconds(oc.getReconnectInterval()).toMillis())
+                                .setMaxInternalQueueSize(oc.getMaxOutgoingInternalQueueSize().orElse(Integer.MAX_VALUE)))))
                 // Start the publisher
                 .onItem().call(RabbitMQPublisher::start)
                 .invoke(s -> {


### PR DESCRIPTION
SM RabbitMQ’s units for `rabbitmq-reconnect-interval` (or `reconnect-interval` on a specific connector) is specified in **_seconds_**.    Vertx’s `NetworkOptions.reconnectInterval` is specified in **_milliseconds_**.

This leads to a pretty egregious hammering of the server when Vertx’s client is doing the reconnection because it’s trying every 10ms (when using the defaults).