### PR TITLE
MQTT support shared subscription feature

### DIFF
--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttHelpers.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttHelpers.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.mqtt;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import io.smallrye.reactive.messaging.mqtt.session.ConstantReconnectDelayOptions;
 import io.smallrye.reactive.messaging.mqtt.session.MqttClientSessionOptions;
@@ -130,6 +131,18 @@ public class MqttHelpers {
         ConstantReconnectDelayOptions options = new ConstantReconnectDelayOptions();
         options.setDelay(Duration.ofSeconds(config.getReconnectIntervalSeconds()));
         return options;
+    }
+
+    /**
+     * If topic starts with shared subscription like `$share/group/....`
+     * we need to remove it `$share/group/` prefix
+     */
+    public static String rebuildMatchesWithSharedSubscription(String topic) {
+        if (Pattern.matches("^\\$share/((?!/).)*/.*", topic)) {
+            return topic.replaceAll("^\\$share/((?!/).)*/", "");
+        } else {
+            return topic;
+        }
     }
 
 }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
@@ -31,7 +31,8 @@ public class MqttSource {
         MqttFailureHandler onNack = createFailureHandler(strategy, config.getChannel());
 
         if (topic.contains("#") || topic.contains("+")) {
-            String replace = escapeTopicSpecialWord(topic).replace("+", "[^/]+")
+            String replace = escapeTopicSpecialWord(MqttHelpers.rebuildMatchesWithSharedSubscription(topic))
+                    .replace("+", "[^/]+")
                     .replace("#", ".+");
             pattern = Pattern.compile(replace);
         } else {

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicMqttTopicSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicMqttTopicSourceTest.java
@@ -21,6 +21,7 @@ import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
@@ -178,5 +179,12 @@ public class DynamicMqttTopicSourceTest extends MqttTestBase {
             return messages;
         }
 
+    }
+
+    @Test
+    public void testTopicWithSharedSubscription() {
+        String topicRegex = "$share/group/$app/hello/#";
+        String replacedRegex = MqttHelpers.rebuildMatchesWithSharedSubscription(topicRegex);
+        Assertions.assertEquals("$app/hello/#", replacedRegex);
     }
 }


### PR DESCRIPTION
Issue link https://github.com/smallrye/smallrye-reactive-messaging/issues/1868
I think this feature is very useful when deploying multiple pods with quarkus/smallrye to avoid duplicate message consumption problems.