### PR TITLE
MutinyEmitter Message methods

### DIFF
--- a/api/revapi.json
+++ b/api/revapi.json
@@ -36,13 +36,18 @@
             "differences": [
                 {
                     "code": "java.method.addedToInterface",
-                    "new": "method <T> T io.smallrye.reactive.messaging.ChannelRegistry::getEmitter(java.lang.String, java.lang.Class<? super T>)",
-                    "justification": "New method added to get emitter by its type"
+                    "new": "method <M extends org.eclipse.microprofile.reactive.messaging.Message<? extends T>> io.smallrye.mutiny.Uni<java.lang.Void> io.smallrye.reactive.messaging.MutinyEmitter<T>::sendMessage(M)",
+                    "justification": "Added to the MutinyEmitter interface"
                 },
                 {
                     "code": "java.method.addedToInterface",
-                    "new": "method <T> void io.smallrye.reactive.messaging.ChannelRegistry::register(java.lang.String, java.lang.Class<T>, T)",
-                    "justification": "New method added to register emitter by its type"
+                    "new": "method <M extends org.eclipse.microprofile.reactive.messaging.Message<? extends T>> void io.smallrye.reactive.messaging.MutinyEmitter<T>::sendMessageAndAwait(M)",
+                    "justification": "Added to the MutinyEmitter interface"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method <M extends org.eclipse.microprofile.reactive.messaging.Message<? extends T>> io.smallrye.mutiny.subscription.Cancellable io.smallrye.reactive.messaging.MutinyEmitter<T>::sendMessageAndForget(M)",
+                    "justification": "Added to the MutinyEmitter interface"
                 }
             ]
         }

--- a/api/src/main/java/io/smallrye/reactive/messaging/MutinyEmitter.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MutinyEmitter.java
@@ -92,11 +92,50 @@ public interface MutinyEmitter<T> extends EmitterType {
      *
      * @param <M> the <em>Message</em> type
      * @param msg the <em>Message</em> to send, must not be {@code null}
+     * @deprecated use {{@link #sendMessageAndForget(Message)}}
      * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
      *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
      *         configured and the emitter overflows.
      */
+    @Deprecated
     <M extends Message<? extends T>> void send(M msg);
+
+    /**
+     * Sends a message to the channel.
+     *
+     * @param <M> the <em>Message</em> type
+     * @param msg the <em>Message</em> to send, must not be {@code null}
+     * @return the {@code Uni}, that requires subscription to send the {@link Message}.
+     * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
+     *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
+     *         configured and the emitter overflows.
+     */
+    <M extends Message<? extends T>> Uni<Void> sendMessage(M msg);
+
+    /**
+     * Sends a message to the channel.
+     *
+     * Execution will block waiting for the resulting {@code Message} to be acknowledged before returning.
+     *
+     * @param <M> the <em>Message</em> type
+     * @param msg the <em>Message</em> to send, must not be {@code null}
+     * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
+     *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
+     *         configured and the emitter overflows.
+     */
+    <M extends Message<? extends T>> void sendMessageAndAwait(M msg);
+
+    /**
+     * Sends a message to the channel without waiting for acknowledgement.
+     *
+     * @param <M> the <em>Message</em> type
+     * @param msg the <em>Message</em> to send, must not be {@code null}
+     * @return the {@code Cancellable} from the subscribed {@code Uni}.
+     * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
+     *         {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
+     *         configured and the emitter overflows.
+     */
+    <M extends Message<? extends T>> Cancellable sendMessageAndForget(M msg);
 
     /**
      * Sends the completion event to the channel indicating that no other events will be sent afterward.


### PR DESCRIPTION
Adds following methods to the `MutinyEmitter`:
- `<M extends Message<? extends T>> Uni<Void> sendMessage(M msg)`
- `<M extends Message<? extends T>> void sendMessageAndAwait(M msg)`
- `<M extends Message<? extends T>> Cancellable sendMessageAndForget(M msg)`
And deprecates `void send(M msg);` in favour of `sendMessageAndForget`. 

This allows the same flexibility as payload-based methods but with custom Message's.
The concrete implementation of all methods is `Uni<Void> sendMessage(M msg)`.

**Discussion**
`Message` keyword is added to all new method names to avoid method name clashes with generic type parameters. 