### PR TITLE
Fix #1858 - NPE from incoming null header

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/tracing/HeaderExtractAdapter.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/tracing/HeaderExtractAdapter.java
@@ -34,6 +34,10 @@ public class HeaderExtractAdapter implements TextMapGetter<Headers> {
         if (header == null) {
             return null;
         }
-        return new String(header.value(), StandardCharsets.UTF_8);
+        byte[] headerValue = header.value();
+        if (headerValue == null) {
+            return null;
+        }
+        return new String(headerValue, StandardCharsets.UTF_8);
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/HeaderExtractAdapterTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/HeaderExtractAdapterTest.java
@@ -1,0 +1,20 @@
+package io.smallrye.reactive.messaging.kafka.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.Test;
+
+class HeaderExtractAdapterTest {
+    @Test
+    public void verifyNullHeaderHandled() {
+        Headers headers = new RecordHeaders();
+        headers.add("test_null_header", null);
+        HeaderExtractAdapter headerExtractAdapter = new HeaderExtractAdapter();
+
+        final String headerValue = headerExtractAdapter.get(headers, "test_null_header");
+
+        assertThat(headerValue).isNull();
+    }
+}


### PR DESCRIPTION
Fixes #1858.

Followed a similar approach done in https://github.com/opentracing-contrib/java-kafka-client/blob/master/opentracing-kafka-client/src/test/java/io/opentracing/contrib/kafka/HeadersMapExtractAdapterTest.java