### PR TITLE
Revert portion of #1747 that is causing early stream cancellation

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -37,6 +37,7 @@ import com.rabbitmq.client.impl.CredentialsProvider;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.smallrye.mutiny.tuples.Tuple2;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
 import io.smallrye.reactive.messaging.health.HealthReport;
@@ -188,9 +189,21 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
                 .map(String::trim).collect(Collectors.toList());
         log.receiverListeningAddress(queueName);
 
-        return receiver.toMulti()
-                .map(m -> new IncomingRabbitMQMessage<>(m, holder, isTracingEnabled, onNack, onAck, contentTypeOverride))
-                .map(m -> isTracingEnabled ? TracingUtils.addIncomingTrace(m, queueName, attributeHeaders) : m);
+        // The processor is used to inject AMQP Connection failure in the stream and trigger a retry.
+        BroadcastProcessor<Message<?>> processor = BroadcastProcessor.create();
+        receiver.exceptionHandler(t -> {
+            log.receiverError(t);
+            processor.onError(t);
+        });
+
+        return Multi.createFrom().deferred(
+                () -> {
+                    Multi<Message<?>> stream = receiver.toMulti()
+                            .map(m -> new IncomingRabbitMQMessage<>(m, holder, isTracingEnabled, onNack, onAck,
+                                    contentTypeOverride))
+                            .map(m -> isTracingEnabled ? TracingUtils.addIncomingTrace(m, queueName, attributeHeaders) : m);
+                    return Multi.createBy().merging().streams(stream, processor);
+                });
     }
 
     /**


### PR DESCRIPTION
As discussed in this [Zulip chat](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/SR.20RM.20Debug) a portion of the change in #1747 is causing failures when used in the Quarkus `2.10.CR1` release.

Although I am still investigating what exact effect this change has on the connected stream, it does appear to fix the issues seen.