### PR TITLE
Fix failing HealthWithSubscriberTest

### DIFF
--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
@@ -92,7 +92,7 @@ public class WeldTestBaseWithoutTails {
 
     @BeforeEach
     public void setUp() {
-        clearConfigFile();
+        releaseConfig();
         initializer = SeContainerInitializer.newInstance();
 
         initializer.addBeanClasses(MediatorFactory.class,


### PR DESCRIPTION
After running ChannelNameConflictTest, which installs an invalid config file, the config values are not correctly cleared.
Resulting in the next test, if using WeldTestBaseWithoutTails, consistently fail.

It's strange but this one-line change does fix it.

Issue: #1660 