### PR TITLE
Only allow a single ack or nack to be sent to RabbitMQ per message

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessageTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessageTest.java
@@ -1,0 +1,73 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.junit.jupiter.api.Test;
+
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Envelope;
+
+import io.smallrye.reactive.messaging.rabbitmq.ack.RabbitMQAckHandler;
+import io.smallrye.reactive.messaging.rabbitmq.fault.RabbitMQFailureHandler;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.rabbitmq.RabbitMQMessage;
+
+public class IncomingRabbitMQMessageTest {
+
+    RabbitMQAckHandler doNothingAck = new RabbitMQAckHandler() {
+        @Override
+        public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Context context) {
+            return CompletableFuture.completedFuture(null);
+        }
+    };
+
+    RabbitMQFailureHandler doNothingNack = new RabbitMQFailureHandler() {
+        @Override
+        public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Context context, Throwable reason) {
+            return CompletableFuture.completedFuture(null);
+        }
+    };
+
+    @Test
+    public void testDoubleAckBehavior() {
+
+        RabbitMQMessage msg = RabbitMQMessage.newInstance(mock(io.vertx.rabbitmq.RabbitMQMessage.class));
+        when(msg.properties()).thenReturn(new BasicProperties());
+        when(msg.envelope()).thenReturn(new Envelope(13456, false, "test", "test"));
+
+        Exception nackReason = new Exception("test");
+
+        IncomingRabbitMQMessage<String> ackMsg = new IncomingRabbitMQMessage<>(msg, mock(ConnectionHolder.class), false,
+                doNothingNack,
+                doNothingAck,
+                "text/plain");
+
+        assertDoesNotThrow(() -> ackMsg.ack().toCompletableFuture().get());
+        assertDoesNotThrow(() -> ackMsg.ack().toCompletableFuture().get());
+        assertDoesNotThrow(() -> ackMsg.nack(nackReason).toCompletableFuture().get());
+    }
+
+    @Test
+    public void testDoubleNackBehavior() {
+
+        RabbitMQMessage msg = RabbitMQMessage.newInstance(mock(io.vertx.rabbitmq.RabbitMQMessage.class));
+        when(msg.properties()).thenReturn(new BasicProperties());
+        when(msg.envelope()).thenReturn(new Envelope(13456, false, "test", "test"));
+
+        Exception nackReason = new Exception("test");
+
+        IncomingRabbitMQMessage<String> nackMsg = new IncomingRabbitMQMessage<>(msg, mock(ConnectionHolder.class), false,
+                doNothingNack,
+                doNothingAck,
+                "text/plain");
+
+        assertDoesNotThrow(() -> nackMsg.nack(nackReason).toCompletableFuture().get());
+        assertDoesNotThrow(() -> nackMsg.nack(nackReason).toCompletableFuture().get());
+        assertDoesNotThrow(() -> nackMsg.ack().toCompletableFuture().get());
+    }
+}


### PR DESCRIPTION
Fixes #1770

Currently if the calls ack or nack more than a combine total of 1 time the client will send all the acks or nacks to the server. Since RabbitMQ explicitly disallows this, it causes a connection error which then causes a complete connection restart.  The worst part is that without some real examination you cannot tell this is from calling ack and/or nack multiple times.

The best example of this is when a user `nacks` a message in a message handler that uses the `POST_PROCESSING` strategy. The framework will then `ack` or `nack` the message based on the outcome of the message handler. This will cause the connection restart as described above. No logging or hints exist to tell users that this is what is causing connection restarts.

This commit replaces the ack and nack handlers, after the first call of either, with versions that are no-ops; silently ignoring any attempt to ack or nack after the first one.

Originally I had detected the error and reported it, but after reading the Eclipse MicroProfile Reactive Messaging Specification it appears there are scenarios where both the user and the framework might be expected to handle ack/nack. Ignoring duplicates felt like an easier system to use.