### PR TITLE
Fix RabbitMQ connector issues

### DIFF
--- a/documentation/src/main/docs/rabbitmq/receiving-messages-from-rabbitmq.md
+++ b/documentation/src/main/docs/rabbitmq/receiving-messages-from-rabbitmq.md
@@ -203,6 +203,15 @@ mp.messaging.incoming.people.queue.declare=true
     name of the exchange; if this is not the case you would need to name the
     exchange explicitly using the `exchange.name` property.
 
+!!!note
+    The connector supports RabbitMQ's "Server-named Queues" feature to create
+    an exclusive, auto-deleting, non-durable and randomly named queue. To
+    enable this feature you set the queue name to exactly `(server.auto)`.
+    Using this name not only enables the server named queue feature but also
+    automatically makes ths queue exclusive, auto-deleting, and non-durable;
+    therefore ignoring any values provided for the `exclusive`, `auto-delete`
+    and `durable` options.
+
 If you want RabbitMQ to create the `people` exchange, queue and binding,
 you need the following configuration:
 

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQClientHelper.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQClientHelper.java
@@ -65,11 +65,15 @@ public class RabbitMQClientHelper {
     static RabbitMQClient getClient(Vertx vertx, RabbitMQConnectorCommonConfiguration config,
             Instance<CredentialsProvider> credentialsProviders) {
         try {
+            String connectionName = String.format("%s (%s)",
+                    config.getChannel(),
+                    config instanceof RabbitMQConnectorIncomingConfiguration ? "Incoming" : "Outgoing");
             String host = config.getHost();
             int port = config.getPort();
             log.brokerConfigured(host, port, config.getChannel());
 
             RabbitMQOptions options = new RabbitMQOptions()
+                    .setConnectionName(connectionName)
                     .setHost(host)
                     .setPort(port)
                     .setSsl(config.getSsl())

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -464,8 +464,6 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
                                     .onItem().invoke(() -> log.queueEstablished(queueName))
                                     .onFailure().invoke(ex -> log.unableToEstablishQueue(queueName, ex))
                                     .onItem().transformToMulti(v -> establishBindings(client, ic))
-                                    // What follows is just to "rejoin" the Multi stream into a single Uni emitting the queue name
-                                    .onCompletion().invoke(() -> Multi.createFrom().item("ignore"))
                                     .onItem().ignoreAsUni().onItem().transform(v -> queueName);
                         });
     }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -438,8 +438,10 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
 
         // Declare the queue (and its binding(s) to the exchange, and TTL) if we have been asked to do so
         final JsonObject queueArgs = new JsonObject();
-        queueArgs.put("x-dead-letter-exchange", ic.getDeadLetterExchange());
-        queueArgs.put("x-dead-letter-routing-key", ic.getDeadLetterRoutingKey().orElse(queueName));
+        if (ic.getAutoBindDlq()) {
+            queueArgs.put("x-dead-letter-exchange", ic.getDeadLetterExchange());
+            queueArgs.put("x-dead-letter-routing-key", ic.getDeadLetterRoutingKey().orElse(queueName));
+        }
         ic.getQueueSingleActiveConsumer().ifPresent(sac -> queueArgs.put("x-single-active-consumer", sac));
 
         ic.getQueueTtl().ifPresent(queueTtl -> {

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQLogging.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/i18n/RabbitMQLogging.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.rabbitmq.i18n;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.Logger.Level;
 import org.jboss.logging.annotations.*;
 
 @MessageLogger(projectCode = "SRMSG", length = 5)
@@ -125,4 +126,9 @@ public interface RabbitMQLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 17038, value = "No valid content_type set, failing back to byte[]. If that's wanted, set the content type to application/octet-stream with \"content-type-override\"")
     void typeConversionFallback();
+
+    @LogMessage(level = Level.DEBUG)
+    @Message(id = 17039, value = "Connection '%d' with RabbitMQ broker established for channel `%s`")
+    void connectionEstablished(int connectionIndex, String channel);
+
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -153,8 +153,8 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
         // verify bindings
         final JsonObject queueArguments = queue.getJsonObject("arguments");
         assertThat(queueArguments).isNotNull();
-        assertThat(queueArguments.getString("x-dead-letter-exchange")).isEqualTo("DLX");
-        assertThat(queueArguments.getString("x-dead-letter-routing-key")).isEqualTo(queueName);
+        assertThat(queueArguments.getString("x-dead-letter-exchange")).isNull();
+        assertThat(queueArguments.getString("x-dead-letter-routing-key")).isNull();
         assertThat(queueArguments.getLong("x-message-ttl")).isEqualTo(queueTtl);
         assertThat(queueArguments.getBoolean("x-single-active-consumer")).isEqualTo(true);
 


### PR DESCRIPTION
This address a number of issues in the RabbitMQ connector. Separate issues are addressed in separate commits.

Fixes #1743, Fixes #1593
* Uses `addConnectionEstablishedCallback` to build topology upon (re)connection.
* Removes "retry" logic added to publisher stream.
* * Already handled by either Vert.x reconnection or "Automatic Recovery"

Fixes #1744 
* Queues named `(server.auto)` are server generated name queues
* * `durable`, `auto-detect` and `exclusive` are ignored.

Fixes #1749 
* Dead letter exchange properties are only set if `auto-bind-dlq` is enabled

Fixes #1742 
* Code removed

Other Changes
* Sets the RabbitMQ connection name to channel name + incoming/outing for easier server debugging
* Reports connector as "connected" once all requested connections are connected and their consumers created
* * Debug logs each individual connection as it connects