### PR TITLE
Bumped Toxiproxy image version to 2.1.4.

### DIFF
--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/test/ProxiedStrimziKafkaContainer.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/test/ProxiedStrimziKafkaContainer.java
@@ -11,6 +11,7 @@ import org.testcontainers.containers.ToxiproxyContainer;
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import io.strimzi.test.container.StrimziKafkaContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Sets advertised listeners to the proxied port instead of exposed port
@@ -23,7 +24,11 @@ public class ProxiedStrimziKafkaContainer extends StrimziKafkaContainer {
     public static final String TOXIPROXY_NETWORK_ALIAS = "toxiproxy";
     public static final String KAFKA_NETWORK_ALIAS = "kafka";
 
-    private final ToxiproxyContainer toxiproxy = new ToxiproxyContainer("shopify/toxiproxy:2.1.4")
+    public static final String TOXIPROXY_IMAGE_NAME_PROPERTY_KEY = "toxiproxy.image.name";
+    public static final String DEFAULT_TOXIPROXY_IMAGE_NAME = "ghcr.io/shopify/toxiproxy:2.4.0";
+    private final ToxiproxyContainer toxiproxy = new ToxiproxyContainer(DockerImageName.parse(
+                    System.getProperty(TOXIPROXY_IMAGE_NAME_PROPERTY_KEY, DEFAULT_TOXIPROXY_IMAGE_NAME))
+            .asCompatibleSubstituteFor("shopify/toxiproxy"))
             .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS);
     private KafkaProxy kafkaProxy;
 

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/test/ProxiedStrimziKafkaContainer.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/test/ProxiedStrimziKafkaContainer.java
@@ -23,7 +23,7 @@ public class ProxiedStrimziKafkaContainer extends StrimziKafkaContainer {
     public static final String TOXIPROXY_NETWORK_ALIAS = "toxiproxy";
     public static final String KAFKA_NETWORK_ALIAS = "kafka";
 
-    private final ToxiproxyContainer toxiproxy = new ToxiproxyContainer("shopify/toxiproxy:2.1.0")
+    private final ToxiproxyContainer toxiproxy = new ToxiproxyContainer("shopify/toxiproxy:2.1.4")
             .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS);
     private KafkaProxy kafkaProxy;
 

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/test/ProxiedStrimziKafkaContainer.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/test/ProxiedStrimziKafkaContainer.java
@@ -23,9 +23,9 @@ public class ProxiedStrimziKafkaContainer extends StrimziKafkaContainer {
     public static final int KAFKA_PORT = 9092;
     public static final String TOXIPROXY_NETWORK_ALIAS = "toxiproxy";
     public static final String KAFKA_NETWORK_ALIAS = "kafka";
-
     public static final String TOXIPROXY_IMAGE_NAME_PROPERTY_KEY = "toxiproxy.image.name";
     public static final String DEFAULT_TOXIPROXY_IMAGE_NAME = "ghcr.io/shopify/toxiproxy:2.4.0";
+    
     private final ToxiproxyContainer toxiproxy = new ToxiproxyContainer(DockerImageName.parse(
                     System.getProperty(TOXIPROXY_IMAGE_NAME_PROPERTY_KEY, DEFAULT_TOXIPROXY_IMAGE_NAME))
             .asCompatibleSubstituteFor("shopify/toxiproxy"))


### PR DESCRIPTION
Hello! :wave:

I am unable to run Toxiproxy version 2.1.0 on my M1 Mac.
```
❯ docker run --platform linux/amd64 shopify/toxiproxy:2.1.0
runtime: failed to create new OS thread (have 2 already; errno=22)
fatal error: newosproc
```
The newest version of the image seems to work fine.
```
❯ docker run --platform linux/amd64 shopify/toxiproxy:2.1.4
time="2022-04-29T13:38:28Z" level="info" msg="API HTTP server starting" host="0.0.0.0" port="8474" version="2.1.4"
```

Is there a chance for a version upgrade and a new release? 🙇 