### PR TITLE
Mutiny 1.7.0 with no prefetch concatmap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
     <micrometer.version>1.9.2</micrometer.version>
 
-    <mutiny.version>1.6.0</mutiny.version>
+    <mutiny.version>1.7.0</mutiny.version>
     <artemis.version>2.19.0</artemis.version>
 
     <jboss-log-manager.version>2.1.18.Final</jboss-log-manager.version>

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/MultiUtils.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/MultiUtils.java
@@ -2,7 +2,6 @@ package io.smallrye.reactive.messaging.providers.helpers;
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -14,7 +13,10 @@ import io.smallrye.reactive.messaging.MediatorConfiguration;
 public class MultiUtils {
 
     public static <T> Multi<T> createFromGenerator(Supplier<T> supplier) {
-        return Multi.createFrom().items(Stream.generate(supplier));
+        return Multi.createFrom().generator(() -> null, (s, g) -> {
+            g.emit(supplier.get());
+            return s;
+        });
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/RequestProtocolTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/RequestProtocolTest.java
@@ -38,7 +38,7 @@ public class RequestProtocolTest extends WeldTestBaseWithoutTails {
                 .until(() -> app.list().size() == 7);
 
         assertThat(app.list()).containsExactly(1, 2, 3, 4, 5, 6, 7);
-        assertThat(app.count()).isEqualTo(8); // request + 1 (pre-fetch)
+        assertThat(app.count()).isEqualTo(7);
     }
 
     @SuppressWarnings("ReactiveStreamsSubscriberImplementation")


### PR DESCRIPTION
- Bump mutiny to 1.7.0
- The hack needed for avoiding buffering is no longer needed
- Messages nacked when MessageConverter throws exception
