### PR TITLE
Kafka commit and failure SPI

### DIFF
--- a/documentation/src/main/docs/kafka/receiving-kafka-records.md
+++ b/documentation/src/main/docs/kafka/receiving-kafka-records.md
@@ -220,6 +220,31 @@ If the instance is present, the following properties will be used:
 -   headers; combined with the original record’s headers, as well as the
     `dead-letter-*` headers described above
 
+## Custom commit and failure strategies
+
+In addition to provided strategies, it is possible to implement custom
+commit and failure strategies and configure Kafka channels with them.
+
+For example, for a custom commit strategy, implement the
+{{ javadoc('io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler', False, 'io.smallrye.reactive/smallrye-reactive-messaging-kafka') }} interface,
+and provide a managed bean implementing the `KafkaCommitHandler.Factory` interface,
+identified using `@Identifier` qualifier.
+
+``` java
+{{ insert('kafka/inbound/KafkaCustomCommit.java') }}
+```
+
+Finally, to use the custom commit strategy,
+set the `commit-strategy` attribute to the identifier of the commit handler factory:
+`mp.messaging.incoming.$channel.commit-strategy=custom`.
+Similarly, custom failure strategies can be configured using `failure-strategy` attribute.
+
+!!!note
+    If the custom strategy implementation inherits
+    {{ javadoc('io.smallrye.reactive.messaging.kafka.commit.ContextHolder', False, 'io.smallrye.reactive/smallrye-reactive-messaging-kafka') }} class it can access the
+    Vert.x event-loop context created for the Kafka consumer
+
+
 ## Retrying processing
 
 You can combine Reactive Messaging with [SmallRye Fault

--- a/documentation/src/main/java/kafka/inbound/KafkaCustomCommit.java
+++ b/documentation/src/main/java/kafka/inbound/KafkaCustomCommit.java
@@ -1,0 +1,60 @@
+package kafka.inbound;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.common.TopicPartition;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
+import io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler;
+import io.vertx.mutiny.core.Vertx;
+
+public class KafkaCustomCommit implements KafkaCommitHandler {
+
+    @Override
+    public <K, V> Uni<Void> handle(IncomingKafkaRecord<K, V> record) {
+        // called on message ack
+        return Uni.createFrom().voidItem();
+    }
+
+    @Override
+    public <K, V> Uni<IncomingKafkaRecord<K, V>> received(IncomingKafkaRecord<K, V> record) {
+        // called before message processing
+        return Uni.createFrom().item(record);
+    }
+
+    @Override
+    public void terminate(boolean graceful) {
+        // called on channel shutdown
+    }
+
+    @Override
+    public void partitionsAssigned(Collection<TopicPartition> partitions) {
+        // called on partitions assignment
+    }
+
+    @Override
+    public void partitionsRevoked(Collection<TopicPartition> partitions) {
+        // called on partitions revoked
+    }
+
+    @ApplicationScoped
+    @Identifier("custom")
+    public static class Factory implements KafkaCommitHandler.Factory {
+
+        @Override
+        public KafkaCommitHandler create(KafkaConnectorIncomingConfiguration config,
+                Vertx vertx,
+                KafkaConsumer<?, ?> consumer,
+                BiConsumer<Throwable, Boolean> reportFailure) {
+            return new KafkaCustomCommit(/* ... */);
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -119,6 +119,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-mutiny-vertx-redis-client</artifactId>
+      <version>${smallrye-vertx-mutiny-clients.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Ensure log4j1 log backend with slf4j -->
     <dependency>

--- a/smallrye-reactive-messaging-kafka/revapi.json
+++ b/smallrye-reactive-messaging-kafka/revapi.json
@@ -31,24 +31,46 @@
             "minCriticality": "documented",
             "differences": [
                 {
-                    "ignore": true,
                     "code": "java.method.numberOfParametersChanged",
                     "old": "method void io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord<K, T>::<init>(org.apache.kafka.clients.consumer.ConsumerRecord<K, T>, java.lang.String, io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler, io.smallrye.reactive.messaging.kafka.fault.KafkaFailureHandler, boolean, boolean)",
                     "new": "method void io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord<K, T>::<init>(org.apache.kafka.clients.consumer.ConsumerRecord<K, T>, java.lang.String, int, io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler, io.smallrye.reactive.messaging.kafka.fault.KafkaFailureHandler, boolean, boolean)",
-                    "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+                    "justification": "Consumer index added to IncomingKafkaRecord constructor"
                 },
                 {
-                    "ignore": true,
                     "code": "java.method.numberOfParametersChanged",
                     "old": "method void io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordBatch<K, T>::<init>(org.apache.kafka.clients.consumer.ConsumerRecords<K, T>, java.lang.String, io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler, io.smallrye.reactive.messaging.kafka.fault.KafkaFailureHandler, boolean, boolean)",
                     "new": "method void io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordBatch<K, T>::<init>(org.apache.kafka.clients.consumer.ConsumerRecords<K, T>, java.lang.String, int, io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler, io.smallrye.reactive.messaging.kafka.fault.KafkaFailureHandler, boolean, boolean)",
-                    "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+                    "justification": "Consumer index added to IncomingKafkaRecordBatch constructor"
                 },
                 {
-                    "ignore": true,
                     "code": "java.method.addedToInterface",
                     "new": "method <K, V> java.util.List<io.smallrye.reactive.messaging.kafka.KafkaConsumer<K, V>> io.smallrye.reactive.messaging.kafka.KafkaClientService::getConsumers(java.lang.String)",
-                    "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE"
+                    "justification": "Added getConsumers method which returns the list of consumers for a given channel"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method io.smallrye.mutiny.Uni<java.lang.Void> io.smallrye.reactive.messaging.kafka.KafkaConsumer<K, V>::commitAsync(java.util.Map<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata>)",
+                    "justification": "Added to KafkaConsumer interface"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method java.util.Map<java.lang.String, ?> io.smallrye.reactive.messaging.kafka.KafkaConsumer<K, V>::configuration()",
+                    "justification": "Added to KafkaConsumer interface"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method void io.smallrye.reactive.messaging.kafka.KafkaProducer<K, V>::close()",
+                    "justification": "Added to KafkaProducer interface"
+                },
+                {
+                    "code": "java.method.addedToInterface",
+                    "new": "method java.util.Map<java.lang.String, ?> io.smallrye.reactive.messaging.kafka.KafkaProducer<K, V>::configuration()",
+                    "justification": "Added to KafkaProducer interface"
+                },
+                {
+                    "code": "java.method.removed",
+                    "old": "method void io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord<K, T>::injectTracingMetadata(io.smallrye.reactive.messaging.TracingMetadata)",
+                    "justification": "Method replaced by injectMetadata on IncomingKafkaRecord"
                 }
             ]
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecord.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecord.java
@@ -139,16 +139,16 @@ public class IncomingKafkaRecord<K, T> implements KafkaRecord<K, T> {
 
     @Override
     public CompletionStage<Void> ack() {
-        return commitHandler.handle(this);
+        return commitHandler.handle(this).subscribeAsCompletionStage();
     }
 
     @Override
     public CompletionStage<Void> nack(Throwable reason, Metadata metadata) {
-        return onNack.handle(this, reason, metadata);
+        return onNack.handle(this, reason, metadata).subscribeAsCompletionStage();
     }
 
-    public synchronized void injectTracingMetadata(TracingMetadata tracingMetadata) {
-        metadata = metadata.with(tracingMetadata);
+    public synchronized void injectMetadata(Object metadata) {
+        this.metadata = this.metadata.with(metadata);
     }
 
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumer.java
@@ -25,6 +25,11 @@ import io.smallrye.mutiny.Uni;
 public interface KafkaConsumer<K, V> {
 
     /**
+     * @return Kafka consumer configuration
+     */
+    Map<String, ?> configuration();
+
+    /**
      * Runs an action on the polling thread.
      * <p>
      * The action is a function taking as parameter the {@link Consumer} and that returns a result (potentially {@code null}).
@@ -110,6 +115,14 @@ public interface KafkaConsumer<K, V> {
     @CheckReturnValue
     Uni<Void> commit(
             Map<TopicPartition, OffsetAndMetadata> map);
+
+    /**
+     * Commits the offsets asynchronously
+     *
+     * @param map the map of topic/partition -> offset to commit
+     * @return the Uni emitting {@code null} when the commit has been executed.
+     */
+    Uni<Void> commitAsync(Map<TopicPartition, OffsetAndMetadata> map);
 
     /**
      * Retrieves the next positions for each assigned topic/partitions

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaProducer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaProducer.java
@@ -33,6 +33,12 @@ import io.smallrye.mutiny.Uni;
  * @param <V> the type of value
  */
 public interface KafkaProducer<K, V> {
+
+    /**
+     * @return Kafka producer configuration
+     */
+    Map<String, ?> configuration();
+
     /**
      * Runs an action on the sending thread.
      * <p>
@@ -123,4 +129,9 @@ public interface KafkaProducer<K, V> {
      * @return the underlying producer. Be aware that to use it you needs to be on the sending thread.
      */
     Producer<K, V> unwrap();
+
+    /**
+     * Close the producer client
+     */
+    void close();
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ContextHolder.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ContextHolder.java
@@ -4,8 +4,8 @@ import java.util.concurrent.*;
 
 import org.apache.kafka.common.errors.InterruptException;
 
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
 
 /**
  * A class holding a vert.x context to make sure methods are always run from the same one.
@@ -25,8 +25,16 @@ public class ContextHolder {
         this.context = context;
     }
 
+    public void capture(io.vertx.core.Context context) {
+        this.context = Context.newInstance(context);
+    }
+
     public Context getContext() {
         return context;
+    }
+
+    public int getTimeoutInMillis() {
+        return timeout;
     }
 
     public void runOnContext(Runnable runnable) {
@@ -35,7 +43,7 @@ public class ContextHolder {
         if (Vertx.currentContext() == context && Context.isOnEventLoopThread()) {
             runnable.run();
         } else {
-            context.runOnContext(x -> runnable.run());
+            context.runOnContext(runnable::run);
         }
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCheckpointCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCheckpointCommit.java
@@ -1,0 +1,132 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import static io.smallrye.reactive.messaging.kafka.commit.StateStore.getProcessingState;
+import static io.smallrye.reactive.messaging.kafka.commit.StateStore.isPersist;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+import org.jboss.logging.Logger;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.tuples.Tuple2;
+import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
+import io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging;
+import io.vertx.mutiny.core.Vertx;
+
+/**
+ * Abstract commit handler for checkpointing processing state on a state store
+ *
+ * Instead of committing topic-partition offsets back to Kafka, checkpointing commit handlers persist and restore offsets on an
+ * external store.
+ * It associates a {@link ProcessingState} with a topic-partition offset, and lets the processing resume from the checkpointed
+ * state.
+ *
+ * This abstract implementation holds a local map of {@link ProcessingState} per topic-partition,
+ * and ensures it is accessed on the captured Vert.x context.
+ *
+ * Concrete implementations provide {@link #fetchProcessingState(TopicPartition)} and
+ * {@link #persistProcessingState(TopicPartition, ProcessingState)} depending on the state store.
+ */
+@Experimental("Experimental API")
+public abstract class KafkaCheckpointCommit extends ContextHolder implements KafkaCommitHandler {
+
+    protected KafkaLogging log = Logger.getMessageLogger(KafkaLogging.class, "io.smallrye.reactive.messaging.kafka");
+
+    protected final Map<TopicPartition, ProcessingState<?>> processingStateMap = new HashMap<>();
+
+    protected final KafkaConnectorIncomingConfiguration config;
+    protected final KafkaConsumer<?, ?> consumer;
+    protected final BiConsumer<Throwable, Boolean> reportFailure;
+
+    public KafkaCheckpointCommit(Vertx vertx,
+            KafkaConnectorIncomingConfiguration config,
+            KafkaConsumer<?, ?> consumer,
+            BiConsumer<Throwable, Boolean> reportFailure,
+            int defaultTimeout) {
+        super(vertx, defaultTimeout);
+        this.config = config;
+        this.consumer = consumer;
+        this.reportFailure = reportFailure;
+    }
+
+    @Override
+    public <K, V> Uni<IncomingKafkaRecord<K, V>> received(IncomingKafkaRecord<K, V> record) {
+        return Uni.createFrom().item(record)
+                .emitOn(this::runOnContext) // state map is accessed on the captured context
+                .onItem().transform(r -> {
+                    TopicPartition tp = new TopicPartition(record.getTopic(), record.getPartition());
+                    r.injectMetadata(new StateStore<>(tp, record.getOffset(), () -> processingStateMap.get(tp)));
+                    return r;
+                });
+    }
+
+    @Override
+    public <K, V> Uni<Void> handle(IncomingKafkaRecord<K, V> record) {
+        TopicPartition tp = new TopicPartition(record.getTopic(), record.getPartition());
+        ProcessingState<?> newState = getProcessingState(record);
+        boolean persist = isPersist(record);
+        if (newState != null) {
+            return Uni.createFrom().item(newState)
+                    .emitOn(this::runOnContext) // state map is accessed on the captured context
+                    .onItem().invoke(s -> processingStateMap.put(tp, s))
+                    .chain(s -> persist ? persistProcessingState(tp, newState) : Uni.createFrom().voidItem())
+                    .replaceWithVoid();
+        }
+        return Uni.createFrom().voidItem();
+    }
+
+    @Override
+    public void terminate(boolean graceful) {
+        consumer.getAssignments()
+                .chain(this::persistStateFor)
+                .emitOn(this::runOnContext) // access state map on the captured context
+                .invoke(processingStateMap::clear)
+                .await().atMost(Duration.ofMillis(getTimeoutInMillis()));
+    }
+
+    @Override
+    public void partitionsAssigned(Collection<TopicPartition> partitions) {
+        List<? extends Tuple2<TopicPartition, ? extends ProcessingState<?>>> states = Multi.createFrom().iterable(partitions)
+                .emitOn(this::runOnContext) // state map is accessed on the captured context
+                .onItem().transformToUniAndConcatenate(tp -> fetchProcessingState(tp).map(s -> Tuple2.of(tp, s)))
+                .emitOn(this::runOnContext) // state map is accessed on the captured context
+                .onItem().invoke(t -> processingStateMap.put(t.getItem1(), t.getItem2()))
+                .collect().asList()
+                .await().atMost(Duration.ofMillis(getTimeoutInMillis()));
+        Consumer<?, ?> kafkaConsumer = consumer.unwrap();
+        for (Tuple2<TopicPartition, ? extends ProcessingState<?>> tuple : states) {
+            ProcessingState<?> state = tuple.getItem2();
+            kafkaConsumer.seek(tuple.getItem1(), state != null ? state.getOffset() : 0L);
+        }
+    }
+
+    @Override
+    public void partitionsRevoked(Collection<TopicPartition> partitions) {
+        persistStateFor(partitions).await().atMost(Duration.ofMillis(getTimeoutInMillis()));
+    }
+
+    private Uni<List<Void>> persistStateFor(Collection<TopicPartition> partitions) {
+        return Multi.createFrom().iterable(partitions)
+                .emitOn(this::runOnContext) // access state map on the captured context
+                .onItem().transform(tp -> Tuple2.of(tp, processingStateMap.get(tp)))
+                .skip().where(t -> t.getItem2() == null)
+                .onItem().transformToUniAndConcatenate(t -> this.persistProcessingState(t.getItem1(), t.getItem2()))
+                .collect().asList();
+    }
+
+    protected abstract Uni<ProcessingState<?>> fetchProcessingState(TopicPartition partition);
+
+    protected abstract Uni<Void> persistProcessingState(TopicPartition partition, ProcessingState<?> state);
+
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
@@ -1,53 +1,91 @@
 package io.smallrye.reactive.messaging.kafka.commit;
 
-import static io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions.ex;
-
 import java.util.Collection;
-import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
 
 import org.apache.kafka.common.TopicPartition;
 
+import io.smallrye.common.annotation.Experimental;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
+import io.vertx.mutiny.core.Vertx;
 
+/**
+ * Kafka commit handling strategy
+ */
+@Experimental("Experimental API")
 public interface KafkaCommitHandler {
 
-    enum Strategy {
-        LATEST,
-        IGNORE,
-        THROTTLED;
-
-        public static KafkaCommitHandler.Strategy from(String s) {
-            if (s.equalsIgnoreCase("latest")) {
-                return LATEST;
-            }
-            if (s.equalsIgnoreCase("ignore")) {
-                return IGNORE;
-            }
-            if (s.equalsIgnoreCase("throttled")) {
-                return THROTTLED;
-            }
-            throw ex.illegalArgumentUnknownCommitStrategy(s);
-        }
+    /**
+     * Identifiers of default strategies
+     */
+    interface Strategy {
+        String LATEST = "latest";
+        String IGNORE = "ignore";
+        String THROTTLED = "throttled";
 
     }
 
+    /**
+     * Factory interface for {@link KafkaCommitHandler}
+     */
+    interface Factory {
+
+        KafkaCommitHandler create(KafkaConnectorIncomingConfiguration config,
+                Vertx vertx, KafkaConsumer<?, ?> consumer, BiConsumer<Throwable, Boolean> reportFailure);
+
+    }
+
+    /**
+     * Called on message received but before calling the processing function.
+     * Returned {@link Uni} allows chaining asynchronous actions before message processing.
+     *
+     * @param record incoming Kafka record
+     * @param <K> type of record key
+     * @param <V> type of record value
+     * @return the {@link Uni} yielding the received record
+     */
     default <K, V> Uni<IncomingKafkaRecord<K, V>> received(IncomingKafkaRecord<K, V> record) {
         return Uni.createFrom().item(record);
     }
 
+    /**
+     * Called on channel shutdown
+     *
+     * @param graceful {@code true} if it is a graceful shutdown
+     */
     default void terminate(boolean graceful) {
         // Do nothing by default.
     }
 
+    /**
+     * Called on partitions assigned on Kafka rebalance listener
+     *
+     * @param partitions assigned partitions
+     */
     default void partitionsAssigned(Collection<TopicPartition> partitions) {
         // Do nothing by default.
     }
 
+    /**
+     * Called on partitions revokd on Kafka rebalance listener
+     *
+     * @param partitions revoked partitions
+     */
     default void partitionsRevoked(Collection<TopicPartition> partitions) {
         // Do nothing by default.
     }
 
-    <K, V> CompletionStage<Void> handle(IncomingKafkaRecord<K, V> record);
+    /**
+     * Handle message acknowledgment
+     *
+     * @param record incoming Kafka record
+     * @param <K> type of record key
+     * @param <V> type of record value
+     * @return a completion stage completed when the message is acknowledged.
+     */
+    <K, V> Uni<Void> handle(IncomingKafkaRecord<K, V> record);
 
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaFileCheckpointCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaFileCheckpointCommit.java
@@ -1,0 +1,114 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import java.io.File;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
+import io.vertx.core.json.Json;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+/**
+ * Checkpointing commit handler which uses local files as state store. It creates a file per topic-partition.
+ */
+@Experimental("Experimental API")
+public class KafkaFileCheckpointCommit extends KafkaCheckpointCommit {
+
+    public static final String FILE_CHECKPOINT_NAME = "checkpoint-file";
+    private final Vertx mutinyVertx;
+    private final File stateDir;
+
+    public KafkaFileCheckpointCommit(KafkaConnectorIncomingConfiguration config,
+            Vertx vertx,
+            KafkaConsumer<?, ?> consumer,
+            BiConsumer<Throwable, Boolean> reportFailure,
+            int defaultTimeout,
+            File stateDir) {
+        super(vertx, config, consumer, reportFailure, defaultTimeout);
+        this.mutinyVertx = vertx;
+        this.stateDir = stateDir;
+    }
+
+    @ApplicationScoped
+    @Identifier(FILE_CHECKPOINT_NAME)
+    public static class Factory implements KafkaCommitHandler.Factory {
+
+        @Override
+        public KafkaCommitHandler create(KafkaConnectorIncomingConfiguration config, Vertx vertx,
+                KafkaConsumer<?, ?> consumer, BiConsumer<Throwable, Boolean> reportFailure) {
+            int defaultTimeout = config.config()
+                    .getOptionalValue(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, Integer.class)
+                    .orElse(60000);
+            String stateDir = config.config().getValue(FILE_CHECKPOINT_NAME + ".stateDir", String.class);
+
+            return new KafkaFileCheckpointCommit(config, vertx, consumer, reportFailure, defaultTimeout,
+                    new File(stateDir));
+        }
+    }
+
+    private String getStatePath(TopicPartition partition) {
+        return stateDir.toPath().resolve(partition.topic() + "-" + partition.partition()).toString();
+    }
+
+    @Override
+    protected Uni<ProcessingState<?>> fetchProcessingState(TopicPartition partition) {
+        String statePath = getStatePath(partition);
+        return mutinyVertx.fileSystem().exists(statePath).chain(exists -> {
+            if (exists)
+                return mutinyVertx.fileSystem().readFile(statePath)
+                        .map(this::deserializeState)
+                        .onFailure().invoke(t -> log.errorf(t, "Error fetching processing state for partition %s", partition))
+                        .onItem().invoke(r -> log.debugf("Fetched state for partition %s : %s", partition, r));
+            return Uni.createFrom().item(() -> null);
+        });
+    }
+
+    private <T> ProcessingState<T> deserializeState(Buffer b) {
+        return Json.decodeValue(b.getDelegate(), ProcessingState.class);
+    }
+
+    @Override
+    protected Uni<Void> persistProcessingState(TopicPartition partition, ProcessingState<?> state) {
+        String statePath = getStatePath(partition);
+        if (state != null) {
+            return mutinyVertx.fileSystem().exists(statePath).chain(exists -> {
+                if (exists)
+                    return fetchProcessingState(partition).onFailure().recoverWithNull();
+                return mutinyVertx.fileSystem().createFile(statePath)
+                        .onItem().transform(x -> (ProcessingState<?>) null)
+                        .onFailure(t -> Optional.ofNullable(t.getCause())
+                                .map(Object::getClass).orElse(null) == FileAlreadyExistsException.class)
+                        .recoverWithNull();
+            }).chain(s -> {
+                if (s != null && s.getOffset() > state.getOffset()) {
+                    log.warnf("Skipping persist operation : higher offset found on store %d > %d",
+                            s.getOffset(), state.getOffset());
+                    return Uni.createFrom().voidItem();
+                } else {
+                    return mutinyVertx.fileSystem().writeFile(statePath, serializeState(state));
+                }
+            })
+                    .onFailure()
+                    .invoke(t -> log.errorf(t, "Error persisting processing state `%s` for partition %s", state, partition))
+                    .onItem().invoke(r -> log.debugf("Persisted state for partition %s : %s -> %s", partition, state, r));
+        } else {
+            return Uni.createFrom().voidItem();
+        }
+    }
+
+    private Buffer serializeState(ProcessingState<?> state) {
+        return Buffer.newInstance(Json.encodeToBuffer(state));
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaIgnoreCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaIgnoreCommit.java
@@ -1,9 +1,15 @@
 package io.smallrye.reactive.messaging.kafka.commit;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
 
+import javax.enterprise.context.ApplicationScoped;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
+import io.vertx.mutiny.core.Vertx;
 
 /**
  * Ignores an ACK and does not commit any offsets.
@@ -16,8 +22,22 @@ import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
  */
 public class KafkaIgnoreCommit implements KafkaCommitHandler {
 
+    @ApplicationScoped
+    @Identifier(Strategy.IGNORE)
+    public static class Factory implements KafkaCommitHandler.Factory {
+
+        @Override
+        public KafkaIgnoreCommit create(
+                KafkaConnectorIncomingConfiguration config,
+                Vertx vertx,
+                KafkaConsumer<?, ?> consumer,
+                BiConsumer<Throwable, Boolean> reportFailure) {
+            return new KafkaIgnoreCommit();
+        }
+    }
+
     @Override
-    public <K, V> CompletionStage<Void> handle(IncomingKafkaRecord<K, V> record) {
-        return CompletableFuture.completedFuture(null);
+    public <K, V> Uni<Void> handle(IncomingKafkaRecord<K, V> record) {
+        return Uni.createFrom().voidItem();
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ProcessingState.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/ProcessingState.java
@@ -1,0 +1,46 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+/**
+ * Checkpoint state associated with an offset.
+ *
+ * This object can be used to persist the processing state per topic-partition into a state store.
+ *
+ * @param <T> type of the processing state
+ */
+public class ProcessingState<T> {
+
+    private T state;
+    private long offset;
+
+    public ProcessingState(T state, long offset) {
+        this.state = state;
+        this.offset = offset;
+    }
+
+    public ProcessingState() {
+    }
+
+    public T getState() {
+        return state;
+    }
+
+    public Long getOffset() {
+        return offset;
+    }
+
+    public void setState(T state) {
+        this.state = state;
+    }
+
+    public void setOffset(Long offset) {
+        this.offset = offset;
+    }
+
+    @Override
+    public String toString() {
+        return "ProcessingState{" +
+                "state=" + state +
+                ", offset=" + offset +
+                '}';
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/StateStore.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/StateStore.java
@@ -1,0 +1,104 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.kafka.common.TopicPartition;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * State store metadata type for injecting state store interactions into received messages.
+ * This allows accessing the current processing state restored from the state store, and produce the next state.
+ * The next state can be saved locally or persisted into the external store.
+ *
+ * <p>
+ * A sample processing method with checkpointing would be:
+ *
+ * <pre>
+ * &#64;Incoming("in")
+ * public CompletionStage&lt;Void&gt; process(Message&lt;String&gt; msg) {
+ *     StateStore&lt;Integer&gt; stateStore = StateStore.fromMessage(msg);
+ *     if (stateStore != null) {
+ *         stateStore.transformAndStoreOnAck(0, current -> current + msg.getPayload());
+ *     }
+ *     return CompletableFuture.completed(null);
+ * }
+ * </pre>
+ *
+ * @param <T> type of the processing state
+ */
+public class StateStore<T> {
+    private final TopicPartition topicPartition;
+    private final long recordOffset;
+    private final Supplier<ProcessingState<T>> currentSupplier;
+    private ProcessingState<T> next;
+    private boolean persist;
+
+    @SuppressWarnings("unchecked")
+    public static <S> ProcessingState<S> getProcessingState(Message<?> message) {
+        return (ProcessingState<S>) message.getMetadata(StateStore.class)
+                .flatMap(StateStore::getNext).orElse(null);
+    }
+
+    public static boolean isPersist(Message<?> message) {
+        return message.getMetadata(StateStore.class).map(StateStore::isPersist).orElse(false);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <S> StateStore<S> fromMessage(Message<?> message) {
+        return (StateStore<S>) message.getMetadata(StateStore.class).orElse(null);
+    }
+
+    public StateStore(TopicPartition topicPartition, long recordOffset, Supplier<ProcessingState<T>> stateSupplier) {
+        this.topicPartition = topicPartition;
+        this.recordOffset = recordOffset;
+        this.currentSupplier = stateSupplier;
+    }
+
+    public TopicPartition getTopicPartition() {
+        return topicPartition;
+    }
+
+    public long getRecordOffset() {
+        return recordOffset;
+    }
+
+    public boolean isPersist() {
+        return persist;
+    }
+
+    public Optional<ProcessingState<T>> getCurrent() {
+        return Optional.ofNullable(currentSupplier.get());
+    }
+
+    public Optional<ProcessingState<T>> getNext() {
+        return Optional.ofNullable(next);
+    }
+
+    public T storeLocal(T state, long offset) {
+        this.next = new ProcessingState<>(state, offset);
+        return this.next.getState();
+    }
+
+    public T storeLocal(T state) {
+        return storeLocal(state, getRecordOffset() + 1);
+    }
+
+    public T transformAndStoreLocal(T initialState, Function<T, T> transformation) {
+        return storeLocal(transformation.apply(getCurrent().map(ProcessingState::getState).orElse(initialState)));
+    }
+
+    public T storeOnAck(T state, long offset) {
+        this.persist = true;
+        return storeLocal(state, offset);
+    }
+
+    public T storeOnAck(T state) {
+        return storeOnAck(state, getRecordOffset() + 1);
+    }
+
+    public T transformAndStoreOnAck(T initialState, Function<T, T> transformation) {
+        return storeOnAck(transformation.apply(getCurrent().map(ProcessingState::getState).orElse(initialState)));
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaIgnoreFailure.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaIgnoreFailure.java
@@ -2,26 +2,44 @@ package io.smallrye.reactive.messaging.kafka.fault;
 
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
-import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+
+import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Metadata;
 
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
+import io.vertx.mutiny.core.Vertx;
 
 public class KafkaIgnoreFailure implements KafkaFailureHandler {
 
     private final String channel;
+
+    @ApplicationScoped
+    @Identifier(Strategy.IGNORE)
+    public static class Factory implements KafkaFailureHandler.Factory {
+
+        @Override
+        public KafkaFailureHandler crate(KafkaConnectorIncomingConfiguration config, Vertx vertx,
+                KafkaConsumer<?, ?> consumer, BiConsumer<Throwable, Boolean> reportFailure) {
+            return new KafkaIgnoreFailure(config.getChannel());
+        }
+    }
 
     public KafkaIgnoreFailure(String channel) {
         this.channel = channel;
     }
 
     @Override
-    public <K, V> CompletionStage<Void> handle(
+    public <K, V> Uni<Void> handle(
             IncomingKafkaRecord<K, V> record, Throwable reason, Metadata metadata) {
         // We commit the message, log and continue
         log.messageNackedIgnore(channel, reason.getMessage());
         log.messageNackedFullIgnored(reason);
-        return record.ack();
+        return Uni.createFrom().completionStage(record.ack());
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/JsonHelper.java
@@ -15,72 +15,87 @@ public class JsonHelper {
         JsonObject json = new JsonObject();
         Iterable<String> propertyNames = config.getPropertyNames();
         for (String originalKey : propertyNames) {
-            // Transform keys that may come from environment variables.
-            // As kafka properties use `.`, transform "_" into "."
-            String key = originalKey;
-            if (key.contains("_") || allCaps(key)) {
-                key = originalKey.toLowerCase().replace("_", ".");
-            }
-            try {
-                Optional<Integer> i = config.getOptionalValue(key, Integer.class);
-                if (!i.isPresent()) {
-                    i = config.getOptionalValue(originalKey, Integer.class);
-                }
-
-                if (i.isPresent() && i.get() instanceof Integer) {
-                    json.put(key, i.get());
-                    continue;
-                }
-            } catch (ClassCastException | IllegalArgumentException e) {
-                // Ignore me
-            }
-
-            try {
-                Optional<Double> d = config.getOptionalValue(key, Double.class);
-                if (!d.isPresent()) {
-                    d = config.getOptionalValue(originalKey, Double.class);
-                }
-                if (d.isPresent() && d.get() instanceof Double) {
-                    json.put(key, d.get());
-                    continue;
-                }
-            } catch (ClassCastException | IllegalArgumentException e) {
-                // Ignore me
-            }
-
-            try {
-                String s = config.getOptionalValue(key, String.class)
-                        .orElseGet(() -> config.getOptionalValue(originalKey, String.class).orElse(null));
-                if (s != null) {
-                    String value = s.trim();
-                    if (value.equalsIgnoreCase("false")) {
-                        json.put(key, false);
-                    } else if (value.equalsIgnoreCase("true")) {
-                        json.put(key, true);
-                    } else {
-                        json.put(key, value);
-                    }
-                    continue;
-                }
-            } catch (ClassCastException e) {
-                // Ignore me
-            }
-
-            // We need to do boolean last, as it would return `false` for any non-parsable object.
-            try {
-                Optional<Boolean> d = config.getOptionalValue(key, Boolean.class);
-                if (!d.isPresent()) {
-                    d = config.getOptionalValue(originalKey, Boolean.class);
-                }
-                if (d.isPresent()) {
-                    json.put(key, d.get());
-                }
-            } catch (ClassCastException | IllegalArgumentException e) {
-                // Ignore the entry
-            }
-
+            extractConfigKey(config, json, originalKey, "");
         }
         return json;
+    }
+
+    public static JsonObject asJsonObject(Config config, String prefix) {
+        JsonObject json = new JsonObject();
+        Iterable<String> propertyNames = config.getPropertyNames();
+        for (String originalKey : propertyNames) {
+            if (originalKey.startsWith(prefix)) {
+                extractConfigKey(config, json, originalKey, prefix);
+            }
+        }
+        return json;
+    }
+
+    private static void extractConfigKey(Config config, JsonObject json, String originalKey, String prefixToStrip) {
+        // Transform keys that may come from environment variables.
+        // As kafka properties use `.`, transform "_" into "."
+        String key = originalKey;
+        if (key.contains("_") || allCaps(key)) {
+            key = originalKey.toLowerCase().replace("_", ".");
+        }
+        String jsonKey = key.substring(prefixToStrip.length());
+        try {
+            Optional<Integer> i = config.getOptionalValue(key, Integer.class);
+            if (!i.isPresent()) {
+                i = config.getOptionalValue(originalKey, Integer.class);
+            }
+
+            if (i.isPresent() && i.get() instanceof Integer) {
+                json.put(jsonKey, i.get());
+                return;
+            }
+        } catch (ClassCastException | IllegalArgumentException e) {
+            // Ignore me
+        }
+
+        try {
+            Optional<Double> d = config.getOptionalValue(key, Double.class);
+            if (!d.isPresent()) {
+                d = config.getOptionalValue(originalKey, Double.class);
+            }
+            if (d.isPresent() && d.get() instanceof Double) {
+                json.put(jsonKey, d.get());
+                return;
+            }
+        } catch (ClassCastException | IllegalArgumentException e) {
+            // Ignore me
+        }
+
+        try {
+            String s = config.getOptionalValue(key, String.class)
+                    .orElseGet(() -> config.getOptionalValue(originalKey, String.class).orElse(null));
+            if (s != null) {
+                String value = s.trim();
+                if (value.equalsIgnoreCase("false")) {
+                    json.put(jsonKey, false);
+                } else if (value.equalsIgnoreCase("true")) {
+                    json.put(jsonKey, true);
+                } else {
+                    json.put(jsonKey, value);
+                }
+                return;
+            }
+        } catch (ClassCastException e) {
+            // Ignore me
+        }
+
+        // We need to do boolean last, as it would return `false` for any non-parsable object.
+        try {
+            Optional<Boolean> d = config.getOptionalValue(key, Boolean.class);
+            if (!d.isPresent()) {
+                d = config.getOptionalValue(originalKey, Boolean.class);
+            }
+            if (d.isPresent()) {
+                json.put(jsonKey, d.get());
+            }
+        } catch (ClassCastException | IllegalArgumentException e) {
+            // Ignore the entry
+        }
     }
 
     private static boolean allCaps(String key) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
@@ -371,6 +371,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     }
 
     @CheckReturnValue
+    @Override
     public Uni<Void> commitAsync(Map<TopicPartition, OffsetAndMetadata> map) {
         return Uni.createFrom().<Void> emitter(e -> {
             consumer.commitAsync(map, (offsets, exception) -> {
@@ -384,6 +385,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
                 .runSubscriptionOn(kafkaWorker);
     }
 
+    @Override
     public Map<String, ?> configuration() {
         return kafkaConfiguration;
     }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaProducer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaProducer.java
@@ -246,10 +246,12 @@ public class ReactiveKafkaProducer<K, V> implements io.smallrye.reactive.messagi
         return producer;
     }
 
+    @Override
     public Map<String, ?> configuration() {
         return kafkaConfiguration;
     }
 
+    @Override
     public void close() {
         if (closed.compareAndSet(false, true)) {
             int timeout = this.closetimeout;

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatchTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaRecordBatchTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -22,6 +21,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaCommitHandler;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaIgnoreCommit;
@@ -43,8 +43,8 @@ public class KafkaRecordBatchTest {
     @BeforeEach
     void setupRecords() {
         MockitoAnnotations.openMocks(this);
-        when(commitHandler.handle(any())).thenReturn(CompletableFuture.completedFuture(null));
-        when(onNack.handle(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(commitHandler.handle(any())).thenReturn(Uni.createFrom().voidItem());
+        when(onNack.handle(any(), any(), any())).thenReturn(Uni.createFrom().voidItem());
 
         HashMap<TopicPartition, List<ConsumerRecord<String, Integer>>> consumerRecords = new HashMap<>();
         consumerRecords.put(new TopicPartition("t", 1),

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -40,9 +40,12 @@ import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.kafka.api.KafkaMetadataUtil;
 import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
 import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.SingletonInstance;
 import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
+import io.smallrye.reactive.messaging.kafka.commit.KafkaThrottledLatestProcessedCommit;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import io.smallrye.reactive.messaging.kafka.companion.test.KafkaBrokerExtension;
+import io.smallrye.reactive.messaging.kafka.fault.KafkaFailStop;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
 import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
@@ -69,7 +72,7 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
         MapBasedConfig config = newCommonConfigForSource()
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -91,7 +94,7 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
 
         companion.topics().createAndWait(topic, 3, Duration.ofMinutes(1));
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -113,7 +116,7 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
         MapBasedConfig config = newCommonConfigForSource()
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<KafkaRecord> messages = new ArrayList<>();
@@ -141,6 +144,9 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
         connector.configurations = UnsatisfiedInstance.instance();
         connector.consumerRebalanceListeners = UnsatisfiedInstance.instance();
         connector.kafkaCDIEvents = testEvents;
+        connector.commitHandlerFactories = new SingletonInstance<>("throttled",
+                new KafkaThrottledLatestProcessedCommit.Factory());
+        connector.failureHandlerFactories = new SingletonInstance<>("fail", new KafkaFailStop.Factory());
         connector.init();
 
         PublisherBuilder<? extends KafkaRecord> builder = (PublisherBuilder<? extends KafkaRecord>) connector
@@ -179,6 +185,9 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
         connector.configurations = UnsatisfiedInstance.instance();
         connector.consumerRebalanceListeners = UnsatisfiedInstance.instance();
         connector.kafkaCDIEvents = new CountKafkaCdiEvents();
+        connector.commitHandlerFactories = new SingletonInstance<>("throttled",
+                new KafkaThrottledLatestProcessedCommit.Factory());
+        connector.failureHandlerFactories = new SingletonInstance<>("fail", new KafkaFailStop.Factory());
         connector.init();
 
         PublisherBuilder<? extends KafkaRecord> builder = (PublisherBuilder<? extends KafkaRecord>) connector
@@ -218,7 +227,7 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
             KafkaCompanion kafkaCompanion = new KafkaCompanion(kafka.getBootstrapServers());
 
             KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-            source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+            source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                     UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents,
                     UnsatisfiedInstance.instance(), -1);
             List<KafkaRecord> messages1 = new ArrayList<>();
@@ -484,7 +493,7 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
         MapBasedConfig config = newCommonConfigForSource()
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -550,7 +559,7 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
                 .with("sasl.jaas.config", "") //optional configuration
                 .with("sasl.mechanism", ""); //optional configuration
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceWithLegacyMetadataTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceWithLegacyMetadataTest.java
@@ -39,9 +39,12 @@ import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.kafka.api.KafkaMetadataUtil;
 import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
 import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.base.SingletonInstance;
 import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
+import io.smallrye.reactive.messaging.kafka.commit.KafkaThrottledLatestProcessedCommit;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import io.smallrye.reactive.messaging.kafka.companion.test.KafkaBrokerExtension;
+import io.smallrye.reactive.messaging.kafka.fault.KafkaFailStop;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
 import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
@@ -74,7 +77,7 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaCompanionTestBase {
         MapBasedConfig config = newCommonConfigForSource()
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -96,7 +99,7 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaCompanionTestBase {
 
         companion.topics().createAndWait(topic, 3);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -118,7 +121,7 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaCompanionTestBase {
         MapBasedConfig config = newCommonConfigForSource()
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<KafkaRecord> messages = new ArrayList<>();
@@ -145,6 +148,9 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaCompanionTestBase {
         connector.executionHolder = new ExecutionHolder(vertx);
         connector.configurations = UnsatisfiedInstance.instance();
         connector.consumerRebalanceListeners = UnsatisfiedInstance.instance();
+        connector.commitHandlerFactories = new SingletonInstance<>("throttled",
+                new KafkaThrottledLatestProcessedCommit.Factory());
+        connector.failureHandlerFactories = new SingletonInstance<>("fail", new KafkaFailStop.Factory());
         connector.kafkaCDIEvents = testEvents;
         connector.init();
 
@@ -184,6 +190,9 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaCompanionTestBase {
         connector.configurations = UnsatisfiedInstance.instance();
         connector.consumerRebalanceListeners = UnsatisfiedInstance.instance();
         connector.kafkaCDIEvents = new CountKafkaCdiEvents();
+        connector.commitHandlerFactories = new SingletonInstance<>("throttled",
+                new KafkaThrottledLatestProcessedCommit.Factory());
+        connector.failureHandlerFactories = new SingletonInstance<>("fail", new KafkaFailStop.Factory());
         connector.init();
 
         PublisherBuilder<? extends KafkaRecord> builder = (PublisherBuilder<? extends KafkaRecord>) connector
@@ -223,7 +232,7 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaCompanionTestBase {
             KafkaCompanion kafkaCompanion = new KafkaCompanion(kafka.getBootstrapServers());
 
             KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-            source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+            source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                     UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents,
                     UnsatisfiedInstance.instance(), -1);
             List<KafkaRecord> messages1 = new ArrayList<>();
@@ -484,7 +493,7 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaCompanionTestBase {
         MapBasedConfig config = newCommonConfigForSource()
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -549,7 +558,7 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaCompanionTestBase {
                 .with("sasl.jaas.config", "") //optional configuration
                 .with("sasl.mechanism", ""); //optional configuration
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/SourceCloseTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/SourceCloseTest.java
@@ -48,10 +48,12 @@ public class SourceCloseTest extends KafkaCompanionTestBase {
         List<Integer> list = new ArrayList<>();
 
         KafkaSource<String, Integer> source1 = new KafkaSource<>(vertx, groupId,
-                new KafkaConnectorIncomingConfiguration(config1), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config1), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
         KafkaSource<String, Integer> source2 = new KafkaSource<>(vertx, groupId,
-                new KafkaConnectorIncomingConfiguration(config2), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config2), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
 
         source1.getStream()

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/MultipleInstance.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/MultipleInstance.java
@@ -1,0 +1,73 @@
+package io.smallrye.reactive.messaging.kafka.base;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.util.TypeLiteral;
+
+import io.smallrye.common.annotation.Identifier;
+
+public class MultipleInstance<T> implements Instance<T> {
+
+    private final Map<String, T> instances;
+
+    public MultipleInstance(T... instances) {
+        this.instances = new HashMap<>();
+        for (T instance : instances) {
+            Identifier identifier = instance.getClass().getAnnotation(Identifier.class);
+            this.instances.put(identifier.value(), instance);
+        }
+    }
+
+    @Override
+    public Instance<T> select(Annotation... qualifiers) {
+        if (qualifiers.length == 0) {
+            return this;
+        }
+        if (qualifiers.length == 1 && qualifiers[0] instanceof Identifier) {
+            String name = ((Identifier) qualifiers[0]).value();
+            if (instances.containsKey(name)) {
+                return new SingletonInstance<>(name, instances.get(name));
+            }
+        }
+        return UnsatisfiedInstance.instance();
+    }
+
+    @Override
+    public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isUnsatisfied() {
+        return false;
+    }
+
+    @Override
+    public boolean isAmbiguous() {
+        return false;
+    }
+
+    @Override
+    public void destroy(T instance) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return instances.values().iterator();
+    }
+
+    @Override
+    public T get() {
+        return instances.values().stream().findFirst().orElse(null);
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceBatchWithCloudEventsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceBatchWithCloudEventsTest.java
@@ -72,7 +72,7 @@ public class KafkaSourceBatchWithCloudEventsTest extends KafkaCompanionTestBase 
         config.put("value.deserializer", JsonObjectSerde.JsonObjectDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -126,7 +126,7 @@ public class KafkaSourceBatchWithCloudEventsTest extends KafkaCompanionTestBase 
         config.put("value.deserializer", BufferSerde.BufferDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -159,7 +159,7 @@ public class KafkaSourceBatchWithCloudEventsTest extends KafkaCompanionTestBase 
         config.put("value.deserializer", StringDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -305,7 +305,7 @@ public class KafkaSourceBatchWithCloudEventsTest extends KafkaCompanionTestBase 
         config.put("channel-name", topic);
         config.put("cloud-events", false);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -343,7 +343,7 @@ public class KafkaSourceBatchWithCloudEventsTest extends KafkaCompanionTestBase 
         config.put("channel-name", topic);
         config.put("cloud-events", false);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -385,7 +385,7 @@ public class KafkaSourceBatchWithCloudEventsTest extends KafkaCompanionTestBase 
         config.put("value.deserializer", StringDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceWithCloudEventsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSourceWithCloudEventsTest.java
@@ -67,7 +67,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("value.deserializer", StringDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -124,7 +124,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("value.deserializer", JsonObjectSerde.JsonObjectDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -177,7 +177,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("value.deserializer", ByteArrayDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -227,7 +227,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("value.deserializer", BufferSerde.BufferDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -259,7 +259,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("value.deserializer", JsonObjectSerde.JsonObjectDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -293,7 +293,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("value.deserializer", StringDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -353,7 +353,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("value.deserializer", StringDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -413,7 +413,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("value.deserializer", StringDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -543,7 +543,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events", false);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -582,7 +582,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("channel-name", topic);
         config.put("cloud-events", false);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();
@@ -624,7 +624,7 @@ public class KafkaSourceWithCloudEventsTest extends KafkaCompanionTestBase {
         config.put("value.deserializer", StringDeserializer.class.getName());
         config.put("channel-name", topic);
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> messages = new ArrayList<>();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ClientTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ClientTestBase.java
@@ -99,7 +99,8 @@ public class ClientTestBase extends KafkaCompanionTestBase {
         SingletonInstance<KafkaConsumerRebalanceListener> listeners = new SingletonInstance<>(groupId,
                 getKafkaConsumerRebalanceListenerAwaitingAssignation());
 
-        source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config),
+        source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories,
+                failureHandlerFactories,
                 listeners, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
         return source;
     }
@@ -112,7 +113,8 @@ public class ClientTestBase extends KafkaCompanionTestBase {
         SingletonInstance<KafkaConsumerRebalanceListener> listeners = new SingletonInstance<>(groupId,
                 getKafkaConsumerRebalanceListenerAwaitingAssignationAndSeekToBeginning());
 
-        source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config),
+        source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories,
+                failureHandlerFactories,
                 listeners, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
         return source;
     }
@@ -126,6 +128,7 @@ public class ClientTestBase extends KafkaCompanionTestBase {
                 getKafkaConsumerRebalanceListenerAwaitingAssignationAndSeekToEnd());
 
         source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config),
+                commitHandlerFactories, failureHandlerFactories,
                 listeners, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
         return source;
     }
@@ -139,6 +142,7 @@ public class ClientTestBase extends KafkaCompanionTestBase {
                 getKafkaConsumerRebalanceListenerAwaitingAssignationAndSeekToOffset());
 
         source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config),
+                commitHandlerFactories, failureHandlerFactories,
                 listeners, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
         return source;
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/HighLatencyTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/HighLatencyTest.java
@@ -66,7 +66,7 @@ public class HighLatencyTest extends KafkaCompanionProxyTestBase {
                 .with("retry-max-wait", 30);
 
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
-        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic,
+        source = new KafkaSource<>(vertx, UUID.randomUUID().toString(), ic, commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents,
                 UnsatisfiedInstance.instance(), -1);
         List<KafkaRecord<?, ?>> messages1 = new ArrayList<>();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/KafkaClientReactiveStreamsPublisherTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/KafkaClientReactiveStreamsPublisherTest.java
@@ -1,5 +1,8 @@
 package io.smallrye.reactive.messaging.kafka.client;
 
+import static io.smallrye.reactive.messaging.kafka.base.WeldTestBase.commitHandlerFactories;
+import static io.smallrye.reactive.messaging.kafka.base.WeldTestBase.failureHandlerFactories;
+
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -117,7 +120,8 @@ public class KafkaClientReactiveStreamsPublisherTest
         MapBasedConfig config = createConsumerConfig(groupId)
                 .put("topic", topic);
 
-        source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config),
+        source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories,
+                failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/PauseResumeTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/PauseResumeTest.java
@@ -59,7 +59,8 @@ public class PauseResumeTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -123,7 +124,8 @@ public class PauseResumeTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -184,7 +186,8 @@ public class PauseResumeTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -249,7 +252,8 @@ public class PauseResumeTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -298,7 +302,8 @@ public class PauseResumeTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaBatchConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaBatchConsumerTest.java
@@ -64,6 +64,7 @@ public class ReactiveKafkaBatchConsumerTest extends ClientTestBase {
                 getKafkaConsumerRebalanceListenerAwaitingAssignation());
 
         source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config),
+                commitHandlerFactories, failureHandlerFactories,
                 listeners, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
         return source;
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaConsumerTest.java
@@ -207,6 +207,7 @@ public class ReactiveKafkaConsumerTest extends ClientTestBase {
                 getKafkaConsumerRebalanceListenerAwaitingAssignation());
 
         source = new KafkaSource<>(vertx, groupId, new KafkaConnectorIncomingConfiguration(config),
+                commitHandlerFactories, failureHandlerFactories,
                 listeners, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 0);
 
         AssertSubscriber<IncomingKafkaRecord<Integer, String>> subscriber = source.getStream()
@@ -389,7 +390,8 @@ public class ReactiveKafkaConsumerTest extends ClientTestBase {
         // The rebalance will split the partitions between the 2 sources, but both will restaert from offset 0, as nothing
         // has been acked.
         KafkaSource<Integer, String> source2 = new KafkaSource<>(vertx, groupId,
-                new KafkaConnectorIncomingConfiguration(config2), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config2), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), 3);
         source2.getStream()
                 .invoke(i -> {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/BatchCommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/BatchCommitStrategiesTest.java
@@ -60,7 +60,8 @@ public class BatchCommitStrategiesTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -139,7 +140,8 @@ public class BatchCommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -194,7 +196,8 @@ public class BatchCommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -283,7 +286,8 @@ public class BatchCommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -349,7 +353,8 @@ public class BatchCommitStrategiesTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
 
         injectMockConsumer(source, consumer);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -62,7 +62,8 @@ public class CommitStrategiesTest extends WeldTestBase {
         MapBasedConfig config = commonConfiguration().with("commit-strategy", "latest").with("client.id",
                 UUID.randomUUID().toString());
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -164,7 +165,8 @@ public class CommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -229,7 +231,8 @@ public class CommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -310,7 +313,8 @@ public class CommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -378,7 +382,8 @@ public class CommitStrategiesTest extends WeldTestBase {
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> {
             source = new KafkaSource<>(vertx, group,
-                    new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                    new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                    getConsumerRebalanceListeners(),
                     CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         }).isInstanceOf(UnsatisfiedResolutionException.class);
     }
@@ -392,7 +397,8 @@ public class CommitStrategiesTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1))
                         .isInstanceOf(AmbiguousResolutionException.class).hasMessageContaining("mine");
     }
@@ -406,7 +412,8 @@ public class CommitStrategiesTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
 
         injectMockConsumer(source, consumer);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/DeprecatedCommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/DeprecatedCommitStrategiesTest.java
@@ -86,7 +86,8 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
                 UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -188,7 +189,8 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -252,7 +254,8 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -331,7 +334,8 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
                 .with("auto.commit.interval.ms", 100);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 
@@ -399,7 +403,8 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> {
             new KafkaSource<>(vertx, group,
-                    new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                    new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                    getConsumerRebalanceListeners(),
                     CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         }).isInstanceOf(UnsatisfiedResolutionException.class);
     }
@@ -413,7 +418,8 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1))
                         .isInstanceOf(DeploymentException.class).hasMessageContaining("mine");
     }
@@ -427,7 +433,8 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
                 .with("client.id", UUID.randomUUID().toString());
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
 
         injectMockConsumer(source, consumer);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
@@ -64,6 +64,7 @@ public class KafkaCommitHandlerTest extends KafkaCompanionTestBase {
         source = new KafkaSource<>(vertx,
                 "test-source-with-auto-commit-enabled",
                 ic,
+                commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
@@ -106,6 +107,7 @@ public class KafkaCommitHandlerTest extends KafkaCompanionTestBase {
 
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx, "test-source-with-auto-commit-disabled", ic,
+                commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(), CountKafkaCdiEvents.noCdiEvents,
                 UnsatisfiedInstance.instance(), -1);
 
@@ -144,6 +146,7 @@ public class KafkaCommitHandlerTest extends KafkaCompanionTestBase {
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit", ic,
+                commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents,
                 UnsatisfiedInstance.instance(), -1);
@@ -192,6 +195,7 @@ public class KafkaCommitHandlerTest extends KafkaCompanionTestBase {
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
         source = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit-without-acking", ic,
+                commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents,
                 UnsatisfiedInstance.instance(), -1);
@@ -245,12 +249,14 @@ public class KafkaCommitHandlerTest extends KafkaCompanionTestBase {
         KafkaConnectorIncomingConfiguration ic2 = new KafkaConnectorIncomingConfiguration(config2);
         source = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit", ic1,
+                commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents,
                 UnsatisfiedInstance.instance(), -1);
 
         KafkaSource<String, Integer> source2 = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit", ic2,
+                commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents,
                 UnsatisfiedInstance.instance(), -1);
@@ -337,12 +343,14 @@ public class KafkaCommitHandlerTest extends KafkaCompanionTestBase {
         KafkaConnectorIncomingConfiguration ic2 = new KafkaConnectorIncomingConfiguration(config2);
         source = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit", ic1,
+                commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents,
                 UnsatisfiedInstance.instance(), -1);
 
         KafkaSource<String, Integer> source2 = new KafkaSource<>(vertx,
                 "test-source-with-throttled-latest-processed-commit", ic2,
+                commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents,
                 UnsatisfiedInstance.instance(), -1);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaFileCheckpointCommitTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaFileCheckpointCommitTest.java
@@ -1,0 +1,205 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import static org.awaitility.Awaitility.await;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.CountKafkaCdiEvents;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
+import io.smallrye.reactive.messaging.kafka.base.SingletonInstance;
+import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
+import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+public class KafkaFileCheckpointCommitTest extends KafkaCompanionTestBase {
+
+    private KafkaSource<String, Integer> source;
+    private KafkaSource<String, Integer> source2;
+
+    @AfterEach
+    public void stopAll() {
+        if (source != null) {
+            source.closeQuietly();
+        }
+        if (source2 != null) {
+            source2.closeQuietly();
+        }
+    }
+
+    private void checkOffsetSum(File tempDir, int sum) {
+        await().until(() -> {
+            List<JsonObject> states = Uni.join().all(Stream.of(0, 1, 2)
+                    .map(i -> tempDir.toPath().resolve(topic + "-" + i).toString())
+                    .map(path -> vertx.fileSystem().readFile(path).map(Buffer::toJsonObject))
+                    .collect(Collectors.toList()))
+                    .andFailFast()
+                    .await().indefinitely();
+
+            int offset = states.stream().mapToInt(tuple -> tuple.getInteger("offset")).sum();
+            int state = states.stream().mapToInt(tuple -> tuple.getInteger("state")).sum();
+
+            return offset == sum && state == sum * (sum - 1) / 2;
+        });
+    }
+
+    @Test
+    public void testMultipleIndependentConsumers(@TempDir File tempDir) {
+        companion.topics().createAndWait(topic, 3);
+
+        MapBasedConfig config = newCommonConfigForSource()
+                .with("group.id", "test-source-with-auto-commit-enabled")
+                .with("commit-strategy", "checkpoint-file")
+                .with("checkpoint-file.stateDir", tempDir.getAbsolutePath())
+                .with("value.deserializer", IntegerDeserializer.class.getName());
+        KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
+
+        source = new KafkaSource<>(vertx,
+                "test-source-with-auto-commit-enabled",
+                ic,
+                new SingletonInstance<>("checkpoint-file", new KafkaFileCheckpointCommit.Factory()),
+                failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
+                CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
+
+        List<Message<?>> messages = Collections.synchronizedList(new ArrayList<>());
+        source.getStream().subscribe().with(m -> {
+            StateStore<Integer> stateStore = StateStore.fromMessage(m);
+            if (stateStore != null) {
+                stateStore.transformAndStoreOnAck(0, current -> current + m.getPayload());
+            }
+            messages.add(m);
+            Uni.createFrom().completionStage(m.ack())
+                    .runSubscriptionOn(vertx::runOnContext)
+                    .subscribeAsCompletionStage();
+        });
+
+        companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i), 100);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> messages.size() >= 100);
+        checkOffsetSum(tempDir, 100);
+
+        KafkaConnectorIncomingConfiguration ic2 = new KafkaConnectorIncomingConfiguration(
+                config.with(ConsumerConfig.CLIENT_ID_CONFIG,
+                        source.getConsumer().get(ConsumerConfig.CLIENT_ID_CONFIG) + "-2"));
+        source2 = new KafkaSource<>(vertx,
+                "test-source-with-auto-commit-enabled",
+                ic2,
+                new SingletonInstance<>("checkpoint-file", new KafkaFileCheckpointCommit.Factory()),
+                failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
+                CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
+
+        List<Message<?>> messages2 = Collections.synchronizedList(new ArrayList<>());
+        source2.getStream().subscribe().with(m -> {
+            StateStore<Integer> stateStore = StateStore.fromMessage(m);
+            if (stateStore != null) {
+                stateStore.transformAndStoreOnAck(0, current -> current + m.getPayload());
+            }
+            messages2.add(m);
+            Uni.createFrom().completionStage(m.ack())
+                    .runSubscriptionOn(vertx::runOnContext)
+                    .subscribeAsCompletionStage();
+        });
+
+        await().until(() -> !source2.getConsumer().getAssignments().await().indefinitely().isEmpty());
+
+        companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i + 100), 100);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> messages.size() + messages2.size() >= 200);
+        checkOffsetSum(tempDir, 200);
+
+        source.closeQuietly();
+        await().until(() -> source2.getConsumer().getAssignments().await().indefinitely().size() == 3);
+
+        companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i + 200), 100);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> messages.size() + messages2.size() >= 300);
+        checkOffsetSum(tempDir, 300);
+    }
+
+    @Test
+    public void testWithPartitions(@TempDir File tempDir) {
+        System.out.println(tempDir.getAbsolutePath());
+
+        addBeans(KafkaFileCheckpointCommit.Factory.class);
+        companion.topics().createAndWait(topic, 3);
+        String groupId = UUID.randomUUID().toString();
+
+        MapBasedConfig config = kafkaConfig("mp.messaging.incoming.kafka")
+                .with("group.id", groupId)
+                .with("topic", topic)
+                .with("partitions", 3)
+                .with("auto.offset.reset", "earliest")
+                .with("commit-strategy", "checkpoint-file")
+                .with("checkpoint-file.stateDir", tempDir.getAbsolutePath())
+                .with("value.deserializer", IntegerDeserializer.class.getName());
+
+        MyApplication application = runApplication(config, MyApplication.class);
+
+        int expected = 1000;
+        Random random = new Random();
+        companion.produceIntegers().usingGenerator(i -> {
+            int p = random.nextInt(3);
+            return new ProducerRecord<>(topic, p, Integer.toString(p), i);
+        }, expected).awaitCompletion(Duration.ofMinutes(1));
+
+        await().atMost(1, TimeUnit.MINUTES)
+                .until(() -> application.count() == expected);
+
+        checkOffsetSum(tempDir, expected);
+    }
+
+    @ApplicationScoped
+    public static class MyApplication {
+        private final AtomicLong count = new AtomicLong();
+        private final Map<String, List<Integer>> received = new ConcurrentHashMap<>();
+
+        @Incoming("kafka")
+        public CompletionStage<Void> consume(Message<Integer> msg) {
+            StateStore<Integer> stateStore = StateStore.fromMessage(msg);
+            if (stateStore != null) {
+                stateStore.transformAndStoreOnAck(0, current -> current + msg.getPayload());
+            }
+            String k = Thread.currentThread().getName();
+            List<Integer> list = received.computeIfAbsent(k, s -> new CopyOnWriteArrayList<>());
+            list.add(msg.getPayload());
+            count.incrementAndGet();
+            return msg.ack();
+        }
+
+        public Map<String, List<Integer>> getReceived() {
+            return received;
+        }
+
+        public long count() {
+            return count.get();
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaRedisCheckpointCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaRedisCheckpointCommit.java
@@ -1,0 +1,142 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import static io.vertx.mutiny.redis.client.Request.cmd;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
+import io.smallrye.reactive.messaging.kafka.impl.JsonHelper;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.RedisOptionsConverter;
+
+public class KafkaRedisCheckpointCommit extends KafkaCheckpointCommit {
+
+    public static final String REDIS_CHECKPOINT_NAME = "checkpoint-redis";
+
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final Redis redis;
+
+    public KafkaRedisCheckpointCommit(KafkaConnectorIncomingConfiguration config,
+            Vertx vertx,
+            KafkaConsumer<?, ?> consumer,
+            BiConsumer<Throwable, Boolean> reportFailure,
+            int defaultTimeout,
+            Redis redis) {
+        super(vertx, config, consumer, reportFailure, defaultTimeout);
+        this.redis = redis;
+    }
+
+    private <T> Uni<T> runWithRedis(Function<Redis, Uni<T>> action) {
+        return Uni.createFrom().deferred(() -> {
+            if (started.compareAndSet(false, true)) {
+                return redis.connect().replaceWith(redis)
+                        .onFailure().invoke(t -> {
+                            started.set(false);
+                            reportFailure.accept(t, true);
+                        });
+            } else {
+                return Uni.createFrom().item(redis);
+            }
+        })
+                .chain(action::apply);
+    }
+
+    @ApplicationScoped
+    @Identifier(REDIS_CHECKPOINT_NAME)
+    public static class Factory implements KafkaCommitHandler.Factory {
+
+        @Override
+        public KafkaCommitHandler create(KafkaConnectorIncomingConfiguration config, Vertx vertx,
+                KafkaConsumer<?, ?> consumer, BiConsumer<Throwable, Boolean> reportFailure) {
+            int defaultTimeout = config.config()
+                    .getOptionalValue(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, Integer.class)
+                    .orElse(60000);
+            JsonObject entries = JsonHelper.asJsonObject(config.config(), REDIS_CHECKPOINT_NAME + ".");
+            RedisOptions options = new RedisOptions();
+            RedisOptionsConverter.fromJson(entries, options);
+            Redis redis = Redis.createClient(vertx, options);
+
+            return new KafkaRedisCheckpointCommit(config, vertx, consumer, reportFailure, defaultTimeout, redis);
+        }
+
+    }
+
+    @Override
+    public void terminate(boolean graceful) {
+        super.terminate(graceful);
+        redis.close();
+        started.set(false);
+    }
+
+    @Override
+    protected Uni<ProcessingState<?>> fetchProcessingState(TopicPartition partition) {
+        return runWithRedis(redis -> redis.send(cmd(Command.GET).arg(getKey(partition)))
+                .onFailure().invoke(t -> log.errorf(t, "Error fetching processing state %s", partition))
+                .onItem().invoke(r -> log.debugf("Fetched state for partition %s : %s", partition, r))
+                .map(r -> Optional.ofNullable(r)
+                        .map(Response::toBuffer)
+                        .map(this::deserializeState)
+                        .orElse(null)));
+    }
+
+    private String getKey(TopicPartition partition) {
+        return partition.topic() + ":" + partition.partition();
+    }
+
+    private <T> ProcessingState<T> deserializeState(Buffer b) {
+        return Json.decodeValue(b.getDelegate(), ProcessingState.class);
+    }
+
+    @Override
+    protected Uni<Void> persistProcessingState(TopicPartition partition, ProcessingState<?> state) {
+        return runWithRedis(redis -> redis.send(cmd(Command.WATCH).arg(getKey(partition)))
+                .chain(() -> redis.send(cmd(Command.GET).arg(getKey(partition)))
+                        .map(r -> Optional.ofNullable(r)
+                                .map(Response::toBuffer)
+                                .map(this::deserializeState)
+                                .orElse(null))
+                        .chain(s -> {
+                            if (s != null && s.getOffset() > state.getOffset()) {
+                                log.warnf("Skipping persist operation for partition %s : higher offset found on store %d > %d",
+                                        partition, s.getOffset(), state.getOffset());
+                                return Uni.createFrom().voidItem();
+                            } else {
+                                return redis.batch(Arrays.asList(
+                                        cmd(Command.MULTI),
+                                        cmd(Command.SET).arg(getKey(partition)).arg(serializeState(state).toString()),
+                                        cmd(Command.EXEC)))
+                                        .onItem().invoke(r -> log.debugf("Persisted state for partition %s : %s -> %s",
+                                                partition, state, r))
+                                        .replaceWithVoid()
+                                        .onFailure().recoverWithUni(t -> {
+                                            log.errorf(t, "Error persisting processing state %s", state);
+                                            return redis.send(cmd(Command.DISCARD)).replaceWithVoid();
+                                        });
+                            }
+                        })));
+    }
+
+    private Buffer serializeState(ProcessingState<?> state) {
+        return Buffer.newInstance(Json.encodeToBuffer(state));
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaRedisCheckpointCommitTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaRedisCheckpointCommitTest.java
@@ -1,13 +1,14 @@
 package io.smallrye.reactive.messaging.kafka.commit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
@@ -25,13 +26,20 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.CountKafkaCdiEvents;
 import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.kafka.TestTags;
 import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
 import io.smallrye.reactive.messaging.kafka.base.SingletonInstance;
 import io.smallrye.reactive.messaging.kafka.base.UnsatisfiedInstance;
@@ -39,11 +47,46 @@ import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.mutiny.redis.client.Request;
+import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.RedisOptions;
 
-public class KafkaFileCheckpointCommitTest extends KafkaCompanionTestBase {
+@Tag(TestTags.FLAKY)
+@Disabled
+public class KafkaRedisCheckpointCommitTest extends KafkaCompanionTestBase {
 
     private KafkaSource<String, Integer> source;
     private KafkaSource<String, Integer> source2;
+
+    public static GenericContainer<?> redis;
+    private Redis redisClient;
+
+    @BeforeAll
+    static void beforeAll() {
+        redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+        redis.start();
+        await().until(() -> redis.isRunning());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (redis != null) {
+            redis.stop();
+        }
+    }
+
+    static String getRedisString() {
+        return String.format("redis://%s:%d", redis.getHost(), redis.getMappedPort(6379));
+    }
+
+    @BeforeEach
+    void setUp() {
+        redisClient = Redis.createClient(vertx, new RedisOptions()
+                .addConnectionString(getRedisString()))
+                .connectAndForget();
+    }
 
     @AfterEach
     public void stopAll() {
@@ -53,39 +96,51 @@ public class KafkaFileCheckpointCommitTest extends KafkaCompanionTestBase {
         if (source2 != null) {
             source2.closeQuietly();
         }
+        redisClient.close();
     }
 
-    private void checkOffsetSum(File tempDir, int sum) {
+    private void checkOffsetSum(int sum) {
         await().until(() -> {
             List<JsonObject> states = Uni.join().all(Stream.of(0, 1, 2)
-                    .map(i -> tempDir.toPath().resolve(topic + "-" + i).toString())
-                    .map(path -> vertx.fileSystem().readFile(path).map(Buffer::toJsonObject))
+                    .map(i -> redisClient.send(Request.cmd(Command.GET).arg(topic + ":" + i))
+                            .map(r -> Optional.ofNullable(r)
+                                    .map(Response::toBuffer)
+                                    .map(Buffer::toJsonObject)
+                                    .orElse(JsonObject.of("offset", 0, "state", 0))))
                     .collect(Collectors.toList()))
                     .andFailFast()
                     .await().indefinitely();
 
             int offset = states.stream().mapToInt(tuple -> tuple.getInteger("offset")).sum();
             int state = states.stream().mapToInt(tuple -> tuple.getInteger("state")).sum();
+            System.out.println(states.stream().map(JsonObject::toString).collect(Collectors.joining(", "))
+                    + " : " + offset + " " + state);
 
-            return offset == sum && state == sum * (sum - 1) / 2;
+            return offset == sum && state == sum(sum);
         });
     }
 
+    private int sum(int sum) {
+        return sum * (sum - 1) / 2;
+    }
+
     @Test
-    public void testMultipleIndependentConsumers(@TempDir File tempDir) {
+    public void testMultipleIndependentConsumers() {
         companion.topics().createAndWait(topic, 3);
 
         MapBasedConfig config = newCommonConfigForSource()
                 .with("group.id", "test-source-with-auto-commit-enabled")
-                .with("commit-strategy", "checkpoint-file")
-                .with("checkpoint-file.stateDir", tempDir.getAbsolutePath())
+                .with("commit-strategy", "checkpoint-redis")
+                .with("checkpoint-redis.connectionString", getRedisString())
+                .with("checkpoint-redis.maxPoolSize", 30)
+                .with("checkpoint-redis.maxWaitingHandlers", 1024)
                 .with("value.deserializer", IntegerDeserializer.class.getName());
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(config);
 
         source = new KafkaSource<>(vertx,
                 "test-source-with-auto-commit-enabled",
                 ic,
-                new SingletonInstance<>("checkpoint-file", new KafkaFileCheckpointCommit.Factory()),
+                new SingletonInstance<>("checkpoint-redis", new KafkaRedisCheckpointCommit.Factory()),
                 failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
@@ -98,13 +153,12 @@ public class KafkaFileCheckpointCommitTest extends KafkaCompanionTestBase {
             }
             messages.add(m);
             return Uni.createFrom().completionStage(m.ack());
-        }).subscribe().with(x -> {
-
+        }).subscribe().with(unused -> {
         });
 
         companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i), 100);
         await().atMost(10, TimeUnit.SECONDS).until(() -> messages.size() >= 100);
-        checkOffsetSum(tempDir, 100);
+        checkOffsetSum(100);
 
         KafkaConnectorIncomingConfiguration ic2 = new KafkaConnectorIncomingConfiguration(
                 config.with(ConsumerConfig.CLIENT_ID_CONFIG,
@@ -112,7 +166,7 @@ public class KafkaFileCheckpointCommitTest extends KafkaCompanionTestBase {
         source2 = new KafkaSource<>(vertx,
                 "test-source-with-auto-commit-enabled",
                 ic2,
-                new SingletonInstance<>("checkpoint-file", new KafkaFileCheckpointCommit.Factory()),
+                new SingletonInstance<>("checkpoint-redis", new KafkaRedisCheckpointCommit.Factory()),
                 failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
@@ -126,28 +180,25 @@ public class KafkaFileCheckpointCommitTest extends KafkaCompanionTestBase {
             messages2.add(m);
             return Uni.createFrom().completionStage(m.ack());
         }).subscribe().with(x -> {
-
         });
 
         await().until(() -> !source2.getConsumer().getAssignments().await().indefinitely().isEmpty());
 
         companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i + 100), 100);
         await().atMost(10, TimeUnit.SECONDS).until(() -> messages.size() + messages2.size() >= 200);
-        checkOffsetSum(tempDir, 200);
+        checkOffsetSum(200);
 
         source.closeQuietly();
         await().until(() -> source2.getConsumer().getAssignments().await().indefinitely().size() == 3);
 
         companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i + 200), 100);
         await().atMost(10, TimeUnit.SECONDS).until(() -> messages.size() + messages2.size() >= 300);
-        checkOffsetSum(tempDir, 300);
+        checkOffsetSum(300);
     }
 
     @Test
-    public void testWithPartitions(@TempDir File tempDir) {
-        System.out.println(tempDir.getAbsolutePath());
-
-        addBeans(KafkaFileCheckpointCommit.Factory.class);
+    public void testWithPartitions() {
+        addBeans(KafkaRedisCheckpointCommit.Factory.class);
         companion.topics().createAndWait(topic, 3);
         String groupId = UUID.randomUUID().toString();
 
@@ -156,23 +207,58 @@ public class KafkaFileCheckpointCommitTest extends KafkaCompanionTestBase {
                 .with("topic", topic)
                 .with("partitions", 3)
                 .with("auto.offset.reset", "earliest")
-                .with("commit-strategy", "checkpoint-file")
-                .with("checkpoint-file.stateDir", tempDir.getAbsolutePath())
+                .with("commit-strategy", "checkpoint-redis")
+                .with("checkpoint-redis.connectionString", getRedisString())
+                .with("checkpoint-redis.maxPoolSize", 30)
+                .with("checkpoint-redis.maxWaitingHandlers", 1024)
                 .with("value.deserializer", IntegerDeserializer.class.getName());
 
         MyApplication application = runApplication(config, MyApplication.class);
 
-        int expected = 1000;
+        int expected = 3000;
         Random random = new Random();
         companion.produceIntegers().usingGenerator(i -> {
             int p = random.nextInt(3);
             return new ProducerRecord<>(topic, p, Integer.toString(p), i);
         }, expected).awaitCompletion(Duration.ofMinutes(1));
 
-        await().atMost(1, TimeUnit.MINUTES)
-                .until(() -> application.count() == expected);
+        await()
+                .atMost(1, TimeUnit.MINUTES)
+                .until(() -> application.count() >= expected);
+        assertThat(application.getReceived().keySet()).hasSizeGreaterThanOrEqualTo(getMaxNumberOfEventLoop(3));
 
-        checkOffsetSum(tempDir, expected);
+        checkOffsetSum(expected);
+    }
+
+    @Test
+    public void testWithPreviousState() {
+        addBeans(KafkaRedisCheckpointCommit.Factory.class);
+        String groupId = UUID.randomUUID().toString();
+
+        redisClient.send(Request.cmd(Command.SET)
+                .arg(topic + ":" + 0)
+                .arg(JsonObject.of("offset", 500, "state", sum(500)).toBuffer().toString()))
+                .await().indefinitely();
+
+        MapBasedConfig config = kafkaConfig("mp.messaging.incoming.kafka")
+                .with("group.id", groupId)
+                .with("topic", topic)
+                .with("auto.offset.reset", "earliest")
+                .with("commit-strategy", "checkpoint-redis")
+                .with("checkpoint-redis.connectionString", getRedisString())
+                .with("value.deserializer", IntegerDeserializer.class.getName());
+
+        MyApplication application = runApplication(config, MyApplication.class);
+
+        int expected = 1000;
+        companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, Integer.toString(i), i), expected)
+                .awaitCompletion(Duration.ofMinutes(1));
+
+        await()
+                .atMost(1, TimeUnit.MINUTES)
+                .until(() -> application.count() >= expected);
+
+        checkOffsetSum(expected);
     }
 
     @ApplicationScoped
@@ -202,4 +288,8 @@ public class KafkaFileCheckpointCommitTest extends KafkaCompanionTestBase {
         }
     }
 
+    private int getMaxNumberOfEventLoop(int expected) {
+        // On Github Actions, only one event loop is created.
+        return Math.min(expected, Runtime.getRuntime().availableProcessors() / 2);
+    }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/RebalanceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/RebalanceTest.java
@@ -55,7 +55,9 @@ public class RebalanceTest extends WeldTestBase {
                 .with("auto.offset.reset", "earliest")
                 .with("auto.commit.interval.ms", 100);
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), getConsumerRebalanceListeners(),
+                new KafkaConnectorIncomingConfiguration(config),
+                commitHandlerFactories, failureHandlerFactories,
+                getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1);
         injectMockConsumer(source, consumer);
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/KeyDeserializerConfigurationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/KeyDeserializerConfigurationTest.java
@@ -59,7 +59,8 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
         String group = UUID.randomUUID().toString();
         MapBasedConfig config = commonConsumerConfiguration();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> list = new ArrayList<>();
@@ -86,7 +87,8 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
         String group = UUID.randomUUID().toString();
         MapBasedConfig config = commonConsumerConfiguration();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> list = new ArrayList<>();
@@ -125,7 +127,8 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 .with("key.deserializer", JsonObjectSerde.JsonObjectDeserializer.class.getName())
                 .with("fail-on-deserialization-failure", false);
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> list = new ArrayList<>();
@@ -165,7 +168,8 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 .with("key.deserializer", ConstantDeserializer.class.getName())
                 .with("deserializer.value", "constant");
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> list = new ArrayList<>();
@@ -206,7 +210,8 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
 
         JsonObject fallback = new JsonObject().put("fallback", "fallback");
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, new SingletonInstance<>("my-deserialization-handler",
                         new DeserializationFailureHandler<JsonObject>() {
                             @Override
@@ -275,7 +280,8 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 .with("key-deserialization-failure-handler", "my-deserialization-handler");
 
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, new SingletonInstance<>("my-deserialization-handler",
                         new DeserializationFailureHandler<JsonObject>() {
                             @Override
@@ -326,7 +332,8 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
 
         assertThatThrownBy(() -> {
             source = new KafkaSource<>(vertx, group,
-                    new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                    new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                    UnsatisfiedInstance.instance(),
                     CountKafkaCdiEvents.noCdiEvents, new SingletonInstance<>("not-matching",
                             new DeserializationFailureHandler<JsonObject>() {
                                 @Override
@@ -369,7 +376,8 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> {
             source = new KafkaSource<>(vertx, group,
-                    new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                    new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                    UnsatisfiedInstance.instance(),
                     CountKafkaCdiEvents.noCdiEvents, new DoubleInstance<>("my-deserialization-handler", i1, i2),
                     -1);
         }).isInstanceOf(AmbiguousResolutionException.class).hasMessageContaining("my-deserialization-handler");
@@ -381,7 +389,8 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 .with("key.deserializer", BrokenDeserializerFailingDuringConfig.class.getName());
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1))
                         .isInstanceOf(KafkaException.class)
                         .hasCauseInstanceOf(IllegalArgumentException.class)

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/ValueDeserializerConfigurationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/ValueDeserializerConfigurationTest.java
@@ -65,7 +65,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> {
             source = new KafkaSource<>(vertx, group,
-                    new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                    new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                    UnsatisfiedInstance.instance(),
                     CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
         }).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("value.deserializer");
     }
@@ -75,7 +76,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
         MapBasedConfig config = commonConsumerConfiguration();
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> list = new ArrayList<>();
@@ -114,7 +116,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 .with("fail-on-deserialization-failure", false);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> list = new ArrayList<>();
@@ -153,7 +156,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 .with("health-enabled", true);
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> list = new ArrayList<>();
@@ -176,7 +180,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 .with("deserializer.value", "constant");
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1);
 
         List<Message<?>> list = new ArrayList<>();
@@ -217,7 +222,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
         JsonObject fallback = new JsonObject().put("fallback", "fallback");
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, new SingletonInstance<>("my-deserialization-handler",
                         new DeserializationFailureHandler<JsonObject>() {
                             @Override
@@ -287,7 +293,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
         JsonObject fallbackForKey = new JsonObject().put("fallback", "key");
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, new SingletonInstance<>("my-deserialization-handler",
                         new DeserializationFailureHandler<JsonObject>() {
                             @Override
@@ -352,7 +359,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
 
         String group = UUID.randomUUID().toString();
         source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, new SingletonInstance<>("my-deserialization-handler",
                         new DeserializationFailureHandler<JsonObject>() {
                             @Override
@@ -403,7 +411,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> {
             source = new KafkaSource<>(vertx, group,
-                    new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                    new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                    UnsatisfiedInstance.instance(),
                     CountKafkaCdiEvents.noCdiEvents, new SingletonInstance<>("not-matching",
                             new DeserializationFailureHandler<JsonObject>() {
                                 @Override
@@ -446,7 +455,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> {
             source = new KafkaSource<>(vertx, group,
-                    new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                    new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                    UnsatisfiedInstance.instance(),
                     CountKafkaCdiEvents.noCdiEvents, new DoubleInstance<>("my-deserialization-handler", i1, i2),
                     -1);
         }).isInstanceOf(AmbiguousResolutionException.class).hasMessageContaining("my-deserialization-handler");
@@ -458,7 +468,8 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 .with("value.deserializer", BrokenDeserializerFailingDuringConfig.class.getName());
         String group = UUID.randomUUID().toString();
         assertThatThrownBy(() -> source = new KafkaSource<>(vertx, group,
-                new KafkaConnectorIncomingConfiguration(config), UnsatisfiedInstance.instance(),
+                new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
+                UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1))
                         .isInstanceOf(KafkaException.class)
                         .hasCauseInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
CDI-based extension points for implementing custom commit and failure handlers.

Introduces `KafkaCommitHandler.Factory` and `KafkaFailureHandler.Factory` interfaces. 
Custom implementations are discovered through a CDI bean which implement the Factory interface with an `@Identifier` which holds the handler name. Channel attributes `commit-strategy` and `failure-strategy` can be configured with that handler name.

Two non-production implementations are included.
An abstract commit handler enables state checkpointing with two concrete implementations file-based and redis store.
