### PR TITLE
Switch the RS TCK JUnit5 shim to that of Mutiny Zero

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
 
     <smallrye-vertx-mutiny-clients.version>2.23.0</smallrye-vertx-mutiny-clients.version>
     <smallrye-reactive-converters.version>2.6.0</smallrye-reactive-converters.version>
+    <mutiny-zero-reactive-streams-junit5-tck.version>0.4.1</mutiny-zero-reactive-streams-junit5-tck.version>
 
     <testcontainers.version>1.17.3</testcontainers.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 
     <smallrye-vertx-mutiny-clients.version>2.23.0</smallrye-vertx-mutiny-clients.version>
     <smallrye-reactive-converters.version>2.6.0</smallrye-reactive-converters.version>
-    <mutiny-zero-reactive-streams-junit5-tck.version>0.4.1</mutiny-zero-reactive-streams-junit5-tck.version>
+    <mutiny-zero-reactive-streams-junit5-tck.version>0.4.2</mutiny-zero-reactive-streams-junit5-tck.version>
 
     <testcontainers.version>1.17.3</testcontainers.version>
 

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -98,8 +98,8 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
-      <artifactId>reactive-streams-junit5-tck</artifactId>
-      <version>${mutiny.version}</version>
+      <artifactId>mutiny-zero-reactive-streams-junit5-tck</artifactId>
+      <version>${mutiny-zero-reactive-streams-junit5-tck.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>


### PR DESCRIPTION
The module has been transfered from Mutiny to Mutiny Zero.
