### PR TITLE
Use empty beans.xml and fix examples

### DIFF
--- a/attic/awssns-quickstart/src/main/resources/META-INF/beans.xml
+++ b/attic/awssns-quickstart/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/attic/gcp-pubsub-quickstart/src/main/resources/META-INF/beans.xml
+++ b/attic/gcp-pubsub-quickstart/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/attic/mqtt-server-quickstart/src/main/resources/META-INF/beans.xml
+++ b/attic/mqtt-server-quickstart/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,0 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
-  bean-discovery-mode="annotated" version="2.0">
-</beans>

--- a/attic/smallrye-reactive-messaging-aws-sns/src/main/resources/META-INF/beans.xml
+++ b/attic/smallrye-reactive-messaging-aws-sns/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/attic/smallrye-reactive-messaging-mqtt-server/src/main/resources/META-INF/beans.xml
+++ b/attic/smallrye-reactive-messaging-mqtt-server/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,0 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
-  bean-discovery-mode="annotated" version="2.0">
-</beans>

--- a/attic/smallrye-reactive-messaging-vertx-eventbus/src/main/resources/META-INF/beans.xml
+++ b/attic/smallrye-reactive-messaging-vertx-eventbus/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/examples/amqp-quickstart/README.md
+++ b/examples/amqp-quickstart/README.md
@@ -9,11 +9,11 @@ First you need a AMQP server. You can follow the instructions from the [ActiveMQ
 
 ## Start the application
 
-The application can be started using: 
+The application can be started using:
 
 ```bash
-mvn package exec:java
-```  
+mvn compile exec:java
+```
 
 Then, looking at the output you can see messages successfully send to and retrieved from a AMQP topic.
 
@@ -23,7 +23,7 @@ In addition to the commandline output, the application is composed by 3 componen
 
 * `BeanUsingAnEmitter` - a bean sending a changing hello message to AMQP topic every second.
 * `Sender` - a bean sending a fixed message to a dynamic AMQP topic every 5 seconds.
-* `Receiver`  - on the consuming side, the `Receiver` retreives messages from a AMQP topic and writes the message content to `stdout`.
+* `Receiver`  - on the consuming side, the `Receiver` retrieves messages from a AMQP topic and writes the message content to `stdout`.
 
 The interaction with AMQP is managed by MicroProfile Reactive Messaging.
 The configuration is located in the microprofile config properties.

--- a/examples/amqp-quickstart/pom.xml
+++ b/examples/amqp-quickstart/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.smallrye.reactive</groupId>
     <artifactId>smallrye-reactive-messaging</artifactId>
     <version>3.16.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>amqp-quickstart</artifactId>
@@ -16,7 +16,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <weld-core.version>3.1.7.SP1</weld-core.version>
+    <weld-core.version>3.1.9.Final</weld-core.version>
 
     <mainClass>acme.Main</mainClass>
 
@@ -56,12 +56,8 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <version>${weld-core.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
     </dependency>
 
     <dependency>

--- a/examples/amqp-quickstart/src/main/resources/META-INF/beans.xml
+++ b/examples/amqp-quickstart/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/examples/amqp-quickstart/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/amqp-quickstart/src/main/resources/META-INF/microprofile-config.properties
@@ -5,18 +5,18 @@ amqp-username=smallrye
 amqp-password=smallrye
 
 # AMQP Sink
-smallrye.messaging.sink.data.connector=smallrye-amqp
-smallrye.messaging.sink.data.address=default
-smallrye.messaging.sink.data.durable=true
+mp.messaging.outgoing.data.connector=smallrye-amqp
+mp.messaging.outgoing.data.address=default
+mp.messaging.outgoing.data.durable=true
 
 # AMQP sink (we write to using an Emitter)
-smallrye.messaging.sink.my-channel.connector=smallrye-amqp
-smallrye.messaging.sink.my-channel.address=hello
-smallrye.messaging.sink.my-channel.durable=true
-smallrye.messaging.sink.my-channel.client-options-name=my-topic-config
+mp.messaging.outgoing.my-channel.connector=smallrye-amqp
+mp.messaging.outgoing.my-channel.address=hello
+mp.messaging.outgoing.my-channel.durable=true
+mp.messaging.outgoing.my-channel.client-options-name=my-topic-config
 
 # AMQP source (we read from)
-smallrye.messaging.source.my-topic.connector=smallrye-amqp
-smallrye.messaging.source.my-topic.address=hello
-smallrye.messaging.source.my-topic.durable=true
-smallrye.messaging.source.my-topic.client-options-name=my-topic-config2
+mp.messaging.incoming.my-topic.connector=smallrye-amqp
+mp.messaging.incoming.my-topic.address=hello
+mp.messaging.incoming.my-topic.durable=true
+mp.messaging.incoming.my-topic.client-options-name=my-topic-config2

--- a/examples/kafka-quickstart-kotlin/README.md
+++ b/examples/kafka-quickstart-kotlin/README.md
@@ -9,11 +9,11 @@ First you need a Kafka cluster. You can follow the instructions from the [Apache
 
 ## Start the application
 
-The application can be started using: 
+The application can be started using:
 
 ```bash
-mvn package exec:java
-```  
+mvn compile exec:java
+```
 
 Then, looking at the output you can see messages successfully send to and read from a Kafka topic.
 
@@ -23,7 +23,7 @@ In addition to the commandline output, the application is composed by 3 componen
 
 * `BeanUsingAnEmitter` - a bean sending a changing hello message to kafka topic every second.
 * `Sender` - a bean sending a fixed message to a kafka topic every 5 seconds.
-* `Receiver`  - on the consuming side, the `Receiver` retreives messages from a kafka topic and writes the message content to `stdout`.
+* `Receiver`  - on the consuming side, the `Receiver` retrieves messages from a kafka topic and writes the message content to `stdout`.
 
 The interaction with Kafka is managed by MicroProfile Reactive Messaging.
 The configuration is located in the microprofile config properties.

--- a/examples/kafka-quickstart-kotlin/pom.xml
+++ b/examples/kafka-quickstart-kotlin/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.smallrye.reactive</groupId>
     <artifactId>smallrye-reactive-messaging</artifactId>
     <version>3.16.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>kafka-quickstart-kotlin</artifactId>
@@ -17,7 +17,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <kotlin.version>1.6.10</kotlin.version>
-    <weld-core.version>3.1.7.SP1</weld-core.version>
+    <weld-core.version>3.1.9.Final</weld-core.version>
 
     <mainClass>acme.Main</mainClass>
 
@@ -57,13 +57,10 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <version>${weld-core.version}</version>
     </dependency>
-    <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-jdk8</artifactId>

--- a/examples/kafka-quickstart-kotlin/src/main/resources/META-INF/beans.xml
+++ b/examples/kafka-quickstart-kotlin/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/examples/kafka-quickstart-kotlin/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/kafka-quickstart-kotlin/src/main/resources/META-INF/microprofile-config.properties
@@ -1,15 +1,15 @@
 
 # Kafka Sink (topic = kafka)
-smallrye.messaging.sink.data.connector=smallrye-kafka
-smallrye.messaging.sink.data.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+mp.messaging.outgoing.data.connector=smallrye-kafka
+mp.messaging.outgoing.data.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 # Kafka Sink used by an Emitter
-smallrye.messaging.sink.my-channel.connector=smallrye-kafka
-smallrye.messaging.sink.my-channel.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-smallrye.messaging.sink.my-channel.topic=kafka
+mp.messaging.outgoing.my-channel.connector=smallrye-kafka
+mp.messaging.outgoing.my-channel.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+mp.messaging.outgoing.my-channel.topic=kafka
 
 
 ## Kafka Source (topic = kafka)
-smallrye.messaging.source.kafka.connector=smallrye-kafka
-smallrye.messaging.source.kafka.group.id=demo
-smallrye.messaging.source.kafka.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+mp.messaging.incoming.kafka.connector=smallrye-kafka
+mp.messaging.incoming.kafka.group.id=demo
+mp.messaging.incoming.kafka.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer

--- a/examples/kafka-quickstart/README.md
+++ b/examples/kafka-quickstart/README.md
@@ -9,11 +9,11 @@ First you need a Kafka cluster. You can follow the instructions from the [Apache
 
 ## Start the application
 
-The application can be started using: 
+The application can be started using:
 
 ```bash
-mvn package exec:java
-```  
+mvn compile exec:java
+```
 
 Then, looking at the output you can see messages successfully send to and read from a Kafka topic.
 
@@ -23,7 +23,7 @@ In addition to the commandline output, the application is composed by 3 componen
 
 * `BeanUsingAnEmitter` - a bean sending a changing hello message to kafka topic every second.
 * `Sender` - a bean sending a fixed message to a kafka topic every 5 seconds.
-* `Receiver`  - on the consuming side, the `Receiver` retreives messages from a kafka topic and writes the message content to `stdout`.
+* `Receiver`  - on the consuming side, the `Receiver` retrieves messages from a kafka topic and writes the message content to `stdout`.
 
 The interaction with Kafka is managed by MicroProfile Reactive Messaging.
 The configuration is located in the microprofile config properties.

--- a/examples/kafka-quickstart/pom.xml
+++ b/examples/kafka-quickstart/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.smallrye.reactive</groupId>
     <artifactId>smallrye-reactive-messaging</artifactId>
     <version>3.16.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>kafka-quickstart</artifactId>
@@ -16,7 +16,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <weld-core.version>3.1.7.SP1</weld-core.version>
+    <weld-core.version>3.1.9.Final</weld-core.version>
 
     <mainClass>acme.Main</mainClass>
 
@@ -49,12 +49,12 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <version>${weld-core.version}</version>
     </dependency>
     <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
     </dependency>
   </dependencies>
 

--- a/examples/kafka-quickstart/src/main/resources/META-INF/beans.xml
+++ b/examples/kafka-quickstart/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/examples/kafka-quickstart/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/kafka-quickstart/src/main/resources/META-INF/microprofile-config.properties
@@ -22,3 +22,4 @@ mp.messaging.incoming.prices.broadcast=true
 mp.messaging.outgoing.prices-out.connector=smallrye-kafka
 mp.messaging.outgoing.prices-out.value.serializer=org.apache.kafka.common.serialization.DoubleSerializer
 mp.messaging.outgoing.prices-out.topic=prices
+mp.messaging.outgoing.prices-out.merge=true

--- a/examples/mqtt-quickstart/README.md
+++ b/examples/mqtt-quickstart/README.md
@@ -12,7 +12,7 @@ First you need a MQTT server. You can follow the instructions from the [Eclipse 
 The application can be started using:
 
 ```bash
-mvn package exec:java
+mvn compile exec:java
 ```
 
 Then, looking at the output you can see messages successfully send to and retrieved from a MQTT topic.

--- a/examples/mqtt-quickstart/pom.xml
+++ b/examples/mqtt-quickstart/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.smallrye.reactive</groupId>
     <artifactId>smallrye-reactive-messaging</artifactId>
     <version>3.16.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>mqtt-quickstart</artifactId>
@@ -16,7 +16,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <weld-core.version>3.1.7.SP1</weld-core.version>
+    <weld-core.version>3.1.9.Final</weld-core.version>
 
     <mainClass>acme.Main</mainClass>
 
@@ -56,12 +56,8 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <version>${weld-core.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
     </dependency>
 
     <dependency>

--- a/examples/mqtt-quickstart/src/main/resources/META-INF/beans.xml
+++ b/examples/mqtt-quickstart/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/examples/mqtt-quickstart/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/mqtt-quickstart/src/main/resources/META-INF/microprofile-config.properties
@@ -1,21 +1,21 @@
 
 # MQTT Sink
-smallrye.messaging.sink.data.connector=smallrye-mqtt
-smallrye.messaging.sink.data.topic=default
-smallrye.messaging.sink.data.host=localhost
-smallrye.messaging.sink.data.port=1883
-smallrye.messaging.sink.data.auto-generated-client-id=true
+mp.messaging.outgoing.data.connector=smallrye-mqtt
+mp.messaging.outgoing.data.topic=default
+mp.messaging.outgoing.data.host=localhost
+mp.messaging.outgoing.data.port=1883
+mp.messaging.outgoing.data.auto-generated-client-id=true
 
 # MQTT sink (we write to using an Emitter)
-smallrye.messaging.sink.my-channel.connector=smallrye-mqtt
-smallrye.messaging.sink.my-channel.topic=hello
-smallrye.messaging.sink.my-channel.host=localhost
-smallrye.messaging.sink.my-channel.port=1883
-smallrye.messaging.sink.my-channel.auto-generated-client-id=true
+mp.messaging.outgoing.my-channel.connector=smallrye-mqtt
+mp.messaging.outgoing.my-channel.topic=hello
+mp.messaging.outgoing.my-channel.host=localhost
+mp.messaging.outgoing.my-channel.port=1883
+mp.messaging.outgoing.my-channel.auto-generated-client-id=true
 
 # MQTT source (we read from)
-smallrye.messaging.source.my-topic.connector=smallrye-mqtt
-smallrye.messaging.source.my-topic.topic=hello
-smallrye.messaging.source.my-topic.host=localhost
-smallrye.messaging.source.my-topic.port=1883
-smallrye.messaging.source.my-topic.auto-generated-client-id=true
+mp.messaging.incoming.my-topic.connector=smallrye-mqtt
+mp.messaging.incoming.my-topic.topic=hello
+mp.messaging.incoming.my-topic.host=localhost
+mp.messaging.incoming.my-topic.port=1883
+mp.messaging.incoming.my-topic.auto-generated-client-id=true

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -12,7 +12,7 @@ This example makes no use of an external broker. Reactive messaging is done in m
 The application can be started using:
 
 ```bash
-mvn package exec:java
+mvn compile exec:java
 ```
 
 Then, looking at the output you can see successful incoming en outgoing messages.

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -2,13 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-
   <parent>
     <groupId>io.smallrye.reactive</groupId>
     <artifactId>smallrye-reactive-messaging</artifactId>
     <version>3.16.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
-  </parent>
+    <relativePath>../../pom.xml</relativePath>  </parent>
 
   <artifactId>reactive-messaging-quickstart</artifactId>
 
@@ -17,7 +15,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <weld-core.version>3.1.7.SP1</weld-core.version>
+    <weld-core.version>3.1.9.Final</weld-core.version>
 
     <mainClass>acme.Main</mainClass>
 
@@ -45,7 +43,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <version>${weld-core.version}</version>
     </dependency>
   </dependencies>

--- a/examples/quickstart/src/main/resources/META-INF/beans.xml
+++ b/examples/quickstart/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/smallrye-reactive-messaging-amqp/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-amqp/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/smallrye-reactive-messaging-camel/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-camel/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/smallrye-reactive-messaging-gcp-pubsub/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       bean-discovery-mode="annotated">
-
-</beans>

--- a/smallrye-reactive-messaging-jms/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-jms/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,0 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee  http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-	bean-discovery-mode="annotated" version="1.1">
-</beans>

--- a/smallrye-reactive-messaging-kafka/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-kafka/src/main/resources/META-INF/beans.xml
@@ -1,9 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-  bean-discovery-mode="annotated">
-
-</beans>

--- a/smallrye-reactive-messaging-mqtt/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-mqtt/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,0 @@
-<beans
-  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
-
-</beans>

--- a/smallrye-reactive-messaging-provider/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-provider/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,0 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee  http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-   bean-discovery-mode="annotated" version="1.1">
-</beans>

--- a/smallrye-reactive-messaging-rabbitmq/src/main/resources/META-INF/beans.xml
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/resources/META-INF/beans.xml
@@ -1,9 +1,0 @@
-<beans
-        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-        bean-discovery-mode="annotated">
-
-</beans>


### PR DESCRIPTION
- Use blank beans.xml file to avoid the differences between javax and jakarta (and also be ready for CDI-Lite)
- Fix examples
