### PR TITLE
Convert IncomingRabbitMQMessage payload eagerly

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTest.java
@@ -40,7 +40,7 @@ public class IncomingRabbitMQMetadataTest {
 
         @Override
         public Buffer body() {
-            return null;
+            return Buffer.buffer();
         }
 
         @Override


### PR DESCRIPTION
Default payload Conversion supports as before `String`, Vert.x `JsonObject`, Vert.x `Buffer` and `byte[]`. If conversions fail it falls back to the `byte[]`. 

This prevents the pipeline from failing when MessageConverter is applied on a RabbitMQ message with a _faulty_ payload. Secondly it avoids calling the conversion on each call to `getPayload`