### PR TITLE
Make incoming message content_type overridable

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQLogging.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQLogging.java
@@ -2,10 +2,7 @@ package io.smallrye.reactive.messaging.rabbitmq.i18n;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
-import org.jboss.logging.annotations.Cause;
-import org.jboss.logging.annotations.LogMessage;
-import org.jboss.logging.annotations.Message;
-import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.*;
 
 @MessageLogger(projectCode = "SRMSG", length = 5)
 public interface RabbitMQLogging extends BasicLogger {
@@ -123,4 +120,9 @@ public interface RabbitMQLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.ERROR)
     @Message(id = 17037, value = "Unable to create client")
     void unableToCreateClient(@Cause Throwable t);
+
+    @Once
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 17038, value = "No valid content_type set, failing back to byte[]. If that's wanted, set the content type to application/octet-stream with \"content-type-override\"")
+    void typeConversionFallback();
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQUsage.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQUsage.java
@@ -66,13 +66,26 @@ public class RabbitMQUsage {
     }
 
     /**
-     * Use the supplied function to asynchronously produce messages and write them to the host.
+     * Use the supplied function to asynchronously produce messages with default content_type and write them to the host.
      *
      * @param exchange the exchange, must not be null
      * @param messageCount the number of messages to produce; must be positive
      * @param messageSupplier the function to produce messages; may not be null
      */
-    void produce(String exchange, String queue, String routingKey, int messageCount, Supplier<Object> messageSupplier) {
+    void produce(String exchange, String queue, String routingKey, int messageCount, Supplier <Object> messageSupplier) {
+        this.produce(exchange, queue, routingKey, messageCount, messageSupplier, "text/plain");
+    }
+
+    /**
+     * Use the supplied function to asynchronously produce messages and write them to the host.
+     *
+     * @param exchange the exchange, must not be null
+     * @param messageCount the number of messages to produce; must be positive
+     * @param messageSupplier the function to produce messages; may not be null
+     * @param contentType the message's content_type attribute
+     */
+    void produce(String exchange, String queue, String routingKey, int messageCount, Supplier <Object> messageSupplier,
+            String contentType) {
         CountDownLatch done = new CountDownLatch(messageCount);
         // Start the machinery to receive the messages
         client.startAndAwait();
@@ -85,7 +98,7 @@ public class RabbitMQUsage {
                     final Buffer body = Buffer.buffer(payload.toString());
                     final BasicProperties properties = new AMQP.BasicProperties().builder()
                             .expiration("10000")
-                            .contentType("text/plain")
+                            .contentType(contentType)
                             .build();
 
                     client.basicPublish(exchange, routingKey, properties, body)
@@ -163,7 +176,7 @@ public class RabbitMQUsage {
         client.stopAndAwait();
     }
 
-    void produceTenIntegers(String exchange, String queue, String routingKey, Supplier<Integer> messageSupplier) {
+    void produceTenIntegers(String exchange, String queue, String routingKey, Supplier <Integer> messageSupplier) {
         this.produce(exchange, queue, routingKey, 10, messageSupplier::get);
     }
 


### PR DESCRIPTION
This is my attempt resolving issue #1642 

The original implementation just gives up if you have a message without the `content_type` attribute set to a supported MIME type(and not using byte[]).
I added a configuration entry `content-type-override` on the incoming channel, so you don't have to modify the message producer if that's in another codebase. Also, a warning will be thrown once if you reach the fallback code and doesn't explicitly declare that you want a byte[]. In the end this shouldn't break any existing code.

You would still get the confusing stack trace if content_type and your function signature mismatches, but that's a much rarer case.