### PR TITLE
Mutiny 2.0 with Flow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ into [CDI](http://www.cdi-spec.org/) beans,or [JAX-RS](https://github.com/eclips
 
 ## Branches
 
-* main - 4.x development stream. Uses Vert.x 4.x, Microprofile 5.x and Jakarta 9
+* main - 4.x development stream. Uses Vert.x 4.x, Microprofile 5.x, Mutiny 2.x and Jakarta 9
 * 3.x - Previous development stream. Uses Vert.x 4.x and Microprofile 4.x
 * 2.x - Not under development anymore. Uses Vert.x 3.x and Microprofile 3.x
 

--- a/api/revapi.json
+++ b/api/revapi.json
@@ -27,7 +27,94 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+        {
+            "code": "java.method.addedToInterface",
+            "new": "method <M extends org.eclipse.microprofile.reactive.messaging.Message<? extends T>> io.smallrye.mutiny.Uni<java.lang.Void> io.smallrye.reactive.messaging.MutinyEmitter<T>::sendMessage(M)",
+            "justification": "Added to the MutinyEmitter interface"
+        },
+        {
+            "code": "java.method.addedToInterface",
+            "new": "method <M extends org.eclipse.microprofile.reactive.messaging.Message<? extends T>> void io.smallrye.reactive.messaging.MutinyEmitter<T>::sendMessageAndAwait(M)",
+            "justification": "Added to the MutinyEmitter interface"
+        },
+        {
+            "code": "java.method.addedToInterface",
+            "new": "method <M extends org.eclipse.microprofile.reactive.messaging.Message<? extends T>> io.smallrye.mutiny.subscription.Cancellable io.smallrye.reactive.messaging.MutinyEmitter<T>::sendMessageAndForget(M)",
+            "justification": "Added to the MutinyEmitter interface"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.returnTypeTypeParametersChanged",
+            "old": "method java.util.List<org.reactivestreams.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>> io.smallrye.reactive.messaging.ChannelRegistry::getPublishers(java.lang.String)",
+            "new": "method java.util.List<java.util.concurrent.Flow.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>> io.smallrye.reactive.messaging.ChannelRegistry::getPublishers(java.lang.String)",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.returnTypeTypeParametersChanged",
+            "old": "method java.util.List<org.reactivestreams.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>> io.smallrye.reactive.messaging.ChannelRegistry::getSubscribers(java.lang.String)",
+            "new": "method java.util.List<java.util.concurrent.Flow.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>> io.smallrye.reactive.messaging.ChannelRegistry::getSubscribers(java.lang.String)",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.parameterTypeChanged",
+            "old": "parameter org.reactivestreams.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.ChannelRegistry::register(java.lang.String, ===org.reactivestreams.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>===, boolean)",
+            "new": "parameter java.util.concurrent.Flow.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.ChannelRegistry::register(java.lang.String, ===java.util.concurrent.Flow.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>===, boolean)",
+            "parameterIndex": "1",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.returnTypeChanged",
+            "old": "method org.reactivestreams.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.ChannelRegistry::register(java.lang.String, org.reactivestreams.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>, boolean)",
+            "new": "method java.util.concurrent.Flow.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.ChannelRegistry::register(java.lang.String, java.util.concurrent.Flow.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>, boolean)",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.parameterTypeChanged",
+            "old": "parameter org.reactivestreams.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.ChannelRegistry::register(java.lang.String, ===org.reactivestreams.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>===, boolean)",
+            "new": "parameter java.util.concurrent.Flow.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.ChannelRegistry::register(java.lang.String, ===java.util.concurrent.Flow.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>===, boolean)",
+            "parameterIndex": "1",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.returnTypeChanged",
+            "old": "method org.reactivestreams.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.ChannelRegistry::register(java.lang.String, org.reactivestreams.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>, boolean)",
+            "new": "method java.util.concurrent.Flow.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.ChannelRegistry::register(java.lang.String, java.util.concurrent.Flow.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>>, boolean)",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.returnTypeChanged",
+            "old": "method org.reactivestreams.Publisher<org.eclipse.microprofile.reactive.messaging.Message<? extends T>> io.smallrye.reactive.messaging.MessagePublisherProvider<T>::getPublisher()",
+            "new": "method java.util.concurrent.Flow.Publisher<org.eclipse.microprofile.reactive.messaging.Message<? extends T>> io.smallrye.reactive.messaging.MessagePublisherProvider<T>::getPublisher()",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.returnTypeChanged",
+            "old": "method org.reactivestreams.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.connector.InboundConnector::getPublisher(org.eclipse.microprofile.config.Config)",
+            "new": "method java.util.concurrent.Flow.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.connector.InboundConnector::getPublisher(org.eclipse.microprofile.config.Config)",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.returnTypeChanged",
+            "old": "method org.reactivestreams.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.connector.OutboundConnector::getSubscriber(org.eclipse.microprofile.config.Config)",
+            "new": "method java.util.concurrent.Flow.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.connector.OutboundConnector::getSubscriber(org.eclipse.microprofile.config.Config)",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.addedToInterface",
+            "new": "method boolean io.smallrye.reactive.messaging.MediatorConfiguration::usesReactiveStreams()",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/api/src/main/java/io/smallrye/reactive/messaging/ChannelRegistry.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/ChannelRegistry.java
@@ -3,11 +3,11 @@ package io.smallrye.reactive.messaging;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Flow.Publisher;
+import java.util.concurrent.Flow.Subscriber;
 
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 
 public interface ChannelRegistry {
 

--- a/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
@@ -30,6 +30,8 @@ public interface MediatorConfiguration {
 
     Production production();
 
+    boolean usesReactiveStreams();
+
     boolean usesBuilderTypes();
 
     Acknowledgment.Strategy getAcknowledgment();

--- a/api/src/main/java/io/smallrye/reactive/messaging/MessagePublisherProvider.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MessagePublisherProvider.java
@@ -1,7 +1,8 @@
 package io.smallrye.reactive.messaging;
 
+import java.util.concurrent.Flow.Publisher;
+
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Publisher;
 
 /**
  * Framework-facing interface for the Emitter implementations.

--- a/api/src/main/java/io/smallrye/reactive/messaging/connector/InboundConnector.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/connector/InboundConnector.java
@@ -1,12 +1,12 @@
 package io.smallrye.reactive.messaging.connector;
 
 import java.util.NoSuchElementException;
+import java.util.concurrent.Flow;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
 import org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory;
-import org.reactivestreams.Publisher;
 
 /**
  * SPI used to implement a connector managing a source of messages for a specific <em>transport</em>. For example, to
@@ -85,7 +85,7 @@ import org.reactivestreams.Publisher;
  * This class is specific to SmallRye and is uses internally instead of
  * {@link org.eclipse.microprofile.reactive.messaging.spi.IncomingConnectorFactory}.
  * Instead of a {@link org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder}, it returns a
- * {@link org.reactivestreams.Publisher}.
+ * {@link Flow.Publisher}.
  */
 public interface InboundConnector extends ConnectorFactory {
 
@@ -100,10 +100,10 @@ public interface InboundConnector extends ConnectorFactory {
      *
      * @param config the configuration, must not be {@code null}, must contain the {@link #CHANNEL_NAME_ATTRIBUTE}
      *        attribute.
-     * @return the created {@link org.reactivestreams.Publisher}, will not be {@code null}.
+     * @return the created {@link Flow.Publisher}, will not be {@code null}.
      * @throws IllegalArgumentException if the configuration is invalid.
      * @throws NoSuchElementException if the configuration does not contain an expected attribute.
      */
-    Publisher<? extends Message<?>> getPublisher(Config config);
+    Flow.Publisher<? extends Message<?>> getPublisher(Config config);
 
 }

--- a/api/src/main/java/io/smallrye/reactive/messaging/connector/OutboundConnector.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/connector/OutboundConnector.java
@@ -1,12 +1,12 @@
 package io.smallrye.reactive.messaging.connector;
 
 import java.util.NoSuchElementException;
+import java.util.concurrent.Flow.Subscriber;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
 import org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory;
-import org.reactivestreams.Subscriber;
 
 /**
  * SPI used to implement a connector managing a sink of messages for a specific <em>transport</em>. For example, to
@@ -78,7 +78,7 @@ import org.reactivestreams.Subscriber;
  * This class is specific to SmallRye and is uses internally instead of
  * {@link org.eclipse.microprofile.reactive.messaging.spi.OutgoingConnectorFactory}. Instead of a
  * {@link org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder}, it returns a
- * {@link org.reactivestreams.Subscriber}.
+ * {@link Subscriber}.
  */
 public interface OutboundConnector extends ConnectorFactory {
 

--- a/documentation/src/main/docs/concepts/message-context.md
+++ b/documentation/src/main/docs/concepts/message-context.md
@@ -56,9 +56,9 @@ Message context works with:
 
 However, message context are **NOT** enforced when using methods consuming or producing:
 
-* `Multi`, `Publisher` and `PublisherBuilder`
-* `Subscriber` and `SubscriberBuilder`
-* `Processor` and `ProcessorBuilder`
+* `Multi`, `Flow.Publisher`, `Publisher` and `PublisherBuilder`
+* `Subscriber`, `Flow.Subscriber`, and `SubscriberBuilder`
+* `Processor`, `Flow.Processor`, and `ProcessorBuilder`
 
 
 ## Under the hood

--- a/documentation/src/main/docs/concepts/signatures.md
+++ b/documentation/src/main/docs/concepts/signatures.md
@@ -4,66 +4,79 @@ The following tables list the supported method signatures and indicate
 the various supported features. For instance, they indicate the default
 and available acknowledgement strategies (when applicable).
 
-| Signature                                          | Invocation time                                                                                                 |
-|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+## Method signatures to generate data
+
+| Signature                                           | Invocation time                                                                                                 |
+|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | `@Outgoing Publisher<Message<O>> method()` `        | Called once at *assembly* time                                                                                  |
-| `@Outgoing Publisher<O> method()` `                  | Called once at *assembly* time                                                                                  |
+| `@Outgoing Publisher<O> method()` `                 | Called once at *assembly* time                                                                                  |
 | `@Outgoing Multi<Message<O>> method()` `            | Called once at *assembly* time                                                                                  |
-| `@Outgoing Multi<O> method()` `                      | Called once at *assembly* time                                                                                  |
+| `@Outgoing Multi<O> method()` `                     | Called once at *assembly* time                                                                                  |
+| `@Outgoing Flow.Publisher<Message<O>> method()` `   | Called once at *assembly* time                                                                                  |
+| `@Outgoing Flow.Publisher<O> method()` `            | Called once at *assembly* time                                                                                  |
 | `@Outgoing PublisherBuilder<Message<O>> method()` ` | Called once at *assembly* time                                                                                  |
-| `@Outgoing PublisherBuilder<O> method()` `           | Called once at *assembly* time                                                                                  |
-| `@Outgoing Message<O> method()` `                     | Called for every downstream request, sequentially                                                               |
-| `@Outgoing O method()` `                              | Called for every downstream request, sequentially                                                               |
+| `@Outgoing PublisherBuilder<O> method()` `          | Called once at *assembly* time                                                                                  |
+| `@Outgoing Message<O> method()` `                   | Called for every downstream request, sequentially                                                               |
+| `@Outgoing O method()` `                            | Called for every downstream request, sequentially                                                               |
 | `@Outgoing CompletionStage<Message<O>> method()` `  | Called for every downstream request, sequentially (After the completion of the last returned CompletionStage)   |
-| `@Outgoing CompletionStage<O> method()` `             | Called for every downstream request, , sequentially (After the completion of the last returned CompletionStage) |
+| `@Outgoing CompletionStage<O> method()` `           | Called for every downstream request, , sequentially (After the completion of the last returned CompletionStage) |
 | `@Outgoing Uni<Message<O>> method()` `              | Called for every downstream request, sequentially (After the completion of the last returned Uni)               |
-| `@Outgoing Uni<O> method()` `                         | Called for every downstream request, , sequentially (After the completion of the last returned Uni)             |
+| `@Outgoing Uni<O> method()` `                       | Called for every downstream request, , sequentially (After the completion of the last returned Uni)             |
 
-Method signatures to generate data
+## Method signatures to consume data
 
-| Signature                                             | Invocation time                                  | Supported Acknowledgement Strategies            |
-|-------------------------------------------------------|--------------------------------------------------|-------------------------------------------------|
-| `@Incoming void method(I p)`                             | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING         |
+| Signature                                              | Invocation time                                  | Supported Acknowledgement Strategies            |
+|--------------------------------------------------------|--------------------------------------------------|-------------------------------------------------|
+| `@Incoming void method(I p)`                           | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING         |
 | `@Incoming CompletionStage<?> method(Message<I> msg)`  | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING                  |
-| `@Incoming CompletionStage<?> method(I p)`              | Called for every incoming payload (sequentially) | *POST_PROCESSING*, PRE_PROCESSING, NONE         |
+| `@Incoming CompletionStage<?> method(I p)`             | Called for every incoming payload (sequentially) | *POST_PROCESSING*, PRE_PROCESSING, NONE         |
 | `@Incoming Uni<?> method(Message<I> msg)`              | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING                  |
-| `@Incoming Uni<?> method(I p)`                          | Called for every incoming payload (sequentially) | *POST_PROCESSING*, PRE_PROCESSING, NONE         |
-| `@Incoming Subscriber<Message<I>> method()`           | Called once at *assembly* time                   | *MANUAL*, POST_PROCESSING, NONE, PRE_PROCESSING |
-| `@Incoming Subscriber<I> method()`                      | Called once at *assembly* time                   | *POST_PROCESSING*, NONE, PRE_PROCESSING         |
+| `@Incoming Uni<?> method(I p)`                         | Called for every incoming payload (sequentially) | *POST_PROCESSING*, PRE_PROCESSING, NONE         |
+| `@Incoming Subscriber<Message<I>> method()`            | Called once at *assembly* time                   | *MANUAL*, POST_PROCESSING, NONE, PRE_PROCESSING |
+| `@Incoming Subscriber<I> method()`                     | Called once at *assembly* time                   | *POST_PROCESSING*, NONE, PRE_PROCESSING         |
+| `@Incoming Flow.Subscriber<Message<I>> method()`       | Called once at *assembly* time                   | *MANUAL*, POST_PROCESSING, NONE, PRE_PROCESSING |
+| `@Incoming Flow.Subscriber<I> method()`                | Called once at *assembly* time                   | *POST_PROCESSING*, NONE, PRE_PROCESSING         |
+| `@Incoming SubscriberBuilder<Message<I>, ?> method()`  | Called once at *assembly* time                   | *MANUAL*, POST_PROCESSING, NONE, PRE_PROCESSING |
+| `@Incoming SubscriberBuilder<I, ?> method()`           | Called once at *assembly* time                   | *MANUAL*, POST_PROCESSING, NONE, PRE_PROCESSING |
 
-Method signatures to consume data
+## Method signatures to process data
 
-| Signature                                                                   | Invocation time                                  | Supported Acknowledgement Strategies    | Metadata Propagation |
-|-----------------------------------------------------------------------------|--------------------------------------------------|-----------------------------------------|----------------------|
-| `@Outgoing @Incoming Message<O> method(Message<I> msg)`                      | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING          | manual               |
-| `@Outgoing @Incoming O method(I payload)`                                      | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING | automatic            |
-| `@Outgoing @Incoming CompletionStage<Message<O>> method(Message<I> msg)`   | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING          | manual               |
-| `@Outgoing @Incoming CompletionStage<O> method(I payload)`                    | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING | automatic            |
-| `@Outgoing @Incoming Uni<Message<O>> method(Message<I> msg)`               | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING          | manual               |
-| `@Outgoing @Incoming Uni<O> method(I payload)`                                | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING | automatic            |
-| `@Outgoing @Incoming Processor<Message<I>, Message<O>> method()`           | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Processor<I, O> method()`                                | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
-| `@Outgoing @Incoming ProcessorBuilder<Message<I>, Message<O>> method()`    | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming ProcessorBuilder<I, O> method()`                         | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
-| `@Outgoing @Incoming Publisher<Message<O>> method(Message<I> msg)`         | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Publisher<O> method(I payload)`                          | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
-| `@Outgoing @Incoming Multi<Message<O>> method(Message<I> msg)`             | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Multi<O> method(I payload)`                              | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
-| `@Outgoing @Incoming PublisherBuilder<Message<O>> method(Message<I> msg)`  | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming PublisherBuilder<O> method(I payload)`                   | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
+| Signature                                                                 | Invocation time                                  | Supported Acknowledgement Strategies    | Metadata Propagation |
+|---------------------------------------------------------------------------|--------------------------------------------------|-----------------------------------------|----------------------|
+| `@Outgoing @Incoming Message<O> method(Message<I> msg)`                   | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING          | manual               |
+| `@Outgoing @Incoming O method(I payload)`                                 | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING | automatic            |
+| `@Outgoing @Incoming CompletionStage<Message<O>> method(Message<I> msg)`  | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING          | manual               |
+| `@Outgoing @Incoming CompletionStage<O> method(I payload)`                | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING | automatic            |
+| `@Outgoing @Incoming Uni<Message<O>> method(Message<I> msg)`              | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING          | manual               |
+| `@Outgoing @Incoming Uni<O> method(I payload)`                            | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING | automatic            |
+| `@Outgoing @Incoming Processor<Message<I>, Message<O>> method()`          | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming Processor<I, O> method()`                            | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
+| `@Outgoing @Incoming Flow.Processor<Message<I>, Message<O>> method()`     | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming Flow.Processor<I, O> method()`                       | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
+| `@Outgoing @Incoming ProcessorBuilder<Message<I>, Message<O>> method()`   | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming ProcessorBuilder<I, O> method()`                     | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
+| `@Outgoing @Incoming Publisher<Message<O>> method(Message<I> msg)`        | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming Publisher<O> method(I payload)`                      | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
+| `@Outgoing @Incoming Multi<Message<O>> method(Message<I> msg)`            | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming Multi<O> method(I payload)`                          | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
+| `@Outgoing @Incoming Flow.Publisher<Message<O>> method(Message<I> msg)`   | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming Flow.Publisher<O> method(I payload)`                 | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
+| `@Outgoing @Incoming PublisherBuilder<Message<O>> method(Message<I> msg)` | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming PublisherBuilder<O> method(I payload)`               | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
 
-Method signatures to process data
+## Method signatures to manipulate streams
 
-| Signature                                                                                       | Invocation time                | Supported Acknowledgement Strategies | Metadata Propagation |
-|-------------------------------------------------------------------------------------------------|--------------------------------|--------------------------------------|----------------------|
+| Signature                                                                                   | Invocation time                | Supported Acknowledgement Strategies | Metadata Propagation |
+|---------------------------------------------------------------------------------------------|--------------------------------|--------------------------------------|----------------------|
 | `@Outgoing @Incoming Publisher<Message<O>> method(Publisher<Message<I>> pub)`               | Called once at *assembly* time | *MANUAL*, NONE, PRE_PROCESSING       | manual               |
-| `@Outgoing @Incoming Publisher<O> method(Publisher<I> pub)`                                     | Called once at *assembly* time | *PRE_PROCESSING*, NONE               | not supported        |
+| `@Outgoing @Incoming Publisher<O> method(Publisher<I> pub)`                                 | Called once at *assembly* time | *PRE_PROCESSING*, NONE               | not supported        |
 | `@Outgoing @Incoming Multi<Message<O>> method(Multi<Message<I>> pub)`                       | Called once at *assembly* time | *MANUAL*, NONE, PRE_PROCESSING       | manual               |
-| `@Outgoing @Incoming Multi<O> method(Multi<I> pub)`                                             | Called once at *assembly* time | *PRE_PROCESSING*, NONE               | not supported        |
+| `@Outgoing @Incoming Multi<O> method(Multi<I> pub)`                                         | Called once at *assembly* time | *PRE_PROCESSING*, NONE               | not supported        |
+| `@Outgoing @Incoming Flow.Publisher<Message<O>> method(Flow.Publisher<Message<I>> pub)`     | Called once at *assembly* time | *MANUAL*, NONE, PRE_PROCESSING       | manual               |
+| `@Outgoing @Incoming Flow.Publisher<O> method(Flow.Publisher<I> pub)`                       | Called once at *assembly* time | *PRE_PROCESSING*, NONE               | not supported        |
 | `@Outgoing @Incoming PublisherBuilder<Message<O>> method(PublisherBuilder<Message<I>> pub)` | Called once at *assembly* time | *MANUAL*, NONE, PRE_PROCESSING       | manual               |
-| `@Outgoing @Incoming PublisherBuilder<O> method(PublisherBuilder<I> pub)`                       | Called once at *assembly* time | NONE, PRE_PROCESSING                 | not supported        |
+| `@Outgoing @Incoming PublisherBuilder<O> method(PublisherBuilder<I> pub)`                   | Called once at *assembly* time | NONE, PRE_PROCESSING                 | not supported        |
 
-Method signatures to manipulate streams
 
 !!!important
     When processing `Message`, it is often required to *chain* the incoming

--- a/documentation/src/main/java/ack/StreamAckExamples.java
+++ b/documentation/src/main/java/ack/StreamAckExamples.java
@@ -1,9 +1,10 @@
 package ack;
 
+import java.util.concurrent.Flow.Publisher;
+
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 

--- a/documentation/src/main/java/emitter/ChannelExamples.java
+++ b/documentation/src/main/java/emitter/ChannelExamples.java
@@ -1,10 +1,11 @@
 package emitter;
 
+import java.util.concurrent.Flow.Publisher;
+
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 

--- a/documentation/src/main/java/emitter/EmitterFactoryExamples.java
+++ b/documentation/src/main/java/emitter/EmitterFactoryExamples.java
@@ -1,5 +1,7 @@
 package emitter;
 
+import java.util.concurrent.Flow.Publisher;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.InjectionPoint;
@@ -7,7 +9,6 @@ import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.reactive.messaging.ChannelRegistry;
 import io.smallrye.reactive.messaging.EmitterConfiguration;

--- a/documentation/src/main/java/generation/GenerationExamples.java
+++ b/documentation/src/main/java/generation/GenerationExamples.java
@@ -2,11 +2,11 @@ package generation;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -52,7 +52,7 @@ public class GenerationExamples {
     // </message-uni>
 
     // <message-stream>
-    public Publisher<Message<String>> generateMessageStream() {
+    public Flow.Publisher<Message<String>> generateMessageStream() {
         Multi<String> multi = reactiveClient.getStream();
         return multi.map(Message::of);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 
     <micrometer.version>1.10.3</micrometer.version>
 
-    <mutiny.version>1.7.0</mutiny.version>
+    <mutiny.version>2.1.0</mutiny.version>
     <artemis.version>2.20.0</artemis.version>
     <commons-io.version>2.11.0</commons-io.version>
 
@@ -92,9 +92,9 @@
 
     <opentelemetry.version>1.22.1-alpha</opentelemetry.version>
 
-    <smallrye-vertx-mutiny-clients.version>2.26.0</smallrye-vertx-mutiny-clients.version>
-    <smallrye-reactive-converters.version>2.6.0</smallrye-reactive-converters.version>
-    <mutiny-zero-reactive-streams-junit5-tck.version>0.4.2</mutiny-zero-reactive-streams-junit5-tck.version>
+    <smallrye-vertx-mutiny-clients.version>3.0.0</smallrye-vertx-mutiny-clients.version>
+    <smallrye-reactive-converters.version>3.0.0</smallrye-reactive-converters.version>
+    <mutiny-zero.version>1.0.0</mutiny-zero.version>
 
     <testcontainers.version>1.17.6</testcontainers.version>
 
@@ -338,6 +338,16 @@
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>mutiny</artifactId>
       <version>${mutiny.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>mutiny-zero</artifactId>
+      <version>${mutiny-zero.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>mutiny-zero-flow-adapters</artifactId>
+      <version>${mutiny-zero.version}</version>
     </dependency>
 
     <!-- Test -->

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpCreditBasedSender.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpCreditBasedSender.java
@@ -6,14 +6,14 @@ import static java.time.Duration.ofSeconds;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow.Processor;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Processor;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkTest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -22,7 +23,6 @@ import org.apache.qpid.proton.amqp.transport.Target;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory;
-import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
@@ -76,11 +76,11 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived, attachAddress);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(topic, server.actualPort());
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(topic, server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, msgCount)
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<Integer>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -109,12 +109,12 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived, attachAddress);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndNonAnonymousSink(topic,
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndNonAnonymousSink(topic,
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<Integer>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -141,14 +141,14 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndNonAnonymousSink(
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndNonAnonymousSink(
                 UUID.randomUUID().toString(),
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(i -> Integer.toString(i))
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<String>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<String>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -222,7 +222,7 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
@@ -232,7 +232,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                     return p;
                 })
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<Person>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<Person>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -277,7 +277,7 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
@@ -296,7 +296,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                     nack.incrementAndGet();
                     return CompletableFuture.completedFuture(null);
                 }))
-                .subscribe((Subscriber<? super Message<Person>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<Person>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
         await().until(() -> nack.get() == 5);
@@ -329,13 +329,13 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(i -> new JsonObject().put(ID, HELLO + i))
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -367,13 +367,13 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(i -> new JsonArray().add(HELLO + i).add(FOO))
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -406,7 +406,7 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
@@ -417,7 +417,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                     return res;
                 })
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -449,13 +449,13 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(i -> new JsonObject().put(ID, HELLO + i).toBuffer())
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -486,13 +486,13 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(i -> new Buffer(new JsonObject().put(ID, HELLO + i).toBuffer()))
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -523,13 +523,13 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(i -> new JsonObject().put(ID, HELLO + i).toBuffer().getBytes())
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -691,7 +691,7 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
 
         //noinspection unchecked
@@ -700,7 +700,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                         .withBody(HELLO + v)
                         .withSubject("foo")
                         .build())
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -734,7 +734,7 @@ public class AmqpSinkTest extends AmqpTestBase {
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived, attachAddress);
 
         String address = UUID.randomUUID().toString();
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndNonAnonymousSink(address,
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndNonAnonymousSink(address,
                 server.actualPort());
 
         //noinspection unchecked
@@ -744,7 +744,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                         .withSubject("foo")
                         .withAddress("unused")
                         .build())
-                .subscribe((Subscriber<? super AmqpMessage<String>>) sink.build());
+                .subscribe((Flow.Subscriber<? super AmqpMessage<String>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -780,7 +780,7 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
 
         //noinspection unchecked
@@ -793,7 +793,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                     message.setSubject("bar");
                     return Message.of(message);
                 })
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -825,10 +825,9 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
 
-        //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(v -> io.vertx.mutiny.amqp.AmqpMessage.create()
                         .withBufferAsBody(Buffer.buffer((HELLO + v).getBytes(StandardCharsets.UTF_8)))
@@ -836,7 +835,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                         .subject("bar")
                         .build())
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<io.vertx.mutiny.amqp.AmqpMessage>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<io.vertx.mutiny.amqp.AmqpMessage>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -868,10 +867,9 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
 
-        //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(v -> {
                     io.vertx.mutiny.amqp.AmqpMessageBuilder builder = io.vertx.mutiny.amqp.AmqpMessageBuilder.create();
@@ -880,7 +878,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                             .subject("baz");
                     return Message.of(builder.build());
                 })
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -912,10 +910,9 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(UUID.randomUUID().toString(),
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(UUID.randomUUID().toString(),
                 server.actualPort());
 
-        //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(v -> {
                     io.vertx.amqp.AmqpMessageBuilder builder = io.vertx.amqp.AmqpMessageBuilder.create();
@@ -924,7 +921,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                             .contentType("text/plain");
                     return Message.of(builder.build());
                 })
-                .subscribe((Subscriber<? super Message<?>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<?>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -959,13 +956,12 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived, attachAddress);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSinkUsingChannelName(topic,
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSinkUsingChannelName(topic,
                 server.actualPort());
 
-        //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(v -> AmqpMessage.<String> builder().withBody(HELLO + v).withSubject("foo").build())
-                .subscribe((Subscriber<? super AmqpMessage<String>>) sink.build());
+                .subscribe((Flow.Subscriber<? super AmqpMessage<String>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -1000,7 +996,7 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(address, server.actualPort());
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(address, server.actualPort());
 
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
@@ -1021,7 +1017,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                         .withApplicationProperties(new JsonObject().put("key", "value"))
                         .withFooter("my-trailer", "hello-footer")
                         .build()))
-                .subscribe((Subscriber<? super Message<Integer>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -1077,7 +1073,7 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSinkWithConnectorTtl(address,
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSinkWithConnectorTtl(address,
                 server.actualPort(),
                 3000);
 
@@ -1099,7 +1095,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                         .withApplicationProperties(new JsonObject().put("key", "value"))
                         .withFooter("my-trailer", "hello-footer")
                         .build()))
-                .subscribe((Subscriber<? super Message<Integer>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -1155,7 +1151,7 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSinkWithConnectorTtl(address,
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSinkWithConnectorTtl(address,
                 server.actualPort(),
                 3000);
 
@@ -1178,7 +1174,7 @@ public class AmqpSinkTest extends AmqpTestBase {
                         .withApplicationProperties(new JsonObject().put("key", "value"))
                         .withFooter("my-trailer", "hello-footer")
                         .build()))
-                .subscribe((Subscriber<? super Message<Integer>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -1234,12 +1230,12 @@ public class AmqpSinkTest extends AmqpTestBase {
 
         server = setupMockServerForTypeTest(messagesReceived, msgsReceived);
 
-        SubscriberBuilder<? extends Message<?>, Void> sink = createProviderAndSink(address, server.actualPort());
+        Flow.Subscriber<? extends Message<?>> sink = createProviderAndSink(address, server.actualPort());
 
         //noinspection unchecked
         Multi.createFrom().range(0, 10)
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<Integer>>) sink.build());
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) sink);
 
         assertThat(msgsReceived.await(6, TimeUnit.SECONDS)).isTrue();
 
@@ -1265,11 +1261,11 @@ public class AmqpSinkTest extends AmqpTestBase {
         assertThat(count.get()).isEqualTo(msgCount);
     }
 
-    private SubscriberBuilder<? extends Message<?>, Void> getSubscriberBuilder(Map<String, Object> config) {
+    private Flow.Subscriber<? extends Message<?>> getSubscriberBuilder(Map<String, Object> config) {
         this.provider = new AmqpConnector();
         provider.setup(executionHolder);
         provider.init();
-        return this.provider.getSubscriberBuilder(new MapBasedConfig(config));
+        return this.provider.getSubscriber(new MapBasedConfig(config));
     }
 
     private Map<String, Object> createBaseConfig(String topic, int port) {
@@ -1283,7 +1279,7 @@ public class AmqpSinkTest extends AmqpTestBase {
         return config;
     }
 
-    private SubscriberBuilder<? extends Message<?>, Void> createProviderAndSink(String topic, int port) {
+    private Flow.Subscriber<? extends Message<?>> createProviderAndSink(String topic, int port) {
         Map<String, Object> config = createBaseConfig(topic, port);
         config.put("address", topic);
 
@@ -1291,7 +1287,7 @@ public class AmqpSinkTest extends AmqpTestBase {
     }
 
     @SuppressWarnings("SameParameterValue")
-    private SubscriberBuilder<? extends Message<?>, Void> createProviderAndSinkWithConnectorTtl(String topic, int port,
+    private Flow.Subscriber<? extends Message<?>> createProviderAndSinkWithConnectorTtl(String topic, int port,
             long ttl) {
         Map<String, Object> config = createBaseConfig(topic, port);
         config.put("address", topic);
@@ -1300,7 +1296,7 @@ public class AmqpSinkTest extends AmqpTestBase {
         return getSubscriberBuilder(config);
     }
 
-    private SubscriberBuilder<? extends Message<?>, Void> createProviderAndNonAnonymousSink(String topic, int port) {
+    private Flow.Subscriber<? extends Message<?>> createProviderAndNonAnonymousSink(String topic, int port) {
         Map<String, Object> config = createBaseConfig(topic, port);
         config.put("address", topic);
         config.put("use-anonymous-sender", false);
@@ -1308,7 +1304,7 @@ public class AmqpSinkTest extends AmqpTestBase {
         return getSubscriberBuilder(config);
     }
 
-    private SubscriberBuilder<? extends Message<?>, Void> createProviderAndSinkUsingChannelName(String topic,
+    private Flow.Subscriber<? extends Message<?>> createProviderAndSinkUsingChannelName(String topic,
             int port) {
         Map<String, Object> config = createBaseConfig(topic, port);
         // We don't add the address config element, relying on the channel name instead

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBean.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBean.java
@@ -1,12 +1,13 @@
 package io.smallrye.reactive.messaging.amqp;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 
@@ -21,7 +22,7 @@ public class ProducingBean {
     }
 
     @Outgoing("data")
-    public Publisher<Integer> source() {
+    public Flow.Publisher<Integer> source() {
         return Multi.createFrom().range(0, 10);
     }
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBeanUsingOutboundMetadata.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBeanUsingOutboundMetadata.java
@@ -1,12 +1,13 @@
 package io.smallrye.reactive.messaging.amqp;
 
+import java.util.concurrent.Flow.Publisher;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAppToAmqpTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAppToAmqpTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
@@ -106,7 +106,7 @@ public class TracingAppToAmqpTest extends AmqpBrokerTestBase {
     @ApplicationScoped
     public static class MyAppGeneratingData {
         @Outgoing("amqp")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
     }

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/incoming/BeanWithCamelSubscriber.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/incoming/BeanWithCamelSubscriber.java
@@ -1,14 +1,16 @@
 package io.smallrye.reactive.messaging.camel.incoming;
 
+import java.util.concurrent.Flow.Subscriber;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.apache.camel.component.reactive.streams.api.CamelReactiveStreamsService;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithCamelSubscriber {
@@ -18,7 +20,7 @@ public class BeanWithCamelSubscriber {
 
     @Incoming("camel")
     public Subscriber<String> sink() {
-        return camel.subscriber("file:./target?fileName=values.txt&fileExist=append", String.class);
+        return AdaptersToFlow.subscriber(camel.subscriber("file:./target?fileName=values.txt&fileExist=append", String.class));
     }
 
     @Outgoing("camel")

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/incoming/BeanWithCamelSubscriberFromReactiveStreamRoute.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/incoming/BeanWithCamelSubscriberFromReactiveStreamRoute.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.camel.incoming;
 
+import java.util.concurrent.Flow.Subscriber;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -7,9 +9,9 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.reactive.streams.api.CamelReactiveStreamsService;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithCamelSubscriberFromReactiveStreamRoute extends RouteBuilder {
@@ -19,7 +21,7 @@ public class BeanWithCamelSubscriberFromReactiveStreamRoute extends RouteBuilder
 
     @Incoming("camel")
     public Subscriber<String> sink() {
-        return reactive.streamSubscriber("camel-sub", String.class);
+        return AdaptersToFlow.subscriber(reactive.streamSubscriber("camel-sub", String.class));
     }
 
     @Outgoing("camel")

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithCamelPublisher.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithCamelPublisher.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -12,7 +13,8 @@ import org.apache.camel.Exchange;
 import org.apache.camel.component.reactive.streams.api.CamelReactiveStreamsService;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
+
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithCamelPublisher {
@@ -35,8 +37,8 @@ public class BeanWithCamelPublisher {
     }
 
     @Outgoing("camel")
-    public Publisher<Exchange> source() {
-        return camel.from("seda:camel");
+    public Flow.Publisher<Exchange> source() {
+        return AdaptersToFlow.publisher(camel.from("seda:camel"));
     }
 
     public List<String> values() {

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithCamelReactiveStreamRoute.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithCamelReactiveStreamRoute.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -13,7 +14,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.reactive.streams.api.CamelReactiveStreamsService;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
+
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithCamelReactiveStreamRoute extends RouteBuilder {
@@ -36,8 +38,8 @@ public class BeanWithCamelReactiveStreamRoute extends RouteBuilder {
     }
 
     @Outgoing("camel")
-    public Publisher<Exchange> source() {
-        return camel.fromStream("my-stream");
+    public Flow.Publisher<Exchange> source() {
+        return AdaptersToFlow.publisher(camel.fromStream("my-stream"));
     }
 
     public List<String> values() {

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithCamelRoute.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithCamelRoute.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -12,7 +13,8 @@ import org.apache.camel.Exchange;
 import org.apache.camel.component.reactive.streams.api.CamelReactiveStreamsService;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
+
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithCamelRoute {
@@ -35,8 +37,8 @@ public class BeanWithCamelRoute {
     }
 
     @Outgoing("camel")
-    public Publisher<Exchange> source() {
-        return camel.from("seda:camel");
+    public Flow.Publisher<Exchange> source() {
+        return AdaptersToFlow.publisher(camel.from("seda:camel"));
     }
 
     public List<String> values() {

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithTypedCamelPublisher.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithTypedCamelPublisher.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow.Publisher;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -11,7 +12,8 @@ import jakarta.inject.Inject;
 import org.apache.camel.component.reactive.streams.api.CamelReactiveStreamsService;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
+
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithTypedCamelPublisher {
@@ -29,7 +31,7 @@ public class BeanWithTypedCamelPublisher {
 
     @Outgoing("sink")
     public Publisher<String> source() {
-        return camel.from("seda:camel", String.class);
+        return AdaptersToFlow.publisher(camel.from("seda:camel", String.class));
     }
 
     public List<String> values() {

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithTypedCamelReactiveStreamRoute.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithTypedCamelReactiveStreamRoute.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow.Publisher;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -12,7 +13,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.reactive.streams.api.CamelReactiveStreamsService;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
+
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithTypedCamelReactiveStreamRoute extends RouteBuilder {
@@ -30,7 +32,7 @@ public class BeanWithTypedCamelReactiveStreamRoute extends RouteBuilder {
 
     @Outgoing("sink")
     public Publisher<String> source() {
-        return camel.fromStream("my-stream", String.class);
+        return AdaptersToFlow.publisher(camel.fromStream("my-stream", String.class));
     }
 
     public List<String> values() {

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithTypedCamelRoute.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/outgoing/BeanWithTypedCamelRoute.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -11,7 +12,8 @@ import jakarta.inject.Inject;
 import org.apache.camel.component.reactive.streams.api.CamelReactiveStreamsService;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
+
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithTypedCamelRoute {
@@ -28,8 +30,8 @@ public class BeanWithTypedCamelRoute {
     }
 
     @Outgoing("sink")
-    public Publisher<String> source() {
-        return camel.from("seda:camel", String.class);
+    public Flow.Publisher<String> source() {
+        return AdaptersToFlow.publisher(camel.from("seda:camel", String.class));
     }
 
     public List<String> values() {

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/BeanWithCamelSinkUsingRSRoute.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/BeanWithCamelSinkUsingRSRoute.java
@@ -1,22 +1,25 @@
 package io.smallrye.reactive.messaging.camel.sink;
 
+import java.util.concurrent.Flow.Publisher;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.reactivestreams.Publisher;
+
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithCamelSinkUsingRSRoute extends RouteBuilder {
 
     @Outgoing("data")
     public Publisher<Message<String>> source() {
-        return ReactiveStreams.of("a", "b", "c", "d")
+        return AdaptersToFlow.publisher(ReactiveStreams.of("a", "b", "c", "d")
                 .map(String::toUpperCase)
                 .map(Message::of)
-                .buildRs();
+                .buildRs());
     }
 
     @Override

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/BeanWithCamelSinkUsingRegularEndpoint.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/BeanWithCamelSinkUsingRegularEndpoint.java
@@ -1,24 +1,26 @@
 package io.smallrye.reactive.messaging.camel.sink;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.reactive.messaging.camel.OutgoingExchangeMetadata;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithCamelSinkUsingRegularEndpoint {
 
     @Outgoing("data")
-    public Publisher<Message<String>> source() {
-        return ReactiveStreams.of("a", "b", "c", "d")
+    public Flow.Publisher<Message<String>> source() {
+        return AdaptersToFlow.publisher(ReactiveStreams.of("a", "b", "c", "d")
                 .map(String::toUpperCase)
                 .map(m -> Message.of(m).addMetadata(
                         new OutgoingExchangeMetadata().putProperty("key", "value").putHeader("headerKey", "headerValue")))
-                .buildRs();
+                .buildRs());
     }
 
 }

--- a/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/BeanWithCamelSinkUsingRegularRoute.java
+++ b/smallrye-reactive-messaging-camel/src/test/java/io/smallrye/reactive/messaging/camel/sink/BeanWithCamelSinkUsingRegularRoute.java
@@ -3,6 +3,7 @@ package io.smallrye.reactive.messaging.camel.sink;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow.Publisher;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -10,9 +11,9 @@ import org.apache.camel.builder.RouteBuilder;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.reactive.messaging.camel.OutgoingExchangeMetadata;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanWithCamelSinkUsingRegularRoute extends RouteBuilder {
@@ -22,11 +23,11 @@ public class BeanWithCamelSinkUsingRegularRoute extends RouteBuilder {
 
     @Outgoing("data")
     public Publisher<Message<String>> source() {
-        return ReactiveStreams.of("a", "b", "c", "d")
+        return AdaptersToFlow.publisher(ReactiveStreams.of("a", "b", "c", "d")
                 .map(String::toUpperCase)
                 .map(m -> Message.of(m).addMetadata(
                         new OutgoingExchangeMetadata().putProperty("key", "value").putHeader("headerKey", "headerValue")))
-                .buildRs();
+                .buildRs());
     }
 
     @Override

--- a/smallrye-reactive-messaging-gcp-pubsub/src/test/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubTest.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/test/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubTest.java
@@ -4,17 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.lang.annotation.Annotation;
+import java.util.concurrent.Flow;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
-import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Subscriber;
 
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.TopicName;
@@ -70,18 +69,18 @@ public class PubSubTest extends PubSubTestBase {
 
     @SuppressWarnings("unchecked")
     private void send(final String message, final String topic) {
-        final SubscriberBuilder<? extends Message<?>, Void> subscriber = createSinkSubscriber(topic);
+        final Flow.Subscriber<? extends Message<?>> subscriber = createSinkSubscriber(topic);
         Multi.createFrom().item(message)
                 .map(Message::of)
-                .subscribe((Subscriber<Message<String>>) subscriber.build());
+                .subscribe((Flow.Subscriber<Message<String>>) subscriber);
     }
 
-    private SubscriberBuilder<? extends Message<?>, Void> createSinkSubscriber(final String topic) {
+    private Flow.Subscriber<? extends Message<?>> createSinkSubscriber(final String topic) {
         final MapBasedConfig config = createSourceConfig(topic, null, PUBSUB_CONTAINER.getFirstMappedPort());
         config.put("topic", topic);
         config.write();
 
-        return getConnector().getSubscriberBuilder(config);
+        return getConnector().getSubscriber(config);
     }
 
     private PubSubConnector getConnector() {

--- a/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/memory/InMemoryConnector.java
+++ b/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/memory/InMemoryConnector.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow.Processor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -20,11 +21,11 @@ import org.eclipse.microprofile.reactive.messaging.spi.OutgoingConnectorFactory;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
-import org.reactivestreams.Processor;
 
 import io.smallrye.mutiny.operators.multi.processors.BroadcastProcessor;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import io.smallrye.reactive.messaging.memory.i18n.InMemoryExceptions;
+import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 /**
  * An implementation of connector used for testing applications without having to use external broker.
@@ -220,7 +221,7 @@ public class InMemoryConnector implements IncomingConnectorFactory, OutgoingConn
             } else {
                 processor = UnicastProcessor.create();
             }
-            this.source = ReactiveStreams.fromPublisher(processor);
+            this.source = ReactiveStreams.fromPublisher(AdaptersToReactiveStreams.publisher(processor));
         }
 
         @Override

--- a/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
+++ b/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsConnector.java
@@ -6,7 +6,12 @@ import static io.smallrye.reactive.messaging.jms.i18n.JmsLogging.log;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Flow;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -22,14 +27,12 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
-import org.eclipse.microprofile.reactive.messaging.spi.IncomingConnectorFactory;
-import org.eclipse.microprofile.reactive.messaging.spi.OutgoingConnectorFactory;
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
-import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction;
+import io.smallrye.reactive.messaging.connector.InboundConnector;
+import io.smallrye.reactive.messaging.connector.OutboundConnector;
 import io.smallrye.reactive.messaging.json.JsonMapping;
 import io.smallrye.reactive.messaging.providers.i18n.ProviderLogging;
 
@@ -58,7 +61,7 @@ import io.smallrye.reactive.messaging.providers.i18n.ProviderLogging;
 @ConnectorAttribute(name = "reply-to", description = "The reply to destination if any", direction = Direction.OUTGOING, type = "string")
 @ConnectorAttribute(name = "reply-to-destination-type", description = "The type of destination for the response. It can be either `queue` or `topic`", direction = Direction.OUTGOING, type = "string", defaultValue = "queue")
 @ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
-public class JmsConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
+public class JmsConnector implements InboundConnector, OutboundConnector {
 
     /**
      * The name of the connector: {@code smallrye-jms}
@@ -122,7 +125,7 @@ public class JmsConnector implements IncomingConnectorFactory, OutgoingConnector
     }
 
     @Override
-    public PublisherBuilder<? extends Message<?>> getPublisherBuilder(Config config) {
+    public Flow.Publisher<? extends Message<?>> getPublisher(Config config) {
         JmsConnectorIncomingConfiguration ic = new JmsConnectorIncomingConfiguration(config);
         JMSContext context = createJmsContext(ic);
         contexts.add(context);
@@ -143,7 +146,7 @@ public class JmsConnector implements IncomingConnectorFactory, OutgoingConnector
     }
 
     @Override
-    public SubscriberBuilder<? extends Message<?>, Void> getSubscriberBuilder(Config config) {
+    public Flow.Subscriber<? extends Message<?>> getSubscriber(Config config) {
         JmsConnectorOutgoingConfiguration oc = new JmsConnectorOutgoingConfiguration(config);
         JMSContext context = createJmsContext(oc);
         contexts.add(context);

--- a/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/jms/JmsSinkTest.java
+++ b/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/jms/JmsSinkTest.java
@@ -13,7 +13,6 @@ import jakarta.jms.*;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.streams.operators.CompletionSubscriber;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +29,7 @@ public class JmsSinkTest extends JmsTestBase {
     private ActiveMQJMSConnectionFactory factory;
     private JsonMapping jsonMapping;
     private ExecutorService executor;
-    private CompletionSubscriber<org.eclipse.microprofile.reactive.messaging.Message<?>, Void> subscriber;
+    private Flow.Subscriber<org.eclipse.microprofile.reactive.messaging.Message<?>> subscriber;
 
     @BeforeEach
     public void init() {
@@ -56,7 +55,7 @@ public class JmsSinkTest extends JmsTestBase {
                 .with("channel-name", "jms");
         JmsSink sink = new JmsSink(jms, new JmsConnectorOutgoingConfiguration(config), jsonMapping, executor);
         MyJmsClient client = new MyJmsClient(jms.createQueue("queue-one"));
-        subscriber = sink.getSink().build();
+        subscriber = sink.getSink();
         subscriber.onSubscribe(new Subscriptions.EmptySubscription());
         AtomicBoolean acked = new AtomicBoolean();
         subscriber.onNext(Message.of("hello",
@@ -76,7 +75,7 @@ public class JmsSinkTest extends JmsTestBase {
         JmsSink sink = new JmsSink(jms, new JmsConnectorOutgoingConfiguration(config), jsonMapping, executor);
         MyJmsClient client1 = new MyJmsClient(jms.createTopic("my-topic"));
         MyJmsClient client2 = new MyJmsClient(jms.createTopic("my-topic"));
-        subscriber = sink.getSink().build();
+        subscriber = sink.getSink();
         subscriber.onSubscribe(new Subscriptions.EmptySubscription());
         AtomicBoolean acked = new AtomicBoolean();
         subscriber.onNext(Message.of("hello",
@@ -98,7 +97,7 @@ public class JmsSinkTest extends JmsTestBase {
                 .with("channel-name", "jms");
         JmsSink sink = new JmsSink(jms, new JmsConnectorOutgoingConfiguration(config), jsonMapping, executor);
         MyJmsClient client = new MyJmsClient(jms.createQueue("queue-one"));
-        subscriber = sink.getSink().build();
+        subscriber = sink.getSink();
         subscriber.onSubscribe(new Subscriptions.EmptySubscription());
         AtomicBoolean acked = new AtomicBoolean();
         subscriber.onNext(Message.of("hello",
@@ -122,7 +121,7 @@ public class JmsSinkTest extends JmsTestBase {
                 .with("channel-name", "jms");
         JmsSink sink = new JmsSink(jms, new JmsConnectorOutgoingConfiguration(config), jsonMapping, executor);
         MyJmsClient client = new MyJmsClient(jms.createQueue("queue-one"));
-        subscriber = sink.getSink().build();
+        subscriber = sink.getSink();
         subscriber.onSubscribe(new Subscriptions.EmptySubscription());
         AtomicBoolean acked = new AtomicBoolean();
         subscriber.onNext(Message.of("hello",
@@ -146,7 +145,7 @@ public class JmsSinkTest extends JmsTestBase {
                 .with("channel-name", "jms");
         JmsSink sink = new JmsSink(jms, new JmsConnectorOutgoingConfiguration(config), jsonMapping, executor);
         MyJmsClient client = new MyJmsClient(jms.createQueue("queue-one"));
-        subscriber = sink.getSink().build();
+        subscriber = sink.getSink();
         subscriber.onSubscribe(new Subscriptions.EmptySubscription());
         AtomicBoolean acked = new AtomicBoolean();
         subscriber.onNext(Message.of("hello",
@@ -168,7 +167,7 @@ public class JmsSinkTest extends JmsTestBase {
                 .with("channel-name", "jms");
         JmsSink sink = new JmsSink(jms, new JmsConnectorOutgoingConfiguration(config), jsonMapping, executor);
         MyJmsClient client = new MyJmsClient(jms.createQueue("queue-one"));
-        subscriber = sink.getSink().build();
+        subscriber = sink.getSink();
         subscriber.onSubscribe(new Subscriptions.EmptySubscription());
         AtomicBoolean acked = new AtomicBoolean();
         subscriber.onNext(Message.of("hello",
@@ -192,7 +191,7 @@ public class JmsSinkTest extends JmsTestBase {
                 .with("channel-name", "jms");
         JmsSink sink = new JmsSink(jms, new JmsConnectorOutgoingConfiguration(config), jsonMapping, executor);
         MyJmsClient client = new MyJmsClient(jms.createQueue("queue-one"));
-        subscriber = sink.getSink().build();
+        subscriber = sink.getSink();
         subscriber.onSubscribe(new Subscriptions.EmptySubscription());
         AtomicBoolean acked = new AtomicBoolean();
         subscriber.onNext(Message.of("hello",
@@ -226,7 +225,7 @@ public class JmsSinkTest extends JmsTestBase {
                 .with("ttl", 10000L);
         JmsSink sink = new JmsSink(jms, new JmsConnectorOutgoingConfiguration(config), jsonMapping, executor);
         MyJmsClient client = new MyJmsClient(jms.createQueue("queue-one"));
-        subscriber = sink.getSink().build();
+        subscriber = sink.getSink();
         subscriber.onSubscribe(new Subscriptions.EmptySubscription());
         AtomicBoolean acked = new AtomicBoolean();
         Message<String> hello = Message.of("hello",

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>mutiny-zero-reactive-streams-junit5-tck</artifactId>
-      <version>${mutiny-zero-reactive-streams-junit5-tck.version}</version>
+      <version>${mutiny-zero.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/smallrye-reactive-messaging-kafka/revapi.json
+++ b/smallrye-reactive-messaging-kafka/revapi.json
@@ -24,7 +24,26 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+        {
+            "code": "java.method.returnTypeChanged",
+            "old": "method org.reactivestreams.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.kafka.KafkaConnector::getPublisher(org.eclipse.microprofile.config.Config)",
+            "new": "method java.util.concurrent.Flow.Publisher<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.kafka.KafkaConnector::getPublisher(org.eclipse.microprofile.config.Config)",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "code": "java.method.returnTypeChanged",
+            "old": "method org.reactivestreams.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.kafka.KafkaConnector::getSubscriber(org.eclipse.microprofile.config.Config)",
+            "new": "method java.util.concurrent.Flow.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.kafka.KafkaConnector::getSubscriber(org.eclipse.microprofile.config.Config)",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        },
+        {
+            "code": "java.method.returnTypeChanged",
+            "old": "method org.reactivestreams.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.kafka.impl.KafkaSink::getSink()",
+            "new": "method java.util.concurrent.Flow.Subscriber<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.kafka.impl.KafkaSink::getSink()",
+            "justification": "Switch from the legacy Reactive Streams APIs to java.util.concurrent.Flow"
+        }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConnector.java
@@ -5,6 +5,8 @@ import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
+import java.util.concurrent.Flow.Publisher;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.PostConstruct;
@@ -21,8 +23,6 @@ import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
@@ -180,7 +180,7 @@ public class KafkaConnector implements InboundConnector, OutboundConnector, Heal
     }
 
     @Override
-    public Publisher<? extends Message<?>> getPublisher(Config config) {
+    public Flow.Publisher<? extends Message<?>> getPublisher(Config config) {
         Config channelConfiguration = ConfigHelper.retrieveChannelConfiguration(configurations, config);
 
         KafkaConnectorIncomingConfiguration ic = new KafkaConnectorIncomingConfiguration(channelConfiguration);
@@ -251,7 +251,7 @@ public class KafkaConnector implements InboundConnector, OutboundConnector, Heal
     }
 
     @Override
-    public Subscriber<? extends Message<?>> getSubscriber(Config config) {
+    public Flow.Subscriber<? extends Message<?>> getSubscriber(Config config) {
         Config channelConfiguration = ConfigHelper.retrieveChannelConfiguration(configurations, config);
 
         KafkaConnectorOutgoingConfiguration oc = new KafkaConnectorOutgoingConfiguration(channelConfiguration);

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordStreamSubscription.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaRecordStreamSubscription.java
@@ -5,6 +5,7 @@ import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Objects;
+import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -12,7 +13,6 @@ import java.util.function.UnaryOperator;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.Subscriptions;
@@ -21,7 +21,7 @@ import io.smallrye.reactive.messaging.kafka.KafkaConnectorIncomingConfiguration;
 import io.vertx.core.Context;
 
 /**
- * A {@link Subscription} which, on {@link #request(long)}, polls {@link ConsumerRecords} from the given consumer client
+ * A {@link Flow.Subscription} which, on {@link #request(long)}, polls {@link ConsumerRecords} from the given consumer client
  * and emits records downstream.
  * <p>
  * It uses an internal queue to store records received but not yet emitted downstream.
@@ -31,7 +31,7 @@ import io.vertx.core.Context;
  * @param <V> type of incoming record payload
  * @param <T> type of the items to emit downstream
  */
-public class KafkaRecordStreamSubscription<K, V, T> implements Subscription {
+public class KafkaRecordStreamSubscription<K, V, T> implements Flow.Subscription {
     private static final int STATE_NEW = 0; // no request yet -- we start polling on the first request
     private static final int STATE_POLLING = 1;
     private static final int STATE_PAUSED = 2;

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSenderProcessor.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSenderProcessor.java
@@ -2,13 +2,13 @@ package io.smallrye.reactive.messaging.kafka.impl;
 
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions.ex;
 
+import java.util.concurrent.Flow.Processor;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Processor;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.Subscriptions;

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSink.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Flow;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -30,7 +31,6 @@ import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Subscriber;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -65,7 +65,7 @@ public class KafkaSink {
     private final int partition;
     private final String topic;
     private final String key;
-    private final Subscriber<? extends Message<?>> subscriber;
+    private final Flow.Subscriber<? extends Message<?>> subscriber;
 
     private final long retries;
     private final int deliveryTimeoutMs;
@@ -345,7 +345,7 @@ public class KafkaSink {
         return key;
     }
 
-    public Subscriber<? extends Message<?>> getSink() {
+    public Flow.Subscriber<? extends Message<?>> getSink() {
         return subscriber;
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -168,7 +168,7 @@ public class KafkaSource<K, V> {
                 IncomingKafkaRecord<K, V> record = new IncomingKafkaRecord<>(rec, channel, index, commitHandler,
                         failureHandler, isCloudEventEnabled, isTracingEnabled);
                 return commitHandler.received(record);
-            }).concatenate(false);
+            }).concatenate();
 
             if (config.getTracingEnabled()) {
                 incomingMulti = incomingMulti.onItem().invoke(record -> incomingTrace(record, false));
@@ -198,7 +198,7 @@ public class KafkaSource<K, V> {
                 IncomingKafkaRecordBatch<K, V> batch = new IncomingKafkaRecordBatch<>(rec, channel, index,
                         commitHandler, failureHandler, isCloudEventEnabled, isTracingEnabled);
                 return receiveBatchRecord(batch);
-            }).concatenate(false);
+            }).concatenate();
 
             if (config.getTracingEnabled()) {
                 incomingMulti = incomingMulti.onItem().invoke(this::incomingTrace);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -24,8 +25,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Multi;
@@ -65,10 +64,10 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
         sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(),
                 UnsatisfiedInstance.instance());
 
-        Subscriber<? extends Message<?>> subscriber = sink.getSink();
+        Flow.Subscriber<? extends Message<?>> subscriber = sink.getSink();
         Multi.createFrom().range(0, 10)
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<Integer>>) subscriber);
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) subscriber);
 
         assertThat(consumed.awaitCompletion(Duration.ofMinutes(1)).count()).isEqualTo(10);
     }
@@ -86,10 +85,10 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
         sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(),
                 UnsatisfiedInstance.instance());
 
-        Subscriber<? extends Message<?>> subscriber = sink.getSink();
+        Flow.Subscriber<? extends Message<?>> subscriber = sink.getSink();
         Multi.createFrom().range(0, 10)
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<Integer>>) subscriber);
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) subscriber);
 
         assertThat(consumed.awaitCompletion(Duration.ofMinutes(1)).count()).isEqualTo(10);
     }
@@ -108,11 +107,11 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
         sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(),
                 UnsatisfiedInstance.instance());
 
-        Subscriber<? extends Message<?>> subscriber = sink.getSink();
+        Flow.Subscriber<? extends Message<?>> subscriber = sink.getSink();
         Multi.createFrom().range(0, 10)
                 .map(i -> Integer.toString(i))
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<String>>) subscriber);
+                .subscribe((Flow.Subscriber<? super Message<String>>) subscriber);
 
         assertThat(consumed.awaitCompletion(Duration.ofMinutes(1)).count()).isEqualTo(10);
     }
@@ -247,7 +246,7 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
 
         List<Object> acked = new CopyOnWriteArrayList<>();
         List<Object> nacked = new CopyOnWriteArrayList<>();
-        Subscriber subscriber = sink.getSink();
+        Flow.Subscriber subscriber = sink.getSink();
         Multi.createFrom().range(0, 6)
                 .map(i -> {
                     if (i == 3 || i == 5) {
@@ -289,7 +288,7 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
         sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(),
                 UnsatisfiedInstance.instance());
 
-        Subscriber subscriber = sink.getSink();
+        Flow.Subscriber subscriber = sink.getSink();
         Multi.createFrom().range(0, 5)
                 .map(i -> {
                     if (i == 3 || i == 5) {
@@ -540,7 +539,7 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -556,7 +555,7 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -572,7 +571,7 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -589,7 +588,7 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -612,7 +611,7 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -622,12 +621,12 @@ public class KafkaSinkTest extends KafkaCompanionTestBase {
     public static class BeanWithMultipleUpstreams {
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source2() {
+        public Flow.Publisher<Integer> source2() {
             return Multi.createFrom().range(10, 20)
                     .onItem().call(x -> Uni.createFrom().voidItem().onItem().delayIt().by(Duration.ofMillis(20)));
         }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkWithLegacyMetadataTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSinkWithLegacyMetadataTest.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -19,8 +20,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -64,10 +63,10 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
         sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(),
                 UnsatisfiedInstance.instance());
 
-        Subscriber<? extends Message<?>> subscriber = sink.getSink();
+        Flow.Subscriber<? extends Message<?>> subscriber = sink.getSink();
         Multi.createFrom().range(0, 10)
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<Integer>>) subscriber);
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) subscriber);
 
         assertThat(consumed.awaitCompletion(Duration.ofMinutes(1)).count()).isEqualTo(10);
     }
@@ -85,10 +84,10 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
         sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(),
                 UnsatisfiedInstance.instance());
 
-        Subscriber<? extends Message<?>> subscriber = sink.getSink();
+        Flow.Subscriber<? extends Message<?>> subscriber = sink.getSink();
         Multi.createFrom().range(0, 10)
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<Integer>>) subscriber);
+                .subscribe((Flow.Subscriber<? super Message<Integer>>) subscriber);
 
         assertThat(consumed.awaitCompletion(Duration.ofMinutes(1)).count()).isEqualTo(10);
     }
@@ -107,11 +106,11 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
         sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(),
                 UnsatisfiedInstance.instance());
 
-        Subscriber<? extends Message<?>> subscriber = sink.getSink();
+        Flow.Subscriber<? extends Message<?>> subscriber = sink.getSink();
         Multi.createFrom().range(0, 10)
                 .map(i -> Integer.toString(i))
                 .map(Message::of)
-                .subscribe((Subscriber<? super Message<String>>) subscriber);
+                .subscribe((Flow.Subscriber<? super Message<String>>) subscriber);
 
         assertThat(consumed.awaitCompletion(Duration.ofMinutes(1)).count()).isEqualTo(10);
     }
@@ -247,7 +246,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
 
         List<Object> acked = new CopyOnWriteArrayList<>();
         List<Object> nacked = new CopyOnWriteArrayList<>();
-        Subscriber subscriber = sink.getSink();
+        Flow.Subscriber subscriber = sink.getSink();
         Multi.createFrom().range(0, 6)
                 .map(i -> {
                     if (i == 3 || i == 5) {
@@ -289,7 +288,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
         sink = new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(),
                 UnsatisfiedInstance.instance());
 
-        Subscriber subscriber = sink.getSink();
+        Flow.Subscriber subscriber = sink.getSink();
         Multi.createFrom().range(0, 5)
                 .map(i -> {
                     if (i == 3 || i == 5) {
@@ -446,7 +445,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -462,7 +461,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -478,7 +477,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -495,7 +494,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -518,7 +517,7 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
@@ -528,12 +527,12 @@ public class KafkaSinkWithLegacyMetadataTest extends KafkaCompanionTestBase {
     public static class BeanWithMultipleUpstreams {
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source2() {
+        public Flow.Publisher<Integer> source2() {
             return Multi.createFrom().range(10, 20)
                     .onItem().call(x -> Uni.createFrom().voidItem().onItem().delayIt().by(Duration.ofMillis(20)));
         }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -35,6 +36,7 @@ import org.testng.Assert;
 
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.kafka.api.KafkaMetadataUtil;
 import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
@@ -148,21 +150,21 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
         connector.failureHandlerFactories = new SingletonInstance<>("fail", new KafkaFailStop.Factory());
         connector.init();
 
-        Multi<? extends KafkaRecord> multi = (Multi<? extends KafkaRecord>) connector.getPublisher(config);
+        Flow.Publisher<KafkaRecord<?, ?>> builder = (Flow.Publisher<KafkaRecord<?, ?>>) connector.getPublisher(config);
 
-        List<KafkaRecord> messages1 = new ArrayList<>();
-        List<KafkaRecord> messages2 = new ArrayList<>();
-        multi.subscribe().with(messages1::add);
-        multi.subscribe().with(messages2::add);
+        AssertSubscriber<KafkaRecord> messages1 = AssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<KafkaRecord> messages2 = AssertSubscriber.create(Long.MAX_VALUE);
+        builder.subscribe(messages1);
+        builder.subscribe(messages2);
 
         companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i), 10);
 
-        await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 10);
-        await().atMost(2, TimeUnit.MINUTES).until(() -> messages2.size() >= 10);
-        assertThat(messages1.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.getItems().size() >= 10);
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages2.getItems().size() >= 10);
+        assertThat(messages1.getItems().stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
                 .containsExactly(0, 1, 2, 3, 4,
                         5, 6, 7, 8, 9);
-        assertThat(messages2.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
+        assertThat(messages2.getItems().stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
                 .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
         assertThat(testEvents.firedConsumerEvents.sum()).isEqualTo(1);
@@ -188,21 +190,21 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
         connector.failureHandlerFactories = new SingletonInstance<>("fail", new KafkaFailStop.Factory());
         connector.init();
 
-        Multi<? extends KafkaRecord> multi = (Multi<? extends KafkaRecord>) connector.getPublisher(config);
+        Flow.Publisher<KafkaRecord<?, ?>> builder = (Flow.Publisher<KafkaRecord<?, ?>>) connector.getPublisher(config);
 
-        List<KafkaRecord> messages1 = new ArrayList<>();
-        List<KafkaRecord> messages2 = new ArrayList<>();
-        multi.subscribe().with(messages1::add);
-        multi.subscribe().with(messages2::add);
+        AssertSubscriber<KafkaRecord> messages1 = AssertSubscriber.create(Long.MAX_VALUE);
+        AssertSubscriber<KafkaRecord> messages2 = AssertSubscriber.create(Long.MAX_VALUE);
+        builder.subscribe(messages1);
+        builder.subscribe(messages2);
 
         companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i), 10);
 
-        await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 10);
-        await().atMost(2, TimeUnit.MINUTES).until(() -> messages2.size() >= 10);
-        assertThat(messages1.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.getItems().size() >= 10);
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages2.getItems().size() >= 10);
+        assertThat(messages1.getItems().stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
                 .containsExactlyInAnyOrder(0, 1, 2, 3, 4,
                         5, 6, 7, 8, 9);
-        assertThat(messages2.stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
+        assertThat(messages2.getItems().stream().map(KafkaRecord::getPayload).collect(Collectors.toList()))
                 .containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingBean.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingBean.java
@@ -1,12 +1,13 @@
 package io.smallrye.reactive.messaging.kafka;
 
+import java.util.concurrent.Flow.Publisher;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingKafkaMessageBean.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingKafkaMessageBean.java
@@ -1,5 +1,6 @@
 package io.smallrye.reactive.messaging.kafka;
 
+import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -8,7 +9,6 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 
@@ -29,7 +29,7 @@ public class ProducingKafkaMessageBean {
     }
 
     @Outgoing("data")
-    public Publisher<Integer> source() {
+    public Flow.Publisher<Integer> source() {
         return Multi.createFrom().range(0, 10);
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingMessageWithHeaderBean.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingMessageWithHeaderBean.java
@@ -2,13 +2,13 @@ package io.smallrye.reactive.messaging.kafka;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.eclipse.microprofile.reactive.messaging.*;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSinkWithCloudEventsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSinkWithCloudEventsTest.java
@@ -7,6 +7,7 @@ import static org.awaitility.Awaitility.await;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.UUID;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -69,7 +70,8 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .withId("some id")
                     .build());
 
-            Multi.createFrom().<Message<?>> item(message).subscribe().withSubscriber((Subscriber) sink.getSink());
+            Multi.createFrom().<Message<?>> item(message)
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.count() == 1);
 
@@ -116,7 +118,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.count() == 1);
 
@@ -160,7 +162,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.count() == 1);
 
@@ -205,7 +207,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
         });
 
         Multi.createFrom().<Message<?>> item(message)
-                .subscribe().withSubscriber((Subscriber) sink.getSink());
+                .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
         await().until(() -> {
             HealthReport.HealthReportBuilder builder = HealthReport.builder();
@@ -250,7 +252,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.count() == 1);
 
@@ -290,7 +292,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.count() == 1);
 
@@ -327,7 +329,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
             Message<?> message = Message.of("hello!");
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.getRecords().size() == 1);
 
@@ -368,7 +370,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.getRecords().size() == 1);
 
@@ -408,7 +410,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.getRecords().size() == 1);
 
@@ -446,7 +448,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.getRecords().size() == 1);
 
@@ -487,7 +489,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.getRecords().size() == 1);
 
@@ -526,7 +528,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.getRecords().size() == 1);
 
@@ -562,7 +564,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
             Message<?> message = Message.of("hello!");
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.getRecords().size() == 1);
 
@@ -603,7 +605,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
         });
 
         Multi.createFrom().<Message<?>> item(message)
-                .subscribe().withSubscriber((Subscriber) sink.getSink());
+                .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
         await().until(() -> {
             HealthReport.HealthReportBuilder builder = HealthReport.builder();
@@ -632,7 +634,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.getRecords().size() == 1);
 
@@ -667,7 +669,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
                     .build());
 
             Multi.createFrom().<Message<?>> item(message)
-                    .subscribe().withSubscriber((Subscriber) sink.getSink());
+                    .subscribe().withSubscriber((Flow.Subscriber) sink.getSink());
 
             await().until(() -> records.getRecords().size() == 1);
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/KafkaClientReactiveStreamsPublisherTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/KafkaClientReactiveStreamsPublisherTest.java
@@ -31,6 +31,7 @@ import io.smallrye.reactive.messaging.kafka.companion.test.KafkaBrokerExtension.
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 import io.vertx.mutiny.core.Vertx;
+import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 @ExtendWith(KafkaBrokerExtension.class)
 public class KafkaClientReactiveStreamsPublisherTest
@@ -94,10 +95,10 @@ public class KafkaClientReactiveStreamsPublisherTest
         Multi<IncomingKafkaRecord<String, String>> multi = createSource()
                 .getStream();
 
-        return Multi.createBy().combining().streams(multi, range).asTuple()
+        return AdaptersToReactiveStreams.publisher(Multi.createBy().combining().streams(multi, range).asTuple()
                 .map(Tuple2::getItem1)
                 .invoke(IncomingKafkaRecord::ack)
-                .onFailure().invoke(t -> System.out.println("Failure detected: " + t));
+                .onFailure().invoke(t -> System.out.println("Failure detected: " + t)));
     }
 
     protected MapBasedConfig createConsumerConfig(String groupId) {
@@ -136,6 +137,6 @@ public class KafkaClientReactiveStreamsPublisherTest
     @Override
     public Publisher<IncomingKafkaRecord<String, String>> createFailedPublisher() {
         // TODO Create a source with a deserialization issue.
-        return Multi.createFrom().failure(() -> new Exception("boom"));
+        return AdaptersToReactiveStreams.publisher(Multi.createFrom().failure(() -> new Exception("boom")));
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaProducerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaProducerTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Flow;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -132,7 +133,7 @@ public class ReactiveKafkaProducerTest extends ClientTestBase {
 
         Thread actualProducer = new Thread(() -> {
             Multi<Message<?>> merge = Multi.createBy().merging().streams(multis);
-            Subscriber<Message<?>> subscriber = (Subscriber<Message<?>>) createSink().getSink();
+            Flow.Subscriber<Message<?>> subscriber = (Flow.Subscriber<Message<?>>) createSink().getSink();
             merge.subscribe().withSubscriber(subscriber);
         });
         threads.add(actualProducer);
@@ -225,7 +226,7 @@ public class ReactiveKafkaProducerTest extends ClientTestBase {
                 emitter.complete();
             });
 
-            Subscriber<Message<?>> subscriber = (Subscriber<Message<?>>) createSink().getSink();
+            Flow.Subscriber<Message<?>> subscriber = (Flow.Subscriber<Message<?>>) createSink().getSink();
             stream.subscribe().withSubscriber(subscriber);
         }
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/SourceBackPressureWithBrokerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/SourceBackPressureWithBrokerTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -20,8 +21,6 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.annotations.Blocking;
@@ -123,7 +122,7 @@ public class SourceBackPressureWithBrokerTest extends KafkaCompanionTestBase {
     @ApplicationScoped
     static class ConsumptionBean {
 
-        private volatile Subscription subscription;
+        private volatile Flow.Subscription subscription;
         private final List<String> list = new CopyOnWriteArrayList<>();
 
         @Inject
@@ -131,9 +130,9 @@ public class SourceBackPressureWithBrokerTest extends KafkaCompanionTestBase {
         Multi<Message<String>> stream;
 
         public void run() {
-            stream.subscribe().withSubscriber(new Subscriber<Message<String>>() {
+            stream.subscribe().withSubscriber(new Flow.Subscriber<Message<String>>() {
                 @Override
-                public void onSubscribe(Subscription s) {
+                public void onSubscribe(Flow.Subscription s) {
                     subscription = s;
                 }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/conflict/ChannelNameConflictTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/conflict/ChannelNameConflictTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.DeploymentException;
@@ -11,7 +12,6 @@ import jakarta.enterprise.inject.spi.DeploymentException;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.annotations.Merge;
@@ -43,7 +43,7 @@ public class ChannelNameConflictTest extends KafkaCompanionTestBase {
     public static class Bean {
 
         @Outgoing("my-topic")
-        public Publisher<String> publisher() {
+        public Flow.Publisher<String> publisher() {
             return Multi.createFrom().item("0");
         }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/health/HealthCheckTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/health/HealthCheckTest.java
@@ -5,6 +5,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -16,7 +17,6 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.*;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.health.HealthReport;
@@ -204,7 +204,7 @@ public class HealthCheckTest extends KafkaCompanionTestBase {
         }
 
         @Outgoing("data")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/BatchTracingPropagationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/BatchTracingPropagationTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -23,7 +24,6 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -161,7 +161,7 @@ public class BatchTracingPropagationTest extends KafkaCompanionTestBase {
     public static class MyAppGeneratingData {
 
         @Outgoing("kafka")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/TracingPropagationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/TracingPropagationTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -32,7 +33,6 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -344,7 +344,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
     @ApplicationScoped
     public static class MyAppGeneratingData {
         @Outgoing("kafka")
-        public Publisher<Integer> source() {
+        public Flow.Publisher<Integer> source() {
             return Multi.createFrom().range(0, 10);
         }
     }
@@ -352,7 +352,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
     @ApplicationScoped
     public static class MyAppGeneratingCloudEventData {
         @Outgoing("kafka")
-        public Publisher<Message<String>> source() {
+        public Flow.Publisher<Message<String>> source() {
             return Multi.createFrom().range(0, 10)
                     .map(i -> Message.of(Integer.toString(i)))
                     .map(m -> m.addMetadata(OutgoingCloudEventMetadata.builder()

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
@@ -3,13 +3,11 @@ package io.smallrye.reactive.messaging.mqtt;
 import static io.smallrye.reactive.messaging.mqtt.i18n.MqttExceptions.ex;
 import static io.smallrye.reactive.messaging.mqtt.i18n.MqttLogging.log;
 
+import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import jakarta.enterprise.inject.Instance;
-
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.health.HealthReport.HealthReportBuilder;
@@ -21,11 +19,11 @@ import io.vertx.mutiny.core.Vertx;
 
 public class MqttSource {
 
+    private final Flow.Publisher<ReceivingMqttMessage> source;
+    private final AtomicBoolean ready = new AtomicBoolean();
     private final String channel;
     private final Pattern pattern;
     private final boolean healthEnabled;
-
-    private final PublisherBuilder<MqttMessage<?>> source;
 
     private final AtomicBoolean started = new AtomicBoolean();
     private final AtomicBoolean alive = new AtomicBoolean();
@@ -63,30 +61,30 @@ public class MqttSource {
                     alive.set(true);
                 });
 
-        this.source = ReactiveStreams.fromPublisher(
-                holder.stream()
-                        .select().where(m -> MqttTopicHelper.matches(topic, pattern, m))
-                        .onItem().transform(m -> new ReceivingMqttMessage(m, onNack))
-                        .stage(multi -> {
-                            if (broadcast)
-                                return multi.broadcast().toAllSubscribers();
-                            return multi;
-                        })
-                        .onOverflow().buffer(config.getBufferSize())
-                        .onCancellation().call(() -> {
-                            alive.set(false);
-                            if (config.getUnsubscribeOnDisconnection())
-                                return Uni
-                                        .createFrom()
-                                        .completionStage(holder.getClient()
-                                                .unsubscribe(topic).toCompletionStage());
-                            else
-                                return Uni.createFrom().voidItem();
-                        })
-                        .onFailure().invoke(e -> {
-                            alive.set(false);
-                            log.unableToConnectToBroker(e);
-                        }));
+        this.source = holder.stream()
+                .select().where(m -> MqttTopicHelper.matches(topic, pattern, m))
+                .onItem().transform(m -> new ReceivingMqttMessage(m, onNack))
+                .stage(multi -> {
+                    if (broadcast)
+                        return multi.broadcast().toAllSubscribers();
+
+                    return multi;
+                })
+                .onOverflow().buffer(config.getBufferSize())
+                .onCancellation().call(() -> {
+                    alive.set(false);
+                    if (config.getUnsubscribeOnDisconnection())
+                        return Uni
+                                .createFrom()
+                                .completionStage(holder.getClient()
+                                        .unsubscribe(topic).toCompletionStage());
+                    else
+                        return Uni.createFrom().voidItem();
+                })
+                .onFailure().invoke(e -> {
+                    alive.set(false);
+                    log.unableToConnectToBroker(e);
+                });
     }
 
     private MqttFailureHandler createFailureHandler(MqttFailureHandler.Strategy strategy, String channel) {
@@ -100,7 +98,7 @@ public class MqttSource {
         }
     }
 
-    PublisherBuilder<MqttMessage<?>> getSource() {
+    Flow.Publisher<ReceivingMqttMessage> getSource() {
         return source;
     }
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicTopicEmitterProducingBean.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicTopicEmitterProducingBean.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.mqtt;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Flow.Publisher;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -10,7 +11,6 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.smallrye.mutiny.Multi;

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicTopicProducingBean.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicTopicProducingBean.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.mqtt;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -9,7 +10,6 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.smallrye.mutiny.Multi;
@@ -29,7 +29,7 @@ public class DynamicTopicProducingBean {
     }
 
     @Outgoing("dyn-data")
-    public Publisher<Integer> source() {
+    public Flow.Publisher<Integer> source() {
         return Multi.createFrom().range(0, 10);
     }
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSinkTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSinkTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -16,7 +17,6 @@ import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
@@ -50,8 +50,7 @@ public class MqttSinkTest extends MqttTestBase {
         config.put("port", port);
         MqttSink sink = new MqttSink(vertx, new MqttConnectorOutgoingConfiguration(new MapBasedConfig(config)), null);
 
-        Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
-
+        Subscriber<? extends Message<?>> subscriber = sink.getSink();
         Multi.createFrom().range(0, 10)
                 .map(Message::of)
                 .subscribe((Subscriber<? super Message<Integer>>) subscriber);
@@ -77,7 +76,7 @@ public class MqttSinkTest extends MqttTestBase {
         config.put("port", port);
         MqttSink sink = new MqttSink(vertx, new MqttConnectorOutgoingConfiguration(new MapBasedConfig(config)), null);
 
-        Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
+        Subscriber<? extends Message<?>> subscriber = sink.getSink();
         Multi.createFrom().range(0, 10)
                 .map(Message::of)
                 .subscribe((Subscriber<? super Message<Integer>>) subscriber);
@@ -104,7 +103,7 @@ public class MqttSinkTest extends MqttTestBase {
         config.put("port", port);
         MqttSink sink = new MqttSink(vertx, new MqttConnectorOutgoingConfiguration(new MapBasedConfig(config)), null);
 
-        Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
+        Subscriber<? extends Message<?>> subscriber = sink.getSink();
         Multi.createFrom().range(0, 10)
                 .map(i -> Integer.toString(i))
                 .map(Message::of)

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
@@ -4,18 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.*;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 
 public class MqttSourceTest extends MqttTestBase {
@@ -42,10 +43,9 @@ public class MqttSourceTest extends MqttTestBase {
                 null);
 
         List<MqttMessage<?>> messages = new ArrayList<>();
-        PublisherBuilder<MqttMessage<?>> stream = source.getSource();
-        stream.forEach(messages::add).run();
+        Flow.Publisher<? extends MqttMessage<?>> stream = source.getSource();
+        Multi.createFrom().publisher(stream).subscribe().with(messages::add);
         awaitUntilReady(source);
-
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(topic, 10, null,
                 counter::getAndIncrement)).start();
@@ -70,8 +70,8 @@ public class MqttSourceTest extends MqttTestBase {
                 null);
 
         List<MqttMessage<?>> messages = new ArrayList<>();
-        PublisherBuilder<MqttMessage<?>> stream = source.getSource();
-        stream.forEach(messages::add).run();
+        Flow.Publisher<? extends MqttMessage<?>> stream = source.getSource();
+        Multi.createFrom().publisher(stream).subscribe().with(messages::add);
         awaitUntilReady(source);
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(topic, 10, null,
@@ -101,9 +101,9 @@ public class MqttSourceTest extends MqttTestBase {
 
         List<MqttMessage<?>> messages1 = new ArrayList<>();
         List<MqttMessage<?>> messages2 = new ArrayList<>();
-        PublisherBuilder<MqttMessage<?>> stream = source.getSource();
-        stream.forEach(messages1::add).run();
-        stream.forEach(messages2::add).run();
+        Flow.Publisher<? extends MqttMessage<?>> stream = source.getSource();
+        Multi.createFrom().publisher(stream).subscribe().with(messages1::add);
+        Multi.createFrom().publisher(stream).subscribe().with(messages2::add);
 
         awaitUntilReady(source);
 
@@ -145,8 +145,8 @@ public class MqttSourceTest extends MqttTestBase {
         random.nextBytes(large);
 
         List<MqttMessage<?>> messages = new ArrayList<>();
-        PublisherBuilder<MqttMessage<?>> stream = source.getSource();
-        stream.forEach(messages::add).run();
+        Flow.Publisher<? extends MqttMessage<?>> stream = source.getSource();
+        Multi.createFrom().publisher(stream).subscribe().with(messages::add);
         awaitUntilReady(source);
         new Thread(() -> usage.produce(topic, 10, null,
                 () -> large)).start();

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MutualTlsMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MutualTlsMqttSourceTest.java
@@ -5,15 +5,16 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertThrows;
 
 import java.util.*;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 
 public class MutualTlsMqttSourceTest extends MutualTlsMqttTestBase {
@@ -45,8 +46,8 @@ public class MutualTlsMqttSourceTest extends MutualTlsMqttTestBase {
                 null);
 
         List<MqttMessage<?>> messages = new ArrayList<>();
-        PublisherBuilder<MqttMessage<?>> stream = source.getSource();
-        stream.forEach(messages::add).run();
+        Flow.Publisher<? extends MqttMessage<?>> stream = source.getSource();
+        Multi.createFrom().publisher(stream).subscribe().with(messages::add);
         awaitUntilReady(source);
         pause();
         AtomicInteger counter = new AtomicInteger();

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ProducingBean.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ProducingBean.java
@@ -1,12 +1,13 @@
 package io.smallrye.reactive.messaging.mqtt;
 
+import java.util.concurrent.Flow.Publisher;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
@@ -5,18 +5,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.*;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 
 @Disabled("does not work on CI - must be investigated")
@@ -47,8 +48,8 @@ public class SecureMqttSourceTest extends SecureMqttTestBase {
                 null);
 
         List<MqttMessage<?>> messages = new ArrayList<>();
-        PublisherBuilder<MqttMessage<?>> stream = source.getSource();
-        stream.forEach(messages::add).run();
+        Flow.Publisher<? extends MqttMessage<?>> stream = source.getSource();
+        Multi.createFrom().publisher(stream).subscribe().with(messages::add);
         awaitUntilReady(source);
         pause();
         AtomicInteger counter = new AtomicInteger();

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/TlsMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/TlsMqttSourceTest.java
@@ -3,16 +3,21 @@ package io.smallrye.reactive.messaging.mqtt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 
 public class TlsMqttSourceTest extends TlsMqttTestBase {
@@ -41,8 +46,8 @@ public class TlsMqttSourceTest extends TlsMqttTestBase {
                 null);
 
         List<MqttMessage<?>> messages = new ArrayList<>();
-        PublisherBuilder<MqttMessage<?>> stream = source.getSource();
-        stream.forEach(messages::add).run();
+        Flow.Publisher<? extends MqttMessage<?>> stream = source.getSource();
+        Multi.createFrom().publisher(stream).subscribe().with(messages::add);
         awaitUntilReady(source);
         pause();
         AtomicInteger counter = new AtomicInteger();

--- a/smallrye-reactive-messaging-provider/revapi.json
+++ b/smallrye-reactive-messaging-provider/revapi.json
@@ -11,16 +11,23 @@
   "extension" : "revapi.filter",
   "configuration" : {
     "elements" : {
-      "include" : [ "class io.smallrye.reactive.messaging.providers.PublisherDecorator", {
-        "matcher" : "java-package",
-        "match" : "io.smallrye.reactive.messaging.providers.connectors"
-      }, {
-        "matcher" : "java-package",
-        "match" : "io.smallrye.reactive.messaging.providers.locals"
-      }, {
-        "matcher" : "java-package",
-        "match" : "io.smallrye.reactive.messaging.providers.wiring"
-      } ]
+      "include" : [
+          "class io.smallrye.reactive.messaging.providers.PublisherDecorator",
+          "class io.smallrye.reactive.messaging.connectors.ExecutionHolder",
+          "class io.smallrye.reactive.messaging.connectors.WorkerPoolRegistry",
+          "class io.smallrye.reactive.messaging.locals.ContextAwareMessage",
+          "class io.smallrye.reactive.messaging.locals.ContextDecorator",
+          "class io.smallrye.reactive.messaging.locals.ContextOperator",
+          "class io.smallrye.reactive.messaging.locals.LocalContextMetadata",
+          "class io.smallrye.reactive.messaging.locals.CycleException",
+          "class io.smallrye.reactive.messaging.locals.Graph",
+          "class io.smallrye.reactive.messaging.locals.OpenGraphException",
+          "class io.smallrye.reactive.messaging.locals.TooManyDownstreamCandidatesException",
+          "class io.smallrye.reactive.messaging.locals.TooManyUpstreamCandidatesException",
+          "class io.smallrye.reactive.messaging.locals.UnsatisfiedBroadcastException",
+          "class io.smallrye.reactive.messaging.locals.Wiring",
+          "class io.smallrye.reactive.messaging.locals.WiringException"
+      ]
     }
   }
 }, {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
@@ -9,13 +9,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 import java.util.function.Function;
 
 import jakarta.enterprise.inject.Instance;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -162,7 +162,7 @@ public abstract class AbstractMediator {
         return configuration.methodAsString();
     }
 
-    public Subscriber<Message<?>> getComputedSubscriber() {
+    public Flow.Subscriber<Message<?>> getComputedSubscriber() {
         return null;
     }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/DefaultMediatorConfiguration.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/DefaultMediatorConfiguration.java
@@ -63,6 +63,8 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
      */
     private boolean useBuilderTypes = false;
 
+    private boolean useReactiveStreams = false;
+
     /**
      * The merge policy.
      */
@@ -141,9 +143,8 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
                 this.acknowledgment);
         this.production = validationOutput.getProduction();
         this.consumption = validationOutput.getConsumption();
-        if (validationOutput.getUseBuilderTypes()) {
-            this.useBuilderTypes = validationOutput.getUseBuilderTypes();
-        }
+        this.useBuilderTypes = validationOutput.getUseBuilderTypes();
+        this.useReactiveStreams = validationOutput.getUseReactiveStreams();
         if (this.acknowledgment == null) {
             this.acknowledgment = this.mediatorConfigurationSupport.processDefaultAcknowledgement(this.shape, this.consumption,
                     this.production);
@@ -217,6 +218,11 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
     @Override
     public boolean usesBuilderTypes() {
         return useBuilderTypes;
+    }
+
+    @Override
+    public boolean usesReactiveStreams() {
+        return useReactiveStreams;
     }
 
     @Override

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MediatorConfigurationSupport.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MediatorConfigurationSupport.java
@@ -6,6 +6,7 @@ import static io.smallrye.reactive.messaging.providers.i18n.ProviderLogging.log;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
@@ -43,8 +44,8 @@ public class MediatorConfigurationSupport {
 
     public Shape determineShape(List<?> incomingValue, Object outgoingValue) {
         if (!incomingValue.isEmpty() && outgoingValue != null) {
-            if (isPublisherOrPublisherBuilder(returnType)
-                    && isConsumingAPublisherOrAPublisherBuilder(parameterTypes)) {
+            if (isPublisherOrReactiveStreamsPublisherOrPublisherBuilder(returnType)
+                    && isConsumingAPublisherOrReactiveStreamsPublisherOrAPublisherBuilder(parameterTypes)) {
                 return Shape.STREAM_TRANSFORMER;
             } else {
                 return Shape.PROCESSOR;
@@ -56,16 +57,18 @@ public class MediatorConfigurationSupport {
         }
     }
 
-    private boolean isPublisherOrPublisherBuilder(Class<?> returnType) {
-        return ClassUtils.isAssignable(returnType, Publisher.class)
+    private boolean isPublisherOrReactiveStreamsPublisherOrPublisherBuilder(Class<?> returnType) {
+        return ClassUtils.isAssignable(returnType, Flow.Publisher.class)
+                || ClassUtils.isAssignable(returnType, Publisher.class)
                 || ClassUtils.isAssignable(returnType, PublisherBuilder.class);
     }
 
-    private boolean isConsumingAPublisherOrAPublisherBuilder(Class<?>[] parameterTypes) {
+    private boolean isConsumingAPublisherOrReactiveStreamsPublisherOrAPublisherBuilder(Class<?>[] parameterTypes) {
         if (parameterTypes.length >= 1) {
             Class<?> type = parameterTypes[0];
-            return ClassUtils.isAssignable(type, Publisher.class) || ClassUtils
-                    .isAssignable(type, PublisherBuilder.class);
+            return ClassUtils.isAssignable(type, Flow.Publisher.class)
+                    || ClassUtils.isAssignable(type, Publisher.class)
+                    || ClassUtils.isAssignable(type, PublisherBuilder.class);
         }
         return false;
     }
@@ -100,14 +103,15 @@ public class MediatorConfigurationSupport {
         final MediatorConfiguration.Production production = MediatorConfiguration.Production.NONE;
 
         // Supported signatures:
-        // 1. Subscriber<Message<I>> method() or SubscriberBuilder<Message<I>, ?> method()
-        // 2. Subscriber<I> method() or SubscriberBuilder<I, ?> method()
+        // 1. Flow.Subscriber<Message<I>> method() or Subscriber<Message<I>> method() or SubscriberBuilder<Message<I>, ?> method()
+        // 2. Flow.Subscriber<I> method() or Subscriber<I> method() or SubscriberBuilder<I, ?> method()
         // 3. CompletionStage<Void> method(Message<I> m) - generic parameter must be Void, + Uni variant
         // 4. CompletionStage<Void> method(I i) - generic parameter must be Void, + Uni variant
         // 5. void/? method(Message<I> m) - this signature has been dropped as it forces blocking acknowledgment. Recommendation: use case 3.
         // 6. void method(I i) - return must ve void
 
-        if (ClassUtils.isAssignable(returnType, Subscriber.class)
+        if (ClassUtils.isAssignable(returnType, Flow.Subscriber.class)
+                || ClassUtils.isAssignable(returnType, Subscriber.class)
                 || ClassUtils.isAssignable(returnType, SubscriberBuilder.class)) {
             // Case 1 or 2.
             // Validation -> No parameter
@@ -129,12 +133,13 @@ public class MediatorConfigurationSupport {
                 payloadType = returnTypeAssignable.getType(0);
             }
 
-            boolean builder = ClassUtils.isAssignable(returnType, SubscriberBuilder.class);
+            boolean useBuilderType = ClassUtils.isAssignable(returnType, SubscriberBuilder.class);
+            boolean useReactiveStreams = ClassUtils.isAssignable(returnType, Subscriber.class);
             if (payloadType == null) {
                 log.unableToExtractIngestedPayloadType(methodAsString,
                         "Cannot extract the type from the method signature");
             }
-            return new ValidationOutput(production, consumption, builder, payloadType);
+            return new ValidationOutput(production, consumption, useBuilderType, useReactiveStreams, payloadType);
         }
 
         if (ClassUtils.isAssignable(returnType, CompletionStage.class)) {
@@ -218,10 +223,8 @@ public class MediatorConfigurationSupport {
         final MediatorConfiguration.Consumption consumption = MediatorConfiguration.Consumption.NONE;
 
         // Supported signatures:
-        // 1. Publisher<Message<O>> method()
-        // 2. Publisher<O> method()
-        // 3. PublisherBuilder<Message<O>> method()
-        // 4. PublisherBuilder<O> method()
+        // 1. Flow.Publisher<Message<O>> method(), Publisher<Message<O>>, PublisherBuilder<Message<O>>
+        // 2. Flow.Publisher<O> method(), Publisher<O>, PublisherBuilder<O>
         // 5. O method() O cannot be Void
         // 6. Message<O> method()
         // 7. CompletionStage<Message<O>> method(), Uni<Message<O>>
@@ -235,10 +238,12 @@ public class MediatorConfigurationSupport {
             throw ex.definitionNoParametersExpected("@Outgoing", methodAsString);
         }
 
-        if (ClassUtils.isAssignable(returnType, Publisher.class)) {
+        if (ClassUtils.isAssignable(returnType, Flow.Publisher.class)
+                || ClassUtils.isAssignable(returnType, Publisher.class)
+                || ClassUtils.isAssignable(returnType, PublisherBuilder.class)) {
             GenericTypeAssignable.Result assignableToMessageCheck = returnTypeAssignable.check(Message.class, 0);
             if (assignableToMessageCheck == GenericTypeAssignable.Result.NotGeneric) {
-                throw ex.definitionMustDeclareParam("@Outgoing", methodAsString, "Publisher");
+                throw ex.definitionMustDeclareParam("@Outgoing", methodAsString, returnType.getSimpleName());
             }
 
             // Case 1 or 2
@@ -246,21 +251,10 @@ public class MediatorConfigurationSupport {
                     assignableToMessageCheck == GenericTypeAssignable.Result.Assignable
                             ? MediatorConfiguration.Production.STREAM_OF_MESSAGE
                             : MediatorConfiguration.Production.STREAM_OF_PAYLOAD,
-                    consumption, null);
-        }
-
-        if (ClassUtils.isAssignable(returnType, PublisherBuilder.class)) {
-            GenericTypeAssignable.Result assignableToMessageCheck = returnTypeAssignable.check(Message.class, 0);
-            if (assignableToMessageCheck == GenericTypeAssignable.Result.NotGeneric) {
-                throw ex.definitionMustDeclareParam("@Outgoing", methodAsString, "PublisherBuilder");
-            }
-
-            // Case 3 or 4
-            return new ValidationOutput(
-                    assignableToMessageCheck == GenericTypeAssignable.Result.Assignable
-                            ? MediatorConfiguration.Production.STREAM_OF_MESSAGE
-                            : MediatorConfiguration.Production.STREAM_OF_PAYLOAD,
-                    consumption, true, null);
+                    consumption,
+                    ClassUtils.isAssignable(returnType, PublisherBuilder.class),
+                    ClassUtils.isAssignable(returnType, Publisher.class),
+                    null);
         }
 
         if (ClassUtils.isAssignable(returnType, Message.class)) {
@@ -320,9 +314,11 @@ public class MediatorConfigurationSupport {
         MediatorConfiguration.Production production;
         MediatorConfiguration.Consumption consumption;
         boolean useBuilderTypes = false;
+        boolean useReactiveStreams = false;
         Type payloadType;
 
-        if (ClassUtils.isAssignable(returnType, Processor.class)
+        if (ClassUtils.isAssignable(returnType, Flow.Processor.class)
+                || ClassUtils.isAssignable(returnType, Processor.class)
                 || ClassUtils.isAssignable(returnType, ProcessorBuilder.class)) {
             // Case 1, 2 or 3, 4
 
@@ -352,8 +348,10 @@ public class MediatorConfigurationSupport {
                     : MediatorConfiguration.Production.STREAM_OF_PAYLOAD;
 
             useBuilderTypes = ClassUtils.isAssignable(returnType, ProcessorBuilder.class);
+            useReactiveStreams = ClassUtils.isAssignable(returnType, Processor.class);
 
-        } else if (ClassUtils.isAssignable(returnType, Publisher.class)
+        } else if (ClassUtils.isAssignable(returnType, Flow.Publisher.class)
+                || ClassUtils.isAssignable(returnType, Publisher.class)
                 || ClassUtils.isAssignable(returnType, PublisherBuilder.class)) {
             // Case 5, 6, 7, 8
             if (parameterTypes.length != 1) {
@@ -376,6 +374,7 @@ public class MediatorConfigurationSupport {
                     parameterTypes[0]);
 
             useBuilderTypes = ClassUtils.isAssignable(returnType, PublisherBuilder.class);
+            useReactiveStreams = ClassUtils.isAssignable(returnType, Publisher.class);
         } else {
             // Case 9, 10, 11, 12
             Class<?> param = parameterTypes[0];
@@ -429,7 +428,7 @@ public class MediatorConfigurationSupport {
             throw ex.illegalStateForValidateProcessor(methodAsString);
         }
 
-        return new ValidationOutput(production, consumption, useBuilderTypes, payloadType);
+        return new ValidationOutput(production, consumption, useBuilderTypes, useReactiveStreams, payloadType);
     }
 
     private Type extractIngestedTypeFromFirstParameter(MediatorConfiguration.Consumption consumption,
@@ -458,12 +457,13 @@ public class MediatorConfigurationSupport {
         MediatorConfiguration.Production production;
         MediatorConfiguration.Consumption consumption;
         boolean useBuilderTypes;
+        boolean useReactiveStreams;
         Type payloadType;
 
         // The mediator produces and consumes a stream
         GenericTypeAssignable.Result returnTypeGenericCheck = returnTypeAssignable.check(Message.class, 0);
         if (returnTypeGenericCheck == GenericTypeAssignable.Result.NotGeneric) {
-            throw ex.definitionExpectedReturnedParam("@Outgoing", methodAsString, "Publisher");
+            throw ex.definitionExpectedReturnedParam("@Outgoing", methodAsString, returnType.getSimpleName());
         }
         production = returnTypeGenericCheck == GenericTypeAssignable.Result.Assignable
                 ? MediatorConfiguration.Production.STREAM_OF_MESSAGE
@@ -472,13 +472,14 @@ public class MediatorConfigurationSupport {
         GenericTypeAssignable.Result firstParamTypeGenericCheck = firstMethodParamTypeAssignable
                 .check(Message.class, 0);
         if (firstParamTypeGenericCheck == GenericTypeAssignable.Result.NotGeneric) {
-            throw ex.definitionExpectedConsumedParam("@Incoming", methodAsString, "Publisher");
+            throw ex.definitionExpectedConsumedParam("@Incoming", methodAsString, parameterTypes[0].getSimpleName());
         }
         consumption = firstParamTypeGenericCheck == GenericTypeAssignable.Result.Assignable
                 ? MediatorConfiguration.Consumption.STREAM_OF_MESSAGE
                 : MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD;
 
         useBuilderTypes = ClassUtils.isAssignable(returnType, PublisherBuilder.class);
+        useReactiveStreams = ClassUtils.isAssignable(returnType, Publisher.class);
 
         // Post Acknowledgement is not supported
         if (acknowledgment == Acknowledgment.Strategy.POST_PROCESSING) {
@@ -512,13 +513,21 @@ public class MediatorConfigurationSupport {
             }
         }
 
+        if (useReactiveStreams) {
+            // Ensure that the parameter is also using the ReactiveStreams type.
+            Class<?> paramClass = parameterTypes[0];
+            if (!ClassUtils.isAssignable(paramClass, Publisher.class)) {
+                throw ex.definitionProduceConsume("@Incoming & @Outgoing", methodAsString);
+            }
+        }
+
         // TODO Ensure that the parameter is also a publisher builder.
 
         if (payloadType == null) {
             log.unableToExtractIngestedPayloadType(methodAsString, "Cannot extract the type from the method signature");
         }
 
-        return new ValidationOutput(production, consumption, useBuilderTypes, payloadType);
+        return new ValidationOutput(production, consumption, useBuilderTypes, useReactiveStreams, payloadType);
     }
 
     public Acknowledgment.Strategy processDefaultAcknowledgement(Shape shape,
@@ -612,19 +621,21 @@ public class MediatorConfigurationSupport {
         private final MediatorConfiguration.Production production;
         private final MediatorConfiguration.Consumption consumption;
         private final boolean useBuilderTypes;
+        private final boolean useReactiveStreams;
         private final Type ingestedPayloadType;
 
         public ValidationOutput(MediatorConfiguration.Production production,
                 MediatorConfiguration.Consumption consumption, Type ingestedPayloadType) {
-            this(production, consumption, false, ingestedPayloadType);
+            this(production, consumption, false, false, ingestedPayloadType);
         }
 
         public ValidationOutput(MediatorConfiguration.Production production,
                 MediatorConfiguration.Consumption consumption,
-                boolean useBuilderTypes, Type ingestedPayloadType) {
+                boolean useBuilderTypes, boolean useReactiveStreams, Type ingestedPayloadType) {
             this.production = production;
             this.consumption = consumption;
             this.useBuilderTypes = useBuilderTypes;
+            this.useReactiveStreams = useReactiveStreams;
             this.ingestedPayloadType = ingestedPayloadType;
         }
 
@@ -642,6 +653,10 @@ public class MediatorConfigurationSupport {
 
         public Type getIngestedPayloadType() {
             return ingestedPayloadType;
+        }
+
+        public boolean getUseReactiveStreams() {
+            return useReactiveStreams;
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/AbstractEmitter.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/AbstractEmitter.java
@@ -2,12 +2,12 @@ package io.smallrye.reactive.messaging.providers.extension;
 
 import static io.smallrye.reactive.messaging.providers.i18n.ProviderExceptions.ex;
 
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.subscription.BackPressureStrategy;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/LegacyEmitterImpl.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/LegacyEmitterImpl.java
@@ -2,8 +2,9 @@ package io.smallrye.reactive.messaging.providers.extension;
 
 import static io.smallrye.reactive.messaging.providers.i18n.ProviderExceptions.ex;
 
+import java.util.concurrent.Flow.Publisher;
+
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.reactive.messaging.MessagePublisherProvider;
 import io.smallrye.reactive.messaging.annotations.Emitter;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ReactiveMessagingExtension.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ReactiveMessagingExtension.java
@@ -6,6 +6,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Instance;
@@ -59,7 +60,15 @@ public class ReactiveMessagingExtension implements Extension {
         workerPoolBeans.add(new WorkerPoolBean<>(annotatedType));
     }
 
-    <T extends Publisher<?>> void processStreamPublisherInjectionPoint(@Observes ProcessInjectionPoint<?, T> pip) {
+    <T extends Flow.Publisher<?>> void processStreamPublisherInjectionPoint(@Observes ProcessInjectionPoint<?, T> pip) {
+        Channel stream = ChannelProducer.getChannelQualifier(pip.getInjectionPoint());
+        if (stream != null) {
+            streamInjectionPoints.add(pip.getInjectionPoint());
+        }
+    }
+
+    <T extends Publisher<?>> void processStreamReactiveStreamPublisherInjectionPoint(
+            @Observes ProcessInjectionPoint<?, T> pip) {
         Channel stream = ChannelProducer.getChannelQualifier(pip.getInjectionPoint());
         if (stream != null) {
             streamInjectionPoints.add(pip.getInjectionPoint());

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/IgnoringSubscriber.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/IgnoringSubscriber.java
@@ -1,8 +1,9 @@
 package io.smallrye.reactive.messaging.providers.helpers;
 
+import java.util.concurrent.Flow;
+import java.util.concurrent.Flow.Subscriber;
+
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
 public class IgnoringSubscriber implements Subscriber<Message<?>> {
 
@@ -13,7 +14,7 @@ public class IgnoringSubscriber implements Subscriber<Message<?>> {
     }
 
     @Override
-    public void onSubscribe(Subscription subscription) {
+    public void onSubscribe(Flow.Subscription subscription) {
         subscription.request(Long.MAX_VALUE);
     }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/MultiUtils.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/MultiUtils.java
@@ -44,10 +44,14 @@ public class MultiUtils {
             return multi;
         }
         return multi.plug(stream -> (Multi) stream
-                .onItem().transformToUniAndConcatenate(message -> {
+                // Normally transformToUniAndConcatenate could be used, which doesn't prefetch.
+                // But TCK tests org.eclipse.microprofile.reactive.messaging.tck.channel.overflow.LatestOverflowStrategyTest
+                // and org.eclipse.microprofile.reactive.messaging.tck.channel.overflow.ThrowExceptionOverflowStrategyOverflowTest
+                // wouldn't pass without prefetching.
+                .onItem().transformToUni(message -> {
                     CompletionStage<Void> ack = message.ack();
                     return Uni.createFrom().completionStage(ack).map(x -> message);
-                }));
+                }).concatenate(true));
     }
 
     @SuppressWarnings({ "unchecked" })

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderExceptions.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderExceptions.java
@@ -202,8 +202,8 @@ public interface ProviderExceptions {
     @Message(id = 60, value = "Invalid method annotated with %s: %s - Consuming a stream of payload is not supported with MANUAL acknowledgment. Use a Publisher<Message<I>> or PublisherBuilder<Message<I>> instead.")
     DefinitionException definitionManualAckNotSupported(String annotation, String methodAsString);
 
-    @Message(id = 61, value = "Invalid method annotated with %s: %s - If the method produces a PublisherBuilder, it needs to consume a PublisherBuilder.")
-    DefinitionException definitionProduceConsume(String annotation, String methodAsString);
+    @Message(id = 61, value = "Invalid method annotated with %s: %s - If the method produces a %s, it needs to consume the same type.")
+    DefinitionException definitionProduceConsume(String annotation, String methodAsString, String expectedType);
 
     @Message(id = 62, value = "Invalid method annotated with %s: %s - The @Merge annotation is only supported for method annotated with @Incoming")
     DefinitionException definitionMergeOnlyIncoming(String annotation, String methodAsString);

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderExceptions.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderExceptions.java
@@ -74,7 +74,7 @@ public interface ProviderExceptions {
     @Message(id = 14, value = "%s")
     WeavingException weavingForIncoming(List<String> incoming, @Cause Throwable cause);
 
-    @Message(id = 15, value = "Invalid return type: %s - expected a Subscriber or a SubscriberBuilder")
+    @Message(id = 15, value = "Invalid return type: %s - expected a Flow.Subscriber, org.reactivestreams.Subscriber or a SubscriberBuilder")
     IllegalStateException illegalStateExceptionForSubscriberOrSubscriberBuilder(String resultClassName);
 
     @Message(id = 16, value = "Failed to create Worker for %s")

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConfiguredChannelFactory.java
@@ -5,6 +5,7 @@ import static io.smallrye.reactive.messaging.providers.i18n.ProviderExceptions.e
 import static io.smallrye.reactive.messaging.providers.i18n.ProviderLogging.log;
 
 import java.util.*;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
@@ -14,8 +15,6 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.*;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.ChannelRegistar;
@@ -161,7 +160,7 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
         return config.getValue("connector", String.class);
     }
 
-    private Publisher<? extends Message<?>> createPublisher(String name, Config config) {
+    private Flow.Publisher<? extends Message<?>> createPublisher(String name, Config config) {
         // Extract the type and throw an exception if missing
         String connector = getConnectorAttribute(config);
 
@@ -179,7 +178,7 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
         return publisher;
     }
 
-    private Subscriber<? extends Message<?>> createSubscriber(String name, Config config) {
+    private Flow.Subscriber<? extends Message<?>> createSubscriber(String name, Config config) {
         // Extract the type and throw an exception if missing
         String connector = getConnectorAttribute(config);
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConnectorFactories.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConnectorFactories.java
@@ -17,6 +17,7 @@ import org.eclipse.microprofile.reactive.messaging.spi.OutgoingConnectorFactory;
 import io.smallrye.reactive.messaging.connector.InboundConnector;
 import io.smallrye.reactive.messaging.connector.OutboundConnector;
 import io.smallrye.reactive.messaging.providers.i18n.ProviderExceptions;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class ConnectorFactories {
@@ -77,11 +78,11 @@ public class ConnectorFactories {
     }
 
     private InboundConnector wrap(IncomingConnectorFactory cf) {
-        return config -> cf.getPublisherBuilder(config).buildRs();
+        return config -> AdaptersToFlow.publisher(cf.getPublisherBuilder(config).buildRs());
     }
 
     private OutboundConnector wrap(OutgoingConnectorFactory cf) {
-        return config -> cf.getSubscriberBuilder(config).build();
+        return config -> AdaptersToFlow.subscriber(cf.getSubscriberBuilder(config).build());
     }
 
     /**

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/InternalChannelRegistry.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/InternalChannelRegistry.java
@@ -3,14 +3,13 @@ package io.smallrye.reactive.messaging.providers.impl;
 import static io.smallrye.reactive.messaging.providers.i18n.ProviderMessages.msg;
 
 import java.util.*;
+import java.util.concurrent.Flow;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.reactive.messaging.ChannelRegistry;
 import io.smallrye.reactive.messaging.MutinyEmitter;
@@ -18,8 +17,8 @@ import io.smallrye.reactive.messaging.MutinyEmitter;
 @ApplicationScoped
 public class InternalChannelRegistry implements ChannelRegistry {
 
-    private final Map<String, List<Publisher<? extends Message<?>>>> publishers = new HashMap<>();
-    private final Map<String, List<Subscriber<? extends Message<?>>>> subscribers = new HashMap<>();
+    private final Map<String, List<Flow.Publisher<? extends Message<?>>>> publishers = new HashMap<>();
+    private final Map<String, List<Flow.Subscriber<? extends Message<?>>>> subscribers = new HashMap<>();
 
     private final Map<String, Boolean> outgoing = new HashMap<>();
     private final Map<String, Boolean> incoming = new HashMap<>();
@@ -27,8 +26,8 @@ public class InternalChannelRegistry implements ChannelRegistry {
     private final Map<Class<?>, Map<String, Object>> emitters = new HashMap<>();
 
     @Override
-    public Publisher<? extends Message<?>> register(String name,
-            Publisher<? extends Message<?>> stream, boolean broadcast) {
+    public Flow.Publisher<? extends Message<?>> register(String name,
+            Flow.Publisher<? extends Message<?>> stream, boolean broadcast) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         Objects.requireNonNull(stream, msg.streamMustBeSet());
         register(publishers, name, stream);
@@ -37,8 +36,8 @@ public class InternalChannelRegistry implements ChannelRegistry {
     }
 
     @Override
-    public synchronized Subscriber<? extends Message<?>> register(String name,
-            Subscriber<? extends Message<?>> subscriber, boolean merge) {
+    public synchronized Flow.Subscriber<? extends Message<?>> register(String name,
+            Flow.Subscriber<? extends Message<?>> subscriber, boolean merge) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         Objects.requireNonNull(subscriber, msg.subscriberMustBeSet());
         register(subscribers, name, subscriber);
@@ -69,7 +68,7 @@ public class InternalChannelRegistry implements ChannelRegistry {
     }
 
     @Override
-    public synchronized List<Publisher<? extends Message<?>>> getPublishers(String name) {
+    public synchronized List<Flow.Publisher<? extends Message<?>>> getPublishers(String name) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         return publishers.getOrDefault(name, Collections.emptyList());
     }
@@ -98,7 +97,7 @@ public class InternalChannelRegistry implements ChannelRegistry {
     }
 
     @Override
-    public synchronized List<Subscriber<? extends Message<?>>> getSubscribers(String name) {
+    public synchronized List<Flow.Subscriber<? extends Message<?>>> getSubscribers(String name) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         return subscribers.getOrDefault(name, Collections.emptyList());
     }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
@@ -3,6 +3,8 @@ package io.smallrye.reactive.messaging.providers.wiring;
 import static io.smallrye.reactive.messaging.providers.helpers.CDIUtils.getSortedInstances;
 
 import java.util.*;
+import java.util.concurrent.Flow;
+import java.util.concurrent.Flow.Publisher;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.PreDestroy;
@@ -13,8 +15,6 @@ import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.ChannelRegistry;
@@ -380,7 +380,7 @@ public class Wiring {
                 merged = Multi.createBy().merging().streams(publishers.stream().map(p -> p).collect(Collectors.toList()));
             }
             // TODO Improve this.
-            Subscriber connector = registry.getSubscribers(name).get(0);
+            Flow.Subscriber connector = registry.getSubscribers(name).get(0);
             for (SubscriberDecorator decorator : getSortedInstances(subscriberDecorators)) {
                 merged = decorator.decorate(merged, Collections.singletonList(name), true);
             }
@@ -649,7 +649,7 @@ public class Wiring {
 
             mediator.connectToUpstream(aggregates);
 
-            Subscriber<Message<?>> subscriber = mediator.getComputedSubscriber();
+            Flow.Subscriber<Message<?>> subscriber = mediator.getComputedSubscriber();
             incomings().forEach(s -> registry.register(s, subscriber, merge()));
 
             mediator.run();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MyBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MyBean.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -10,7 +11,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
@@ -36,7 +36,7 @@ public class MyBean {
     }
 
     @Outgoing("my-dummy-stream")
-    Publisher<Message<String>> stream() {
+    Flow.Publisher<Message<String>> stream() {
         return Multi.createFrom().items("foo", "bar").map(Message::of);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MyCollector.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MyCollector.java
@@ -3,6 +3,7 @@ package io.smallrye.reactive.messaging;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -12,7 +13,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -52,7 +52,7 @@ public class MyCollector {
     }
 
     @Outgoing("count")
-    public Publisher<Message<Integer>> source() {
+    public Flow.Publisher<Message<Integer>> source() {
         return Multi.createFrom().range(0, 10)
                 .map(Message::of);
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ProcessorShapeReturningProcessorTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ProcessorShapeReturningProcessorTest.java
@@ -8,8 +8,18 @@ import io.smallrye.reactive.messaging.beans.BeanProducingAProcessorBuilderOfMess
 import io.smallrye.reactive.messaging.beans.BeanProducingAProcessorBuilderOfPayloads;
 import io.smallrye.reactive.messaging.beans.BeanProducingAProcessorOfMessages;
 import io.smallrye.reactive.messaging.beans.BeanProducingAProcessorOfPayloads;
+import io.smallrye.reactive.messaging.beans.BeanProducingARSProcessorOfMessages;
+import io.smallrye.reactive.messaging.beans.BeanProducingARSProcessorOfPayloads;
 
 public class ProcessorShapeReturningProcessorTest extends WeldTestBase {
+
+    @Test
+    public void testBeanProducingARSProcessorOfMessages() {
+        addBeanClass(BeanProducingARSProcessorOfMessages.class);
+        initialize();
+        MyCollector collector = container.select(MyCollector.class).get();
+        assertThat(collector.payloads()).isEqualTo(EXPECTED);
+    }
 
     @Test
     public void testBeanProducingAProcessorOfMessages() {
@@ -30,6 +40,14 @@ public class ProcessorShapeReturningProcessorTest extends WeldTestBase {
     @Test
     public void testBeanProducingAProcessorOfPayloads() {
         addBeanClass(BeanProducingAProcessorOfPayloads.class);
+        initialize();
+        MyCollector collector = container.select(MyCollector.class).get();
+        assertThat(collector.payloads()).isEqualTo(EXPECTED);
+    }
+
+    @Test
+    public void testBeanProducingARSProcessorOfPayloads() {
+        addBeanClass(BeanProducingARSProcessorOfPayloads.class);
         initialize();
         MyCollector collector = container.select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/PublisherShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/PublisherShapeTest.java
@@ -6,6 +6,7 @@ import static org.awaitility.Awaitility.await;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.se.SeContainer;
@@ -15,7 +16,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.beans.*;
@@ -129,7 +129,7 @@ public class PublisherShapeTest extends WeldTestBaseWithoutTails {
         addBeanClass(InfiniteSubscriber.class);
         initialize();
 
-        List<Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
+        List<Flow.Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
         assertThat(producer).isNotEmpty();
         InfiniteSubscriber subscriber = get(InfiniteSubscriber.class);
         await().until(() -> subscriber.list().size() == 4);
@@ -142,7 +142,7 @@ public class PublisherShapeTest extends WeldTestBaseWithoutTails {
         addBeanClass(InfiniteSubscriber.class);
         initialize();
 
-        List<Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
+        List<Flow.Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
         assertThat(producer).isNotEmpty();
         InfiniteSubscriber subscriber = get(InfiniteSubscriber.class);
         await().until(() -> subscriber.list().size() == 4);
@@ -155,7 +155,7 @@ public class PublisherShapeTest extends WeldTestBaseWithoutTails {
         addBeanClass(InfiniteSubscriber.class);
         initialize();
 
-        List<Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
+        List<Flow.Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
         assertThat(producer).isNotEmpty();
         InfiniteSubscriber subscriber = get(InfiniteSubscriber.class);
         await().until(() -> subscriber.list().size() == 4);
@@ -169,7 +169,7 @@ public class PublisherShapeTest extends WeldTestBaseWithoutTails {
         addBeanClass(InfiniteSubscriber.class);
         initialize();
 
-        List<Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
+        List<Flow.Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
         assertThat(producer).isNotEmpty();
 
         InfiniteSubscriber subscriber = get(InfiniteSubscriber.class);
@@ -206,7 +206,7 @@ public class PublisherShapeTest extends WeldTestBaseWithoutTails {
 
     private void assertThatProducerWasPublished(SeContainer container) {
         assertThat(registry(container).getIncomingNames()).contains("producer");
-        List<Publisher<? extends Message<?>>> producer = registry(container).getPublishers("producer");
+        List<Flow.Publisher<? extends Message<?>>> producer = registry(container).getPublishers("producer");
         assertThat(producer).isNotEmpty();
         List<String> list = Multi.createFrom().publisher(producer.get(0)).map(Message::getPayload)
                 .map(i -> (String) i)

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/PublisherShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/PublisherShapeTest.java
@@ -68,8 +68,24 @@ public class PublisherShapeTest extends WeldTestBaseWithoutTails {
     }
 
     @Test
+    public void testBeanProducingMessagesAsRSPublisher() {
+        addBeanClass(BeanProducingMessagesAsRSPublisher.class);
+        initialize();
+        CollectorOnly collector = container.select(CollectorOnly.class).get();
+        assertThat(collector.payloads()).isEqualTo(EXPECTED);
+    }
+
+    @Test
     public void testBeanProducingPayloadsAsPublisher() {
         addBeanClass(BeanProducingPayloadAsPublisher.class);
+        initialize();
+        CollectorOnly collector = container.select(CollectorOnly.class).get();
+        assertThat(collector.payloads()).isEqualTo(EXPECTED);
+    }
+
+    @Test
+    public void testBeanProducingPayloadsAsRSPublisher() {
+        addBeanClass(BeanProducingPayloadAsRSPublisher.class);
         initialize();
         CollectorOnly collector = container.select(CollectorOnly.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
@@ -94,7 +110,15 @@ public class PublisherShapeTest extends WeldTestBaseWithoutTails {
     @Test
     public void testThatWeCanProducePublisherOfMessages() {
         addBeanClass(MyProducerSink.class);
-        addBeanClass(BeanReturningAPublisherBuilderOfItems.class);
+        addBeanClass(BeanReturningAPublisherOfMessages.class);
+        initialize();
+        assertThatProducerWasPublished(container);
+    }
+
+    @Test
+    public void testThatWeCanProduceRSPublisherOfMessages() {
+        addBeanClass(MyProducerSink.class);
+        addBeanClass(BeanReturningARSPublisherOfMessages.class);
         initialize();
         assertThatProducerWasPublished(container);
     }
@@ -110,7 +134,7 @@ public class PublisherShapeTest extends WeldTestBaseWithoutTails {
     @Test
     public void testThatWeCanProducePublisherOfItems() {
         addBeanClass(MyProducerSink.class);
-        addBeanClass(BeanReturningAPublisherBuilderOfItems.class);
+        addBeanClass(BeanReturningAPublisherOfItems.class);
         initialize();
         assertThatProducerWasPublished(container);
     }
@@ -119,6 +143,14 @@ public class PublisherShapeTest extends WeldTestBaseWithoutTails {
     public void testThatWeCanProducePublisherBuilderOfItems() {
         addBeanClass(MyProducerSink.class);
         addBeanClass(BeanReturningAPublisherBuilderOfItems.class);
+        initialize();
+        assertThatProducerWasPublished(container);
+    }
+
+    @Test
+    public void testThatWeCanProduceRSPublisherOfItems() {
+        addBeanClass(MyProducerSink.class);
+        addBeanClass(BeanReturningARSPublisherOfItems.class);
         initialize();
         assertThatProducerWasPublished(container);
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SourceOnly.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SourceOnly.java
@@ -1,13 +1,15 @@
 package io.smallrye.reactive.messaging;
 
+import java.util.concurrent.Flow.Publisher;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class SourceOnly {
@@ -18,7 +20,7 @@ public class SourceOnly {
         return Multi.createFrom().range(1, 11)
                 .map(i -> Integer.toString(i))
                 .map(Message::of)
-                .concatMap(m -> ReactiveStreams.of(m, m).buildRs());
+                .concatMap(m -> AdaptersToFlow.publisher(ReactiveStreams.of(m, m).buildRs()));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/StreamTransformerShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/StreamTransformerShapeTest.java
@@ -1,6 +1,9 @@
 package io.smallrye.reactive.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +38,18 @@ public class StreamTransformerShapeTest extends WeldTestBase {
     @Test
     public void testBeanConsumingMsgAsFlowableAndPublishingMsgAsPublisher() {
         addBeanClass(BeanConsumingMsgAsFlowableAndPublishingMsgAsPublisher.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testBeanConsumingMsgAsFlowableAndPublishingMsgAsPublisherBuilder() {
+        addBeanClass(BeanConsumingMsgAsFlowableAndPublishingMsgAsPublisherBuilder.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testBeanConsumingMsgAsFlowableAndPublishingMsgAsRSPublisher() {
+        addBeanClass(BeanConsumingMsgAsFlowableAndPublishingMsgAsRSPublisher.class);
         initialize();
         MyCollector collector = container.select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
@@ -51,6 +66,12 @@ public class StreamTransformerShapeTest extends WeldTestBase {
     @Test
     public void testBeanConsumingMsgAsFluxAndPublishingMsgAsPublisher() {
         addBeanClass(BeanConsumingMsgAsFluxAndPublishingMsgAsPublisher.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testBeanConsumingMsgAsFluxAndPublishingMsgAsRSPublisher() {
+        addBeanClass(BeanConsumingMsgAsFluxAndPublishingMsgAsRSPublisher.class);
         initialize();
         MyCollector collector = container.select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
@@ -59,6 +80,18 @@ public class StreamTransformerShapeTest extends WeldTestBase {
     @Test
     public void testBeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable() {
         addBeanClass(BeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testBeanConsumingMsgAsPublisherBuilderAndPublishingMsgAsFlowable() {
+        addBeanClass(BeanConsumingMsgAsPublisherBuilderAndPublishingMsgAsFlowable.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testBeanConsumingMsgAsRSPublisherAndPublishingMsgAsFlowable() {
+        addBeanClass(BeanConsumingMsgAsRSPublisherAndPublishingMsgAsFlowable.class);
         initialize();
         MyCollector collector = container.select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
@@ -73,6 +106,12 @@ public class StreamTransformerShapeTest extends WeldTestBase {
     }
 
     @Test
+    public void testBeanConsumingMsgAsRSPublisherAndPublishingMsgAsMulti() {
+        addBeanClass(BeanConsumingMsgAsRSPublisherAndPublishingMsgAsMulti.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
     public void testBeanConsumingMsgAsPublisherBuilderAndPublishingMsgAsPublisherBuilder() {
         addBeanClass(BeanConsumingMsgAsPublisherBuilderAndPublishingMsgAsPublisherBuilder.class);
         initialize();
@@ -83,6 +122,14 @@ public class StreamTransformerShapeTest extends WeldTestBase {
     @Test
     public void testBeanProducingAProcessor() {
         addBeanClass(BeanProducingAProcessorOfMessages.class);
+        initialize();
+        MyCollector collector = container.select(MyCollector.class).get();
+        assertThat(collector.payloads()).isEqualTo(EXPECTED);
+    }
+
+    @Test
+    public void testBeanProducingARSProcessor() {
+        addBeanClass(BeanProducingARSProcessorOfMessages.class);
         initialize();
         MyCollector collector = container.select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/StreamTransformerShapeWithPayloadsTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/StreamTransformerShapeWithPayloadsTest.java
@@ -1,6 +1,9 @@
 package io.smallrye.reactive.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +38,12 @@ public class StreamTransformerShapeWithPayloadsTest extends WeldTestBase {
     @Test
     public void testBeanConsumingItemAsFlowableAndPublishingItemAsPublisher() {
         addBeanClass(BeanConsumingItemAsFlowableAndPublishingItemAsPublisher.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testBeanConsumingItemAsFlowableAndPublishingItemAsRSPublisher() {
+        addBeanClass(BeanConsumingItemAsFlowableAndPublishingItemAsRSPublisher.class);
         initialize();
         MyCollector collector = container.getBeanManager().createInstance().select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
@@ -49,8 +58,20 @@ public class StreamTransformerShapeWithPayloadsTest extends WeldTestBase {
     }
 
     @Test
+    public void testBeanConsumingItemAsMultiAndPublishingItemAsRSPublisher() {
+        addBeanClass(BeanConsumingItemAsMultiAndPublishingItemAsRSPublisher.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
     public void testBeanConsumingItemAsFluxAndPublishingItemAsPublisher() {
         addBeanClass(BeanConsumingItemAsFluxAndPublishingItemAsPublisher.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testBeanConsumingItemAsFluxAndPublishingItemAsRSPublisher() {
+        addBeanClass(BeanConsumingItemAsFluxAndPublishingItemAsRSPublisher.class);
         initialize();
         MyCollector collector = container.getBeanManager().createInstance().select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
@@ -59,6 +80,12 @@ public class StreamTransformerShapeWithPayloadsTest extends WeldTestBase {
     @Test
     public void testBeanConsumingItemAsPublisherAndPublishingItemAsFlowable() {
         addBeanClass(BeanConsumingItemAsPublisherAndPublishingItemAsFlowable.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testBeanConsumingItemAsRSPublisherAndPublishingItemAsFlowable() {
+        addBeanClass(BeanConsumingItemAsRSPublisherAndPublishingItemAsFlowable.class);
         initialize();
         MyCollector collector = container.getBeanManager().createInstance().select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
@@ -70,6 +97,12 @@ public class StreamTransformerShapeWithPayloadsTest extends WeldTestBase {
         initialize();
         MyCollector collector = container.getBeanManager().createInstance().select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
+    }
+
+    @Test
+    public void testBeanConsumingItemAsRSPublisherAndPublishingItemAsMulti() {
+        addBeanClass(BeanConsumingItemAsRSPublisherAndPublishingItemAsMulti.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
     }
 
     @Test

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
@@ -6,6 +6,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.se.SeContainer;
@@ -14,7 +15,6 @@ import jakarta.enterprise.inject.spi.DeploymentException;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.beans.*;
@@ -151,7 +151,7 @@ public class SubscriberShapeTest extends WeldTestBaseWithoutTails {
 
     private void assertThatSubscriberWasPublished(SeContainer container) {
         assertThat(registry(container).getOutgoingNames()).contains("subscriber");
-        List<Subscriber<? extends Message<?>>> subscriber = registry(container).getSubscribers("subscriber");
+        List<Flow.Subscriber<? extends Message<?>>> subscriber = registry(container).getSubscribers("subscriber");
         assertThat(subscriber).isNotEmpty();
     }
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/SubscriberShapeTest.java
@@ -35,10 +35,26 @@ public class SubscriberShapeTest extends WeldTestBaseWithoutTails {
     }
 
     @Test
+    public void testBeanProducingARSSubscriberOfMessages() {
+        initializer.addBeanClasses(BeanReturningARSSubscriberOfMessages.class);
+        initialize();
+        BeanReturningARSSubscriberOfMessages collector = container.select(BeanReturningARSSubscriberOfMessages.class).get();
+        assertThat(collector.payloads()).isEqualTo(EXPECTED);
+    }
+
+    @Test
     public void testBeanProducingASubscriberOfPayloads() {
         initializer.addBeanClasses(BeanReturningASubscriberOfPayloads.class);
         initialize();
         BeanReturningASubscriberOfPayloads collector = container.select(BeanReturningASubscriberOfPayloads.class).get();
+        assertThat(collector.payloads()).isEqualTo(EXPECTED);
+    }
+
+    @Test
+    public void testBeanProducingARSSubscriberOfPayloads() {
+        initializer.addBeanClasses(BeanReturningARSSubscriberOfPayloads.class);
+        initialize();
+        BeanReturningARSSubscriberOfPayloads collector = container.select(BeanReturningARSSubscriberOfPayloads.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithMessageProcessors.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithMessageProcessors.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -117,7 +118,7 @@ public class BeanWithMessageProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToNoAck() {
+    public Flow.Publisher<Message<String>> sourceToNoAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -137,7 +138,7 @@ public class BeanWithMessageProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToAutoAck() {
+    public Flow.Publisher<Message<String>> sourceToAutoAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -157,7 +158,7 @@ public class BeanWithMessageProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPreAck() {
+    public Flow.Publisher<Message<String>> sourceToPreAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -195,7 +196,7 @@ public class BeanWithMessageProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToNoAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToNoAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -214,7 +215,7 @@ public class BeanWithMessageProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToAutoAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToAutoAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -233,7 +234,7 @@ public class BeanWithMessageProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToPreAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToPreAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithPayloadProcessors.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithPayloadProcessors.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -15,7 +16,6 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.ProcessorBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.reactivestreams.Processor;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 
@@ -81,7 +81,7 @@ public class BeanWithPayloadProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToNoAck() {
+    public Flow.Publisher<Message<String>> sourceToNoAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -100,7 +100,7 @@ public class BeanWithPayloadProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToAutoAck() {
+    public Flow.Publisher<Message<String>> sourceToAutoAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -120,7 +120,7 @@ public class BeanWithPayloadProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPreAck() {
+    public Flow.Publisher<Message<String>> sourceToPreAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -139,7 +139,7 @@ public class BeanWithPayloadProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToNoAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToNoAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -157,7 +157,7 @@ public class BeanWithPayloadProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToAutoAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToAutoAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -176,7 +176,7 @@ public class BeanWithPayloadProcessors extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToPreAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToPreAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsManipulatingMessages.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsManipulatingMessages.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.ack;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -85,7 +86,7 @@ public class BeanWithProcessorsManipulatingMessages extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToNoAck() {
+    public Flow.Publisher<Message<String>> sourceToNoAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -106,7 +107,7 @@ public class BeanWithProcessorsManipulatingMessages extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_CS)
-    public Publisher<Message<String>> sourceToNoAckCS() {
+    public Flow.Publisher<Message<String>> sourceToNoAckCS() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -127,7 +128,7 @@ public class BeanWithProcessorsManipulatingMessages extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_UNI)
-    public Publisher<Message<String>> sourceToNoAckUni() {
+    public Flow.Publisher<Message<String>> sourceToNoAckUni() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -145,7 +146,7 @@ public class BeanWithProcessorsManipulatingMessages extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPreAck() {
+    public Flow.Publisher<Message<String>> sourceToPreAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -163,7 +164,7 @@ public class BeanWithProcessorsManipulatingMessages extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT_CS)
-    public Publisher<Message<String>> sourceToPreAckCS() {
+    public Flow.Publisher<Message<String>> sourceToPreAckCS() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -181,7 +182,7 @@ public class BeanWithProcessorsManipulatingMessages extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT_UNI)
-    public Publisher<Message<String>> sourceToPreAckUni() {
+    public Flow.Publisher<Message<String>> sourceToPreAckUni() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -198,7 +199,7 @@ public class BeanWithProcessorsManipulatingMessages extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToDefaultAck() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -215,7 +216,7 @@ public class BeanWithProcessorsManipulatingMessages extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT_CS)
-    public Publisher<Message<String>> sourceToDefaultAckCS() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAckCS() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -234,7 +235,7 @@ public class BeanWithProcessorsManipulatingMessages extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT_UNI)
-    public Publisher<Message<String>> sourceToDefaultAckUni() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAckUni() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsManipulatingPayloads.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsManipulatingPayloads.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.ack;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -9,7 +10,6 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -114,7 +114,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToNoAck() {
+    public Flow.Publisher<Message<String>> sourceToNoAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -135,7 +135,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_CS)
-    public Publisher<Message<String>> sourceToNoAckCS() {
+    public Flow.Publisher<Message<String>> sourceToNoAckCS() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -155,7 +155,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_UNI)
-    public Publisher<Message<String>> sourceToNoAckUni() {
+    public Flow.Publisher<Message<String>> sourceToNoAckUni() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -173,7 +173,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPreAck() {
+    public Flow.Publisher<Message<String>> sourceToPreAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -191,7 +191,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT_CS)
-    public Publisher<Message<String>> sourceToPreAckCS() {
+    public Flow.Publisher<Message<String>> sourceToPreAckCS() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -209,7 +209,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT_UNI)
-    public Publisher<Message<String>> sourceToPreAckUNI() {
+    public Flow.Publisher<Message<String>> sourceToPreAckUNI() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -227,7 +227,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(POST_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPostAck() {
+    public Flow.Publisher<Message<String>> sourceToPostAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -245,7 +245,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(POST_ACKNOWLEDGMENT_CS)
-    public Publisher<Message<String>> sourceToPostCSAck() {
+    public Flow.Publisher<Message<String>> sourceToPostCSAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -263,7 +263,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(POST_ACKNOWLEDGMENT_UNI)
-    public Publisher<Message<String>> sourceToPostUNIAck() {
+    public Flow.Publisher<Message<String>> sourceToPostUNIAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -280,7 +280,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToDefaultAck() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -297,7 +297,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT_CS)
-    public Publisher<Message<String>> sourceToDefaultAckCS() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAckCS() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -314,7 +314,7 @@ public class BeanWithProcessorsManipulatingPayloads extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT_UNI)
-    public Publisher<Message<String>> sourceToDefaultAckUNI() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAckUNI() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsProducingMessageStreams.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsProducingMessageStreams.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.ack;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -128,7 +129,7 @@ public class BeanWithProcessorsProducingMessageStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToNoAck() {
+    public Flow.Publisher<Message<String>> sourceToNoAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -147,7 +148,7 @@ public class BeanWithProcessorsProducingMessageStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToNoAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToNoAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -167,7 +168,7 @@ public class BeanWithProcessorsProducingMessageStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPreAck() {
+    public Flow.Publisher<Message<String>> sourceToPreAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -186,7 +187,7 @@ public class BeanWithProcessorsProducingMessageStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToPreAckBuilder() {
+    public Flow.Publisher<Message<String>> sourceToPreAckBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -206,7 +207,7 @@ public class BeanWithProcessorsProducingMessageStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToDefaultAck() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -225,7 +226,7 @@ public class BeanWithProcessorsProducingMessageStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToDefaultAckBuilder() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAckBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsProducingPayloadStreams.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithProcessorsProducingPayloadStreams.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.ack;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -74,7 +75,7 @@ public class BeanWithProcessorsProducingPayloadStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToNoAck() {
+    public Flow.Publisher<Message<String>> sourceToNoAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -93,7 +94,7 @@ public class BeanWithProcessorsProducingPayloadStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToNoAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToNoAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -113,7 +114,7 @@ public class BeanWithProcessorsProducingPayloadStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPreAck() {
+    public Flow.Publisher<Message<String>> sourceToPreAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -132,7 +133,7 @@ public class BeanWithProcessorsProducingPayloadStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToPreAckBuilder() {
+    public Flow.Publisher<Message<String>> sourceToPreAckBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -151,7 +152,7 @@ public class BeanWithProcessorsProducingPayloadStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToDefaultAck() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -169,7 +170,7 @@ public class BeanWithProcessorsProducingPayloadStreams extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToDefaultAckBuilder() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAckBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithStreamTransformers.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/BeanWithStreamTransformers.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.ack;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -133,7 +134,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToNoAck() {
+    public Flow.Publisher<Message<String>> sourceToNoAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -152,7 +153,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToNoAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToNoAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -211,7 +212,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPreAck() {
+    public Flow.Publisher<Message<String>> sourceToPreAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -230,7 +231,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToPreAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToPreAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -264,7 +265,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToDefAck() {
+    public Flow.Publisher<Message<String>> sourceToDefAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -298,7 +299,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToDefaultAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -318,7 +319,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(PAYLOAD_NO_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToNoAckMessage() {
+    public Flow.Publisher<Message<String>> sourceToNoAckMessage() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -337,7 +338,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(PAYLOAD_NO_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToNoAckWithMessageBuilder() {
+    public Flow.Publisher<Message<String>> sourceToNoAckWithMessageBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -356,7 +357,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(PAYLOAD_DEFAULT_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPayloadDefAck() {
+    public Flow.Publisher<Message<String>> sourceToPayloadDefAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -374,7 +375,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(PAYLOAD_DEFAULT_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToDefaultWithPayloadAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToDefaultWithPayloadAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -394,7 +395,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(PAYLOAD_PRE_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPayloadPreAck() {
+    public Flow.Publisher<Message<String>> sourceToPayloadPreAck() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();
@@ -413,7 +414,7 @@ public class BeanWithStreamTransformers extends SpiedBeanHelper {
     }
 
     @Outgoing(PAYLOAD_PRE_ACKNOWLEDGMENT_BUILDER)
-    public Publisher<Message<String>> sourceToPreWithPayloadAckWithBuilder() {
+    public Flow.Publisher<Message<String>> sourceToPreWithPayloadAckWithBuilder() {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> {
                     nap();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SpiedBeanHelper.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SpiedBeanHelper.java
@@ -13,7 +13,6 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.Reception;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 
@@ -47,7 +46,7 @@ public class SpiedBeanHelper {
         executor.shutdownNow();
     }
 
-    protected Publisher<Message<String>> source(String id) {
+    protected Flow.Publisher<Message<String>> source(String id) {
         return Multi.createFrom().items("a", "b", "c", "d", "e")
                 .map(payload -> Message.of(payload, () -> CompletableFuture.runAsync(() -> {
                     nap();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningCompletionStage.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningCompletionStage.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.ack;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -9,7 +10,6 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 @ApplicationScoped
 public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBeanHelper {
@@ -36,7 +36,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     }
 
     @Outgoing(MANUAL_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToManualAck() {
+    public Flow.Publisher<Message<String>> sourceToManualAck() {
         return source(MANUAL_ACKNOWLEDGMENT);
     }
 
@@ -48,7 +48,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToNoAckMessage() {
+    public Flow.Publisher<Message<String>> sourceToNoAckMessage() {
         return source(NO_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -60,7 +60,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_PAYLOAD)
-    public Publisher<Message<String>> sourceToNoAckPayload() {
+    public Flow.Publisher<Message<String>> sourceToNoAckPayload() {
         return source(NO_ACKNOWLEDGMENT_PAYLOAD);
     }
 
@@ -71,7 +71,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     }
 
     @Outgoing(PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToPrePocessingMessage() {
+    public Flow.Publisher<Message<String>> sourceToPrePocessingMessage() {
         return source(PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -82,7 +82,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     }
 
     @Outgoing(PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
-    public Publisher<Message<String>> sourceToPrePocessingPayload() {
+    public Flow.Publisher<Message<String>> sourceToPrePocessingPayload() {
         return source(PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 
@@ -93,7 +93,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     }
 
     @Outgoing(POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToPostPocessingMessage() {
+    public Flow.Publisher<Message<String>> sourceToPostPocessingMessage() {
         return source(POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -104,7 +104,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     }
 
     @Outgoing(POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
-    public Publisher<Message<String>> sourceToPostPocessingPayload() {
+    public Flow.Publisher<Message<String>> sourceToPostPocessingPayload() {
         return source(POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 
@@ -116,7 +116,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     }
 
     @Outgoing(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToDefaultProcessingMessage() {
+    public Flow.Publisher<Message<String>> sourceToDefaultProcessingMessage() {
         return source(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -127,7 +127,7 @@ public class SubscriberBeanWithMethodsReturningCompletionStage extends SpiedBean
     }
 
     @Outgoing(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
-    public Publisher<Message<String>> defaultToPostProcessingPayload() {
+    public Flow.Publisher<Message<String>> defaultToPostProcessingPayload() {
         return source(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningSubscribers.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningSubscribers.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.ack;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
@@ -7,7 +9,6 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 @ApplicationScoped
@@ -37,7 +38,7 @@ public class SubscriberBeanWithMethodsReturningSubscribers extends SpiedBeanHelp
     }
 
     @Outgoing(MANUAL_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToManualAckWithMessage() {
+    public Flow.Publisher<Message<String>> sourceToManualAckWithMessage() {
         return source(MANUAL_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -53,7 +54,7 @@ public class SubscriberBeanWithMethodsReturningSubscribers extends SpiedBeanHelp
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToNoAckWithMessage() {
+    public Flow.Publisher<Message<String>> sourceToNoAckWithMessage() {
         return source(NO_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -69,7 +70,7 @@ public class SubscriberBeanWithMethodsReturningSubscribers extends SpiedBeanHelp
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_PAYLOAD)
-    public Publisher<Message<String>> sourceToNoAckWithPayload() {
+    public Flow.Publisher<Message<String>> sourceToNoAckWithPayload() {
         return source(NO_ACKNOWLEDGMENT_PAYLOAD);
     }
 
@@ -85,7 +86,7 @@ public class SubscriberBeanWithMethodsReturningSubscribers extends SpiedBeanHelp
     }
 
     @Outgoing(PRE_PROCESSING_ACK_MESSAGE)
-    public Publisher<Message<String>> sourceToPreAckWithMessage() {
+    public Flow.Publisher<Message<String>> sourceToPreAckWithMessage() {
         return source(PRE_PROCESSING_ACK_MESSAGE);
     }
 
@@ -101,7 +102,7 @@ public class SubscriberBeanWithMethodsReturningSubscribers extends SpiedBeanHelp
     }
 
     @Outgoing(PRE_PROCESSING_ACK_PAYLOAD)
-    public Publisher<Message<String>> sourceToPreAckWithPayload() {
+    public Flow.Publisher<Message<String>> sourceToPreAckWithPayload() {
         return source(PRE_PROCESSING_ACK_PAYLOAD);
     }
 
@@ -116,7 +117,7 @@ public class SubscriberBeanWithMethodsReturningSubscribers extends SpiedBeanHelp
     }
 
     @Outgoing(DEFAULT_PROCESSING_ACK_PAYLOAD)
-    public Publisher<Message<String>> sourceToDefaultAckWithPayload() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAckWithPayload() {
         return source(DEFAULT_PROCESSING_ACK_PAYLOAD);
     }
 
@@ -132,7 +133,7 @@ public class SubscriberBeanWithMethodsReturningSubscribers extends SpiedBeanHelp
     }
 
     @Outgoing(DEFAULT_PROCESSING_ACK_MESSAGE)
-    public Publisher<Message<String>> sourceToDefaultAckWithMessage() {
+    public Flow.Publisher<Message<String>> sourceToDefaultAckWithMessage() {
         return source(DEFAULT_PROCESSING_ACK_MESSAGE);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningUni.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningUni.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.ack;
 
 import java.time.Duration;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -8,7 +9,6 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Uni;
 
@@ -39,7 +39,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     }
 
     @Outgoing(MANUAL_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToManualAck() {
+    public Flow.Publisher<Message<String>> sourceToManualAck() {
         return source(MANUAL_ACKNOWLEDGMENT);
     }
 
@@ -54,7 +54,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToNoAckMessage() {
+    public Flow.Publisher<Message<String>> sourceToNoAckMessage() {
         return source(NO_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -67,7 +67,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT_PAYLOAD)
-    public Publisher<Message<String>> sourceToNoAckPayload() {
+    public Flow.Publisher<Message<String>> sourceToNoAckPayload() {
         return source(NO_ACKNOWLEDGMENT_PAYLOAD);
     }
 
@@ -80,7 +80,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToPreProcessingMessage() {
+    public Flow.Publisher<Message<String>> sourceToPreProcessingMessage() {
         return source(PRE_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -93,7 +93,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
-    public Publisher<Message<String>> sourceToPrePocessingPayload() {
+    public Flow.Publisher<Message<String>> sourceToPrePocessingPayload() {
         return source(PRE_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 
@@ -106,7 +106,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     }
 
     @Outgoing(POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToPostPocessingMessage() {
+    public Flow.Publisher<Message<String>> sourceToPostPocessingMessage() {
         return source(POST_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -119,7 +119,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     }
 
     @Outgoing(POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
-    public Publisher<Message<String>> sourceToPostProcessingPayload() {
+    public Flow.Publisher<Message<String>> sourceToPostProcessingPayload() {
         return source(POST_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 
@@ -132,7 +132,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE)
-    public Publisher<Message<String>> sourceToDefaultProcessingMessage() {
+    public Flow.Publisher<Message<String>> sourceToDefaultProcessingMessage() {
         return source(DEFAULT_PROCESSING_ACKNOWLEDGMENT_MESSAGE);
     }
 
@@ -144,7 +144,7 @@ public class SubscriberBeanWithMethodsReturningUni extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD)
-    public Publisher<Message<String>> defaultToPostProcessingPayload() {
+    public Flow.Publisher<Message<String>> defaultToPostProcessingPayload() {
         return source(DEFAULT_PROCESSING_ACKNOWLEDGMENT_PAYLOAD);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningVoid.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ack/SubscriberBeanWithMethodsReturningVoid.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.ack;
 
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -8,7 +9,6 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 /**
  * It is not supported to return `void` or an object (that it not a CompletionStage) when consuming a Message. So, we are
@@ -34,7 +34,7 @@ public class SubscriberBeanWithMethodsReturningVoid extends SpiedBeanHelper {
     }
 
     @Outgoing(MANUAL_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToManualAck() {
+    public Flow.Publisher<Message<String>> sourceToManualAck() {
         return source(MANUAL_ACKNOWLEDGMENT);
     }
 
@@ -45,7 +45,7 @@ public class SubscriberBeanWithMethodsReturningVoid extends SpiedBeanHelper {
     }
 
     @Outgoing(NO_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToNoAck() {
+    public Flow.Publisher<Message<String>> sourceToNoAck() {
         return source(NO_ACKNOWLEDGMENT);
     }
 
@@ -55,7 +55,7 @@ public class SubscriberBeanWithMethodsReturningVoid extends SpiedBeanHelper {
     }
 
     @Outgoing(DEFAULT_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToAutoAck() {
+    public Flow.Publisher<Message<String>> sourceToAutoAck() {
         return source(DEFAULT_ACKNOWLEDGMENT);
     }
 
@@ -66,7 +66,7 @@ public class SubscriberBeanWithMethodsReturningVoid extends SpiedBeanHelper {
     }
 
     @Outgoing(PRE_PROCESSING_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPreAck() {
+    public Flow.Publisher<Message<String>> sourceToPreAck() {
         return source(PRE_PROCESSING_ACKNOWLEDGMENT);
     }
 
@@ -77,7 +77,7 @@ public class SubscriberBeanWithMethodsReturningVoid extends SpiedBeanHelper {
     }
 
     @Outgoing(POST_PROCESSING_ACKNOWLEDGMENT)
-    public Publisher<Message<String>> sourceToPostAck() {
+    public Flow.Publisher<Message<String>> sourceToPostAck() {
         return source(POST_PROCESSING_ACKNOWLEDGMENT);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsFlowableAndPublishingItemAsRSPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsFlowableAndPublishingItemAsRSPublisher.java
@@ -1,25 +1,23 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
-public class BeanConsumingItemAsFlowableAndPublishingItemAsPublisher {
+public class BeanConsumingItemAsFlowableAndPublishingItemAsRSPublisher {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flow.Publisher<String> process(Flowable<Integer> source) {
-        return AdaptersToFlow.publisher(source
+    public Publisher<String> process(Flowable<Integer> source) {
+        return source
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))
-                .map(i -> Integer.toString(i)));
+                .map(i -> Integer.toString(i));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsFluxAndPublishingItemAsPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsFluxAndPublishingItemAsPublisher.java
@@ -1,12 +1,14 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 import reactor.core.publisher.Flux;
 
 @ApplicationScoped
@@ -14,11 +16,11 @@ public class BeanConsumingItemAsFluxAndPublishingItemAsPublisher {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Publisher<String> process(Flux<Integer> source) {
-        return source
+    public Flow.Publisher<String> process(Flux<Integer> source) {
+        return AdaptersToFlow.publisher(source
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))
-                .map(i -> Integer.toString(i));
+                .map(i -> Integer.toString(i)));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsFluxAndPublishingItemAsRSPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsFluxAndPublishingItemAsRSPublisher.java
@@ -1,25 +1,24 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToFlow;
+import reactor.core.publisher.Flux;
 
 @ApplicationScoped
-public class BeanConsumingItemAsFlowableAndPublishingItemAsPublisher {
+public class BeanConsumingItemAsFluxAndPublishingItemAsRSPublisher {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flow.Publisher<String> process(Flowable<Integer> source) {
-        return AdaptersToFlow.publisher(source
+    public Publisher<String> process(Flux<Integer> source) {
+        return source
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))
-                .map(i -> Integer.toString(i)));
+                .map(i -> Integer.toString(i));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsMultiAndPublishingItemAsMulti.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsMultiAndPublishingItemAsMulti.java
@@ -7,6 +7,7 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanConsumingItemAsMultiAndPublishingItemAsMulti {
@@ -16,7 +17,7 @@ public class BeanConsumingItemAsMultiAndPublishingItemAsMulti {
     public Multi<String> process(Multi<Integer> source) {
         return source
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
+                .flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
                 .map(i -> Integer.toString(i));
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsMultiAndPublishingItemAsPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsMultiAndPublishingItemAsPublisher.java
@@ -1,23 +1,25 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanConsumingItemAsMultiAndPublishingItemAsPublisher {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Publisher<String> process(Multi<Integer> source) {
+    public Flow.Publisher<String> process(Multi<Integer> source) {
         return source
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
+                .flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
                 .map(i -> Integer.toString(i));
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsMultiAndPublishingItemAsRSPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsMultiAndPublishingItemAsRSPublisher.java
@@ -1,29 +1,24 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
+import io.smallrye.mutiny.Multi;
 import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 @ApplicationScoped
-public class BeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable {
+public class BeanConsumingItemAsMultiAndPublishingItemAsRSPublisher {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flowable<Message<String>> process(Flow.Publisher<Message<Integer>> source) {
+    public Publisher<String> process(Multi<Integer> source) {
         return Flowable.fromPublisher(AdaptersToReactiveStreams.publisher(source))
-                .map(Message::getPayload)
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
-                .map(i -> Integer.toString(i))
-                .map(Message::of);
+                .map(i -> Integer.toString(i + 1));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsPublisherAndPublishingItemAsFlowable.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsPublisherAndPublishingItemAsFlowable.java
@@ -1,20 +1,22 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
+import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 @ApplicationScoped
 public class BeanConsumingItemAsPublisherAndPublishingItemAsFlowable {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flowable<String> process(Publisher<Integer> source) {
-        return Flowable.fromPublisher(source)
+    public Flowable<String> process(Flow.Publisher<Integer> source) {
+        return Flowable.fromPublisher(AdaptersToReactiveStreams.publisher(source))
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))
                 .map(i -> Integer.toString(i));

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsPublisherAndPublishingItemAsMulti.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsPublisherAndPublishingItemAsMulti.java
@@ -1,23 +1,25 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanConsumingItemAsPublisherAndPublishingItemAsMulti {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Multi<String> process(Publisher<Integer> source) {
+    public Multi<String> process(Flow.Publisher<Integer> source) {
         return Multi.createFrom().publisher(source)
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
+                .flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
                 .map(i -> Integer.toString(i));
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsRSPublisherAndPublishingItemAsFlowable.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsRSPublisherAndPublishingItemAsFlowable.java
@@ -1,25 +1,23 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
-public class BeanConsumingItemAsFlowableAndPublishingItemAsPublisher {
+public class BeanConsumingItemAsRSPublisherAndPublishingItemAsFlowable {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flow.Publisher<String> process(Flowable<Integer> source) {
-        return AdaptersToFlow.publisher(source
+    public Flowable<String> process(Publisher<Integer> source) {
+        return Flowable.fromPublisher(source)
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))
-                .map(i -> Integer.toString(i)));
+                .map(i -> Integer.toString(i));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsRSPublisherAndPublishingItemAsMulti.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingItemAsRSPublisherAndPublishingItemAsMulti.java
@@ -1,25 +1,25 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
+import io.smallrye.mutiny.Multi;
 import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
-public class BeanConsumingItemAsFlowableAndPublishingItemAsPublisher {
+public class BeanConsumingItemAsRSPublisherAndPublishingItemAsMulti {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flow.Publisher<String> process(Flowable<Integer> source) {
-        return AdaptersToFlow.publisher(source
+    public Multi<String> process(Publisher<Integer> source) {
+        return Multi.createFrom().publisher(AdaptersToFlow.publisher(source))
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
-                .map(i -> Integer.toString(i)));
+                .flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
+                .map(i -> Integer.toString(i));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFlowableAndPublishingMsgAsPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFlowableAndPublishingMsgAsPublisher.java
@@ -1,26 +1,28 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanConsumingMsgAsFlowableAndPublishingMsgAsPublisher {
 
     @Incoming("count")
     @Outgoing("sink")
-    Publisher<Message<String>> process(Flowable<Message<Integer>> source) {
-        return source
+    Flow.Publisher<Message<String>> process(Flowable<Message<Integer>> source) {
+        return AdaptersToFlow.publisher(source
                 .map(Message::getPayload)
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))
                 .map(i -> Integer.toString(i))
-                .map(Message::of);
+                .map(Message::of));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFlowableAndPublishingMsgAsPublisherBuilder.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFlowableAndPublishingMsgAsPublisherBuilder.java
@@ -1,29 +1,27 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 @ApplicationScoped
-public class BeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable {
+public class BeanConsumingMsgAsFlowableAndPublishingMsgAsPublisherBuilder {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flowable<Message<String>> process(Flow.Publisher<Message<Integer>> source) {
-        return Flowable.fromPublisher(AdaptersToReactiveStreams.publisher(source))
+    PublisherBuilder<Message<String>> process(Flowable<Message<Integer>> source) {
+        return ReactiveStreams.fromPublisher(source
                 .map(Message::getPayload)
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))
                 .map(i -> Integer.toString(i))
-                .map(Message::of);
+                .map(Message::of));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFlowableAndPublishingMsgAsRSPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFlowableAndPublishingMsgAsRSPublisher.java
@@ -1,7 +1,5 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -10,15 +8,14 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 @ApplicationScoped
-public class BeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable {
+public class BeanConsumingMsgAsFlowableAndPublishingMsgAsRSPublisher {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flowable<Message<String>> process(Flow.Publisher<Message<Integer>> source) {
-        return Flowable.fromPublisher(AdaptersToReactiveStreams.publisher(source))
+    Publisher<Message<String>> process(Flowable<Message<Integer>> source) {
+        return source
                 .map(Message::getPayload)
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFluxAndPublishingMsgAsPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFluxAndPublishingMsgAsPublisher.java
@@ -1,13 +1,15 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 import reactor.core.publisher.Flux;
 
 @ApplicationScoped
@@ -15,13 +17,13 @@ public class BeanConsumingMsgAsFluxAndPublishingMsgAsPublisher {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Publisher<Message<String>> process(Flux<Message<Integer>> source) {
-        return source
+    public Flow.Publisher<Message<String>> process(Flux<Message<Integer>> source) {
+        return AdaptersToFlow.publisher(source
                 .map(Message::getPayload)
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))
                 .map(i -> Integer.toString(i))
-                .map(Message::of);
+                .map(Message::of));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFluxAndPublishingMsgAsRSPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsFluxAndPublishingMsgAsRSPublisher.java
@@ -1,7 +1,5 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -10,15 +8,15 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
+import reactor.core.publisher.Flux;
 
 @ApplicationScoped
-public class BeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable {
+public class BeanConsumingMsgAsFluxAndPublishingMsgAsRSPublisher {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flowable<Message<String>> process(Flow.Publisher<Message<Integer>> source) {
-        return Flowable.fromPublisher(AdaptersToReactiveStreams.publisher(source))
+    public Publisher<Message<String>> process(Flux<Message<Integer>> source) {
+        return source
                 .map(Message::getPayload)
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsMultiAndPublishingMsgAsMulti.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsMultiAndPublishingMsgAsMulti.java
@@ -8,6 +8,7 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanConsumingMsgAsMultiAndPublishingMsgAsMulti {
@@ -18,7 +19,7 @@ public class BeanConsumingMsgAsMultiAndPublishingMsgAsMulti {
         return source
                 .map(Message::getPayload)
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
+                .flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
                 .map(i -> Integer.toString(i))
                 .map(Message::of);
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsMultiAndPublishingMsgAsPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsMultiAndPublishingMsgAsPublisher.java
@@ -1,14 +1,16 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow.Publisher;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanConsumingMsgAsMultiAndPublishingMsgAsPublisher {
@@ -19,7 +21,7 @@ public class BeanConsumingMsgAsMultiAndPublishingMsgAsPublisher {
         return source
                 .map(Message::getPayload)
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
+                .flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
                 .map(i -> Integer.toString(i))
                 .map(Message::of);
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsPublisherAndPublishingMsgAsMulti.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsPublisherAndPublishingMsgAsMulti.java
@@ -1,25 +1,27 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanConsumingMsgAsPublisherAndPublishingMsgAsMulti {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Multi<Message<String>> process(Publisher<Message<Integer>> source) {
+    public Multi<Message<String>> process(Flow.Publisher<Message<Integer>> source) {
         return Multi.createFrom().publisher(source)
                 .map(Message::getPayload)
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
+                .flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
                 .map(i -> Integer.toString(i))
                 .map(Message::of);
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsPublisherBuilderAndPublishingMsgAsFlowable.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsPublisherBuilderAndPublishingMsgAsFlowable.java
@@ -1,24 +1,21 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 @ApplicationScoped
-public class BeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable {
+public class BeanConsumingMsgAsPublisherBuilderAndPublishingMsgAsFlowable {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flowable<Message<String>> process(Flow.Publisher<Message<Integer>> source) {
-        return Flowable.fromPublisher(AdaptersToReactiveStreams.publisher(source))
+    public Flowable<Message<String>> process(PublisherBuilder<Message<Integer>> source) {
+        return Flowable.fromPublisher(source.buildRs())
                 .map(Message::getPayload)
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsRSPublisherAndPublishingMsgAsFlowable.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsRSPublisherAndPublishingMsgAsFlowable.java
@@ -1,7 +1,5 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -10,15 +8,14 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 @ApplicationScoped
-public class BeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable {
+public class BeanConsumingMsgAsRSPublisherAndPublishingMsgAsFlowable {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flowable<Message<String>> process(Flow.Publisher<Message<Integer>> source) {
-        return Flowable.fromPublisher(AdaptersToReactiveStreams.publisher(source))
+    public Flowable<Message<String>> process(Publisher<Message<Integer>> source) {
+        return Flowable.fromPublisher(source)
                 .map(Message::getPayload)
                 .map(i -> i + 1)
                 .flatMap(i -> Flowable.just(i, i))

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsRSPublisherAndPublishingMsgAsMulti.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanConsumingMsgAsRSPublisherAndPublishingMsgAsMulti.java
@@ -1,7 +1,5 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -10,18 +8,19 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.reactivestreams.Publisher;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
+import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
-public class BeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable {
+public class BeanConsumingMsgAsRSPublisherAndPublishingMsgAsMulti {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flowable<Message<String>> process(Flow.Publisher<Message<Integer>> source) {
-        return Flowable.fromPublisher(AdaptersToReactiveStreams.publisher(source))
+    public Multi<Message<String>> process(Publisher<Message<Integer>> source) {
+        return Multi.createFrom().publisher(AdaptersToFlow.publisher(source))
                 .map(Message::getPayload)
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
+                .flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
                 .map(i -> Integer.toString(i))
                 .map(Message::of);
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingAProcessorOfPayloads.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingAProcessorOfPayloads.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -8,18 +10,19 @@ import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.reactivestreams.Processor;
 
 import io.reactivex.Flowable;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanProducingAProcessorOfPayloads {
 
     @Incoming("count")
     @Outgoing("sink")
-    Processor<Integer, String> process() {
-        return ReactiveStreams.<Integer> builder()
+    Flow.Processor<Integer, String> process() {
+        return AdaptersToFlow.processor(ReactiveStreams.<Integer> builder()
                 .map(i -> i + 1)
                 .flatMapRsPublisher(i -> Flowable.just(i, i))
                 .map(i -> Integer.toString(i))
-                .buildRs();
+                .buildRs());
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingARSProcessorOfMessages.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingARSProcessorOfMessages.java
@@ -1,29 +1,28 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.Processor;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToReactiveStreams;
 
 @ApplicationScoped
-public class BeanConsumingMsgAsPublisherAndPublishingMsgAsFlowable {
+public class BeanProducingARSProcessorOfMessages {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flowable<Message<String>> process(Flow.Publisher<Message<Integer>> source) {
-        return Flowable.fromPublisher(AdaptersToReactiveStreams.publisher(source))
+    public Processor<Message<Integer>, Message<String>> process() {
+        return ReactiveStreams.<Message<Integer>> builder()
                 .map(Message::getPayload)
                 .map(i -> i + 1)
-                .flatMap(i -> Flowable.just(i, i))
+                .flatMapRsPublisher(i -> Flowable.just(i, i))
                 .map(i -> Integer.toString(i))
-                .map(Message::of);
+                .map(Message::of)
+                .buildRs();
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingARSProcessorOfPayloads.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingARSProcessorOfPayloads.java
@@ -1,30 +1,25 @@
 package io.smallrye.reactive.messaging.beans;
 
-import java.util.concurrent.Flow;
-
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.Processor;
 
 import io.reactivex.Flowable;
-import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
-public class BeanProducingAProcessorOfMessages {
+public class BeanProducingARSProcessorOfPayloads {
 
     @Incoming("count")
     @Outgoing("sink")
-    public Flow.Processor<Message<Integer>, Message<String>> process() {
-        return AdaptersToFlow.processor(ReactiveStreams.<Message<Integer>> builder()
-                .map(Message::getPayload)
+    Processor<Integer, String> process() {
+        return ReactiveStreams.<Integer> builder()
                 .map(i -> i + 1)
                 .flatMapRsPublisher(i -> Flowable.just(i, i))
                 .map(i -> Integer.toString(i))
-                .map(Message::of)
-                .buildRs());
+                .buildRs();
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingMessagesAsMulti.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingMessagesAsMulti.java
@@ -7,13 +7,15 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanProducingMessagesAsMulti {
 
     @Outgoing("sink")
     Multi<Message<String>> publisher() {
-        return Multi.createFrom().range(1, 11).flatMap(i -> Flowable.just(i, i)).map(i -> Integer.toString(i))
+        return Multi.createFrom().range(1, 11).flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
+                .map(i -> Integer.toString(i))
                 .map(Message::of);
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingMessagesAsPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingMessagesAsPublisher.java
@@ -1,19 +1,24 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
-import io.reactivex.Flowable;
+import io.smallrye.mutiny.Multi;
 
 @ApplicationScoped
 public class BeanProducingMessagesAsPublisher {
 
     @Outgoing("sink")
-    public Publisher<Message<String>> publisher() {
-        return Flowable.range(1, 10).flatMap(i -> Flowable.just(i, i)).map(i -> Integer.toString(i)).map(Message::of);
+    public Flow.Publisher<Message<String>> publisher() {
+        return Multi.createFrom()
+                .range(1, 11)
+                .flatMap(i -> Multi.createFrom().items(i, i))
+                .map(i -> Integer.toString(i))
+                .map(Message::of);
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingMessagesAsRSPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingMessagesAsRSPublisher.java
@@ -1,0 +1,19 @@
+package io.smallrye.reactive.messaging.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+
+@ApplicationScoped
+public class BeanProducingMessagesAsRSPublisher {
+
+    @Outgoing("sink")
+    public Publisher<Message<String>> publisher() {
+        return Flowable.range(1, 10).flatMap(i -> Flowable.just(i, i)).map(i -> Integer.toString(i)).map(Message::of);
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingPayloadAsMulti.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingPayloadAsMulti.java
@@ -6,13 +6,15 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 import io.reactivex.Flowable;
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanProducingPayloadAsMulti {
 
     @Outgoing("sink")
     public Multi<String> publisher() {
-        return Multi.createFrom().range(1, 11).flatMap(i -> Flowable.just(i, i)).map(i -> Integer.toString(i));
+        return Multi.createFrom().range(1, 11).flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
+                .map(i -> Integer.toString(i));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingPayloadAsPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingPayloadAsPublisher.java
@@ -1,18 +1,22 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
-import io.reactivex.Flowable;
+import io.smallrye.mutiny.Multi;
 
 @ApplicationScoped
 public class BeanProducingPayloadAsPublisher {
 
     @Outgoing("sink")
-    Publisher<String> publisher() {
-        return Flowable.range(1, 10).flatMap(i -> Flowable.just(i, i)).map(i -> Integer.toString(i));
+    Flow.Publisher<String> publisher() {
+        return Multi.createFrom()
+                .range(1, 11)
+                .flatMap(i -> Multi.createFrom().items(i, i))
+                .map(i -> Integer.toString(i));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingPayloadAsRSPublisher.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingPayloadAsRSPublisher.java
@@ -1,0 +1,18 @@
+package io.smallrye.reactive.messaging.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+
+@ApplicationScoped
+public class BeanProducingPayloadAsRSPublisher {
+
+    @Outgoing("sink")
+    Publisher<String> publisher() {
+        return Flowable.range(1, 10).flatMap(i -> Flowable.just(i, i)).map(i -> Integer.toString(i));
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningAPublisherOfItems.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningAPublisherOfItems.java
@@ -1,17 +1,19 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
 
 @ApplicationScoped
 public class BeanReturningAPublisherOfItems {
 
     @Outgoing("producer")
-    public Publisher<String> create() {
-        return ReactiveStreams.of("a", "b", "c").buildRs();
+    public Flow.Publisher<String> create() {
+        return Multi.createFrom().items("a", "b", "c");
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningAPublisherOfMessages.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningAPublisherOfMessages.java
@@ -1,18 +1,20 @@
 package io.smallrye.reactive.messaging.beans;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.reactivestreams.Publisher;
+
+import io.smallrye.mutiny.Multi;
 
 @ApplicationScoped
 public class BeanReturningAPublisherOfMessages {
 
     @Outgoing("producer")
-    public Publisher<Message<String>> create() {
-        return ReactiveStreams.of("a", "b", "c").map(Message::of).buildRs();
+    public Flow.Publisher<Message<String>> create() {
+        return Multi.createFrom().items("a", "b", "c").map(Message::of);
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningARSPublisherOfItems.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningARSPublisherOfItems.java
@@ -1,0 +1,17 @@
+package io.smallrye.reactive.messaging.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.Publisher;
+
+@ApplicationScoped
+public class BeanReturningARSPublisherOfItems {
+
+    @Outgoing("producer")
+    public Publisher<String> create() {
+        return ReactiveStreams.of("a", "b", "c").buildRs();
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningARSPublisherOfMessages.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningARSPublisherOfMessages.java
@@ -1,0 +1,18 @@
+package io.smallrye.reactive.messaging.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.Publisher;
+
+@ApplicationScoped
+public class BeanReturningARSPublisherOfMessages {
+
+    @Outgoing("producer")
+    public Publisher<Message<String>> create() {
+        return ReactiveStreams.of("a", "b", "c").map(Message::of).buildRs();
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningARSSubscriberOfMessages.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningARSSubscriberOfMessages.java
@@ -1,0 +1,28 @@
+package io.smallrye.reactive.messaging.beans;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.Subscriber;
+
+@ApplicationScoped
+public class BeanReturningARSSubscriberOfMessages {
+
+    private List<String> list = new ArrayList<>();
+
+    @Incoming("count")
+    Subscriber<Message<String>> create() {
+        return ReactiveStreams.<Message<String>> builder().forEach(m -> list.add(m.getPayload()))
+                .build();
+    }
+
+    public List<String> payloads() {
+        return list;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningARSSubscriberOfPayloads.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningARSSubscriberOfPayloads.java
@@ -1,0 +1,26 @@
+package io.smallrye.reactive.messaging.beans;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.Subscriber;
+
+@ApplicationScoped
+public class BeanReturningARSSubscriberOfPayloads {
+
+    private List<String> list = new ArrayList<>();
+
+    @Incoming("count")
+    public Subscriber<String> create() {
+        return ReactiveStreams.<String> builder().forEach(m -> list.add(m)).build();
+    }
+
+    public List<String> payloads() {
+        return list;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningASubscriberOfMessages.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningASubscriberOfMessages.java
@@ -2,12 +2,12 @@ package io.smallrye.reactive.messaging.beans;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.reactivestreams.Subscriber;
 
 @ApplicationScoped
@@ -16,9 +16,33 @@ public class BeanReturningASubscriberOfMessages {
     private List<String> list = new ArrayList<>();
 
     @Incoming("count")
-    Subscriber<Message<String>> create() {
-        return ReactiveStreams.<Message<String>> builder().forEach(m -> list.add(m.getPayload()))
-                .build();
+    Flow.Subscriber<Message<String>> create() {
+        return new Flow.Subscriber<>() {
+
+            Flow.Subscription s;
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                s = subscription;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(Message<String> item) {
+                list.add(item.getPayload());
+                s.request(1);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                //ignore
+            }
+
+            @Override
+            public void onComplete() {
+                //ignore
+            }
+        };
     }
 
     public List<String> payloads() {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningASubscriberOfPayloads.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanReturningASubscriberOfPayloads.java
@@ -2,12 +2,11 @@ package io.smallrye.reactive.messaging.beans;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
-import org.reactivestreams.Subscriber;
 
 @ApplicationScoped
 public class BeanReturningASubscriberOfPayloads {
@@ -15,8 +14,32 @@ public class BeanReturningASubscriberOfPayloads {
     private List<String> list = new ArrayList<>();
 
     @Incoming("count")
-    public Subscriber<String> create() {
-        return ReactiveStreams.<String> builder().forEach(m -> list.add(m)).build();
+    public Flow.Subscriber<String> create() {
+        return new Flow.Subscriber<>() {
+            Flow.Subscription s;
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                s = subscription;
+                subscription.request(1);
+            }
+
+            @Override
+            public void onNext(String item) {
+                list.add(item);
+                s.request(1);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                // ignore
+            }
+
+            @Override
+            public void onComplete() {
+                // ignore
+            }
+        };
     }
 
     public List<String> payloads() {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/BlockingPublisherTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/BlockingPublisherTest.java
@@ -4,11 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
+import java.util.concurrent.Flow;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.reactive.messaging.PublisherShapeTest;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
@@ -23,7 +23,7 @@ public class BlockingPublisherTest extends WeldTestBaseWithoutTails {
         addBeanClass(PublisherShapeTest.InfiniteSubscriber.class);
         initialize();
 
-        List<Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
+        List<Flow.Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
         assertThat(producer).isNotEmpty();
         PublisherShapeTest.InfiniteSubscriber subscriber = get(PublisherShapeTest.InfiniteSubscriber.class);
         await().until(() -> subscriber.list().size() == 4);
@@ -44,7 +44,7 @@ public class BlockingPublisherTest extends WeldTestBaseWithoutTails {
         addBeanClass(PublisherShapeTest.InfiniteSubscriber.class);
         initialize();
 
-        List<Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
+        List<Flow.Publisher<? extends Message<?>>> producer = registry(container).getPublishers("infinite-producer");
         assertThat(producer).isNotEmpty();
         PublisherShapeTest.InfiniteSubscriber subscriber = get(PublisherShapeTest.InfiniteSubscriber.class);
         await().until(() -> subscriber.list().size() == 4);

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/BlockingSubscriberTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/BlockingSubscriberTest.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -15,7 +16,6 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.*;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
@@ -235,7 +235,7 @@ class BlockingSubscriberTest extends WeldTestBaseWithoutTails {
     @ApplicationScoped
     public static class ProduceIn {
         @Outgoing("in")
-        public Publisher<String> produce() {
+        public Flow.Publisher<String> produce() {
             return Multi.createFrom().items("a", "b", "c", "d", "e", "f");
         }
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/InvalidBlockingConfigTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/InvalidBlockingConfigTest.java
@@ -2,13 +2,14 @@ package io.smallrye.reactive.messaging.blocking;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.DeploymentException;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
@@ -45,7 +46,7 @@ public class InvalidBlockingConfigTest extends WeldTestBaseWithoutTails {
     @ApplicationScoped
     public static class ProduceIn {
         @Outgoing("in")
-        public Publisher<String> produce() {
+        public Flow.Publisher<String> produce() {
             return Multi.createFrom().items("a", "b", "c");
         }
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/InvalidBlockingProcessorShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/InvalidBlockingProcessorShapeTest.java
@@ -23,6 +23,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Blocking;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 public class InvalidBlockingProcessorShapeTest extends WeldTestBaseWithoutTails {
     @Test
@@ -300,10 +301,10 @@ public class InvalidBlockingProcessorShapeTest extends WeldTestBaseWithoutTails 
         @Outgoing("sink")
         public Multi<String> process(Integer payload) {
             return Multi.createFrom().publisher(
-                    ReactiveStreams.of(payload)
+                    AdaptersToFlow.publisher(ReactiveStreams.of(payload)
                             .map(i -> i + 1)
                             .flatMapRsPublisher(i -> Flowable.just(i, i))
-                            .map(i -> Integer.toString(i)).buildRs());
+                            .map(i -> Integer.toString(i)).buildRs()));
         }
     }
 
@@ -320,12 +321,12 @@ public class InvalidBlockingProcessorShapeTest extends WeldTestBaseWithoutTails 
         @Outgoing("sink")
         public Multi<Message<String>> process(Message<Integer> message) {
             return Multi.createFrom().publisher(
-                    ReactiveStreams.of(message)
+                    AdaptersToFlow.publisher(ReactiveStreams.of(message)
                             .map(Message::getPayload)
                             .map(i -> i + 1)
                             .flatMapRsPublisher(i -> Flowable.just(i, i))
                             .map(i -> Integer.toString(i))
-                            .map(Message::of).buildRs());
+                            .map(Message::of).buildRs()));
         }
     }
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/InvalidBlockingPublisherShapeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/InvalidBlockingPublisherShapeTest.java
@@ -24,6 +24,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Blocking;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 public class InvalidBlockingPublisherShapeTest extends WeldTestBaseWithoutTails {
     @Test
@@ -52,7 +53,8 @@ public class InvalidBlockingPublisherShapeTest extends WeldTestBaseWithoutTails 
         @Blocking
         @Outgoing("sink")
         public Multi<Message<String>> publisher() {
-            return Multi.createFrom().range(1, 11).flatMap(i -> Flowable.just(i, i)).map(i -> Integer.toString(i))
+            return Multi.createFrom().range(1, 11).flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
+                    .map(i -> Integer.toString(i))
                     .map(Message::of);
         }
     }
@@ -68,7 +70,8 @@ public class InvalidBlockingPublisherShapeTest extends WeldTestBaseWithoutTails 
         @Blocking
         @Outgoing("sink")
         public Multi<String> publisher() {
-            return Multi.createFrom().range(1, 11).flatMap(i -> Flowable.just(i, i)).map(i -> Integer.toString(i));
+            return Multi.createFrom().range(1, 11).flatMap(i -> AdaptersToFlow.publisher(Flowable.just(i, i)))
+                    .map(i -> Integer.toString(i));
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithAPublisherBuilderOfMessages.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithAPublisherBuilderOfMessages.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanInjectedWithAPublisherBuilderOfMessages {
@@ -27,7 +28,7 @@ public class BeanInjectedWithAPublisherBuilderOfMessages {
 
     public List<String> consume() {
         return Multi.createBy().concatenating()
-                .streams(constructor.buildRs(), field.buildRs())
+                .streams(AdaptersToFlow.publisher(constructor.buildRs()), AdaptersToFlow.publisher(field.buildRs()))
                 .map(Message::getPayload)
                 .collect().asList()
                 .await().indefinitely();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithAPublisherBuilderOfPayloads.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithAPublisherBuilderOfPayloads.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
 public class BeanInjectedWithAPublisherBuilderOfPayloads {
@@ -25,7 +26,7 @@ public class BeanInjectedWithAPublisherBuilderOfPayloads {
 
     public List<String> consume() {
         return Multi.createBy().concatenating()
-                .streams(constructor.buildRs(), field.buildRs())
+                .streams(AdaptersToFlow.publisher(constructor.buildRs()), AdaptersToFlow.publisher(field.buildRs()))
                 .collect().asList()
                 .await().indefinitely();
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithAPublisherOfMessages.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithAPublisherOfMessages.java
@@ -1,27 +1,27 @@
 package io.smallrye.reactive.messaging.inject;
 
 import java.util.List;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 
 @ApplicationScoped
 public class BeanInjectedWithAPublisherOfMessages {
 
-    private final Publisher<Message<String>> constructor;
+    private final Flow.Publisher<Message<String>> constructor;
 
     @Inject
     @Channel("hello")
-    private Publisher<Message<String>> field;
+    private Flow.Publisher<Message<String>> field;
 
     @Inject
-    public BeanInjectedWithAPublisherOfMessages(@Channel("bonjour") Publisher<Message<String>> constructor) {
+    public BeanInjectedWithAPublisherOfMessages(@Channel("bonjour") Flow.Publisher<Message<String>> constructor) {
         this.constructor = constructor;
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithAPublisherOfPayloads.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithAPublisherOfPayloads.java
@@ -1,12 +1,12 @@
 package io.smallrye.reactive.messaging.inject;
 
 import java.util.List;
+import java.util.concurrent.Flow.Publisher;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithARSPublisherOfMessages.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithARSPublisherOfMessages.java
@@ -7,25 +7,28 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
 
 import io.smallrye.mutiny.Multi;
 
 @ApplicationScoped
-public class BeanInjectedWithAPublisherOfPayloads {
+public class BeanInjectedWithARSPublisherOfMessages {
 
-    private final Flow.Publisher<String> constructor;
+    private final Flow.Publisher<Message<String>> constructor;
+
     @Inject
     @Channel("hello")
-    private Flow.Publisher<String> field;
+    private Flow.Publisher<Message<String>> field;
 
     @Inject
-    public BeanInjectedWithAPublisherOfPayloads(@Channel("bonjour") Flow.Publisher<String> constructor) {
+    public BeanInjectedWithARSPublisherOfMessages(@Channel("bonjour") Flow.Publisher<Message<String>> constructor) {
         this.constructor = constructor;
     }
 
     public List<String> consume() {
         return Multi.createBy().concatenating()
                 .streams(constructor, field)
+                .map(Message::getPayload)
                 .collect().asList()
                 .await().indefinitely();
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithARSPublisherOfPayloads.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/BeanInjectedWithARSPublisherOfPayloads.java
@@ -1,31 +1,32 @@
 package io.smallrye.reactive.messaging.inject;
 
 import java.util.List;
-import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @ApplicationScoped
-public class BeanInjectedWithAPublisherOfPayloads {
+public class BeanInjectedWithARSPublisherOfPayloads {
 
-    private final Flow.Publisher<String> constructor;
+    private final Publisher<String> constructor;
     @Inject
     @Channel("hello")
-    private Flow.Publisher<String> field;
+    private Publisher<String> field;
 
     @Inject
-    public BeanInjectedWithAPublisherOfPayloads(@Channel("bonjour") Flow.Publisher<String> constructor) {
+    public BeanInjectedWithARSPublisherOfPayloads(@Channel("bonjour") Publisher<String> constructor) {
         this.constructor = constructor;
     }
 
     public List<String> consume() {
         return Multi.createBy().concatenating()
-                .streams(constructor, field)
+                .streams(AdaptersToFlow.publisher(constructor), AdaptersToFlow.publisher(field))
                 .collect().asList()
                 .await().indefinitely();
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/ChannelInjectionTest.java
@@ -18,6 +18,14 @@ public class ChannelInjectionTest extends WeldTestBaseWithoutTails {
     }
 
     @Test
+    public void testInjectionOfRSPublisherOfMessages() {
+        addBeanClass(SourceBean.class);
+        BeanInjectedWithARSPublisherOfMessages bean = installInitializeAndGet(BeanInjectedWithARSPublisherOfMessages.class);
+        assertThat(bean.consume())
+                .containsExactlyInAnyOrder("B", "O", "N", "J", "O", "U", "R", "h", "e", "l", "l", "o");
+    }
+
+    @Test
     public void testInjectionOfMultiOfMessages() {
         addBeanClass(SourceBean.class);
         BeanInjectedWithAMultiOfMessages bean = installInitializeAndGet(BeanInjectedWithAMultiOfMessages.class);
@@ -37,6 +45,14 @@ public class ChannelInjectionTest extends WeldTestBaseWithoutTails {
     public void testInjectionOfPublisherOfPayloads() {
         addBeanClass(SourceBean.class);
         BeanInjectedWithAPublisherOfPayloads bean = installInitializeAndGet(BeanInjectedWithAPublisherOfPayloads.class);
+        assertThat(bean.consume())
+                .containsExactlyInAnyOrder("B", "O", "N", "J", "O", "U", "R", "h", "e", "l", "l", "o");
+    }
+
+    @Test
+    public void testInjectionOfRSPublisherOfPayloads() {
+        addBeanClass(SourceBean.class);
+        BeanInjectedWithARSPublisherOfPayloads bean = installInitializeAndGet(BeanInjectedWithARSPublisherOfPayloads.class);
         assertThat(bean.consume())
                 .containsExactlyInAnyOrder("B", "O", "N", "J", "O", "U", "R", "h", "e", "l", "l", "o");
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterInjectionTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -31,6 +32,7 @@ import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
 import io.smallrye.reactive.messaging.annotations.Merge;
 import io.smallrye.reactive.messaging.providers.DefaultEmitterConfiguration;
 import io.smallrye.reactive.messaging.providers.extension.EmitterImpl;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
 
@@ -669,13 +671,13 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
         };
         EmitterConfiguration config = new DefaultEmitterConfiguration("my-channel", EMITTER, overflow, null);
         EmitterImpl<String> emitter = new EmitterImpl<>(config, 128);
-        Publisher<Message<? extends String>> publisher = emitter.getPublisher();
+        Flow.Publisher<Message<? extends String>> publisher = emitter.getPublisher();
 
         TestSubscriber<Message<? extends String>> sub1 = new TestSubscriber<>();
-        publisher.subscribe(sub1);
+        publisher.subscribe(AdaptersToFlow.subscriber(sub1));
 
         TestSubscriber<Message<? extends String>> sub2 = new TestSubscriber<>();
-        publisher.subscribe(sub2);
+        publisher.subscribe(AdaptersToFlow.subscriber(sub2));
 
         sub1.assertNoErrors();
         sub2.assertNoErrors();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterInjectionTest.java
@@ -39,6 +39,7 @@ import io.smallrye.reactive.messaging.providers.extension.MutinyEmitterImpl;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.VertxInternal;
+import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 public class MutinyEmitterInjectionTest extends WeldTestBaseWithoutTails {
 
@@ -753,13 +754,13 @@ public class MutinyEmitterInjectionTest extends WeldTestBaseWithoutTails {
         };
         EmitterConfiguration config = new DefaultEmitterConfiguration("my-channel", MUTINY_EMITTER, overflow, null);
         MutinyEmitterImpl<String> emitter = new MutinyEmitterImpl<>(config, 128);
-        Publisher<Message<? extends String>> publisher = emitter.getPublisher();
+        Flow.Publisher<Message<? extends String>> publisher = emitter.getPublisher();
 
         TestSubscriber<Message<? extends String>> sub1 = new TestSubscriber<>();
-        publisher.subscribe(sub1);
+        publisher.subscribe(AdaptersToFlow.subscriber(sub1));
 
         TestSubscriber<Message<? extends String>> sub2 = new TestSubscriber<>();
-        publisher.subscribe(sub2);
+        publisher.subscribe(AdaptersToFlow.subscriber(sub2));
 
         sub1.assertNoErrors();
         sub2.assertNoErrors();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/invalid/InvalidProcessorSignatureTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/invalid/InvalidProcessorSignatureTest.java
@@ -5,6 +5,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.DeploymentException;
@@ -15,7 +16,6 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
@@ -175,7 +175,7 @@ public class InvalidProcessorSignatureTest extends WeldTestBaseWithoutTails {
     public static class PayloadToPayloads {
         @Incoming("i")
         @Outgoing("o")
-        public Publisher<String> consume(String i) {
+        public Flow.Publisher<String> consume(String i) {
             return Multi.createFrom().item(i);
         }
     }
@@ -193,7 +193,7 @@ public class InvalidProcessorSignatureTest extends WeldTestBaseWithoutTails {
     public static class PayloadToMessages {
         @Incoming("i")
         @Outgoing("o")
-        public Publisher<Message<String>> consume(String i) {
+        public Flow.Publisher<Message<String>> consume(String i) {
             return Multi.createFrom().item(Message.of(i));
         }
     }
@@ -211,7 +211,7 @@ public class InvalidProcessorSignatureTest extends WeldTestBaseWithoutTails {
     public static class MessageToMessages {
         @Incoming("i")
         @Outgoing("o")
-        public Publisher<Message<String>> consume(Message<String> i) {
+        public Flow.Publisher<Message<String>> consume(Message<String> i) {
             return Multi.createFrom().item(i.withPayload(i.getPayload().toLowerCase()));
         }
     }
@@ -229,7 +229,7 @@ public class InvalidProcessorSignatureTest extends WeldTestBaseWithoutTails {
     public static class MessageToPayloads {
         @Incoming("i")
         @Outgoing("o")
-        public Publisher<String> consume(Message<String> i) {
+        public Flow.Publisher<String> consume(Message<String> i) {
             return Multi.createFrom().item(i.getPayload());
         }
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/locals/LocalPropagationTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/locals/LocalPropagationTest.java
@@ -18,7 +18,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
 import org.junit.jupiter.api.*;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.mutiny.Multi;
@@ -168,7 +167,7 @@ public class LocalPropagationTest extends WeldTestBaseWithoutTails {
         ExecutionHolder executionHolder;
 
         @Override
-        public Publisher<? extends Message<?>> getPublisher(Config config) {
+        public Flow.Publisher<? extends Message<?>> getPublisher(Config config) {
             Context context = executionHolder.vertx().getOrCreateContext();
             return Multi.createFrom().items(1, 2, 3, 4, 5)
                     .onItem()

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/locals/LocalPropagationWithoutContextTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/locals/LocalPropagationWithoutContextTest.java
@@ -5,6 +5,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -18,7 +19,6 @@ import org.eclipse.microprofile.reactive.messaging.spi.Connector;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -53,7 +53,7 @@ public class LocalPropagationWithoutContextTest extends WeldTestBaseWithoutTails
     public static class ConnectorEmittingDirectly implements InboundConnector {
 
         @Override
-        public Publisher<? extends Message<?>> getPublisher(Config config) {
+        public Flow.Publisher<? extends Message<?>> getPublisher(Config config) {
             return Multi.createFrom().items(1, 2, 3, 4, 5)
                     .map(Message::of)
                     .onItem().transformToUniAndConcatenate(i -> Uni.createFrom().emitter(e -> e.complete(i)));

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/PublisherPropagationTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/PublisherPropagationTest.java
@@ -3,13 +3,14 @@ package io.smallrye.reactive.messaging.metadata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.util.concurrent.Flow;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
@@ -39,7 +40,7 @@ public class PublisherPropagationTest extends WeldTestBaseWithoutTails {
     public static class ProcessorReturningPublisherOfPayload {
         @Incoming("source")
         @Outgoing("intermediate")
-        public Publisher<String> process(String payload) {
+        public Flow.Publisher<String> process(String payload) {
             return Multi.createFrom().items(payload, payload);
         }
 
@@ -49,7 +50,7 @@ public class PublisherPropagationTest extends WeldTestBaseWithoutTails {
     public static class ProcessorRetuningPublisherOfMessage {
         @Incoming("intermediate")
         @Outgoing("sink")
-        public Publisher<Message<String>> process(Message<String> input) {
+        public Flow.Publisher<Message<String>> process(Message<String> input) {
             return Multi.createFrom().items(
                     input.withMetadata(input.getMetadata().with(new MessageTest.MyMetadata<>("hello"))),
                     input.withMetadata(input.getMetadata().with(new MessageTest.MyMetadata<>("hello"))));

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/SimplePropagationTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/SimplePropagationTest.java
@@ -10,7 +10,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.*;
 import org.junit.jupiter.api.Test;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
@@ -84,7 +83,7 @@ public class SimplePropagationTest extends WeldTestBaseWithoutTails {
     public static class Source {
 
         @Outgoing("source")
-        public Publisher<Message<String>> source() {
+        public Multi<Message<String>> source() {
             return Multi.createFrom().range(1, 11)
                     .map(i -> Message.of(Integer.toString(i), Metadata.of(new CounterMetadata(i), new MsgMetadata("foo"))));
         }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
@@ -4,13 +4,13 @@ import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions.ex
 import static java.time.Duration.ofSeconds;
 
 import java.util.Optional;
+import java.util.concurrent.Flow;
+import java.util.concurrent.Flow.Processor;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.reactivestreams.Processor;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -89,18 +89,18 @@ public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>,
     /* ----------------------------------------------------- */
 
     /**
-     * Request {@link Publisher} to start streaming data.
+     * Request {@link Flow.Publisher} to start streaming data.
      * <p>
      * This is a "factory method" and can be called multiple times, each time starting a new {@link Subscription}.
      * <p>
      * Each {@link Subscription} will work for only a single {@link Subscriber}.
      * <p>
-     * A {@link Subscriber} should only subscribe once to a single {@link Publisher}.
+     * A {@link Subscriber} should only subscribe once to a single {@link Flow.Publisher}.
      * <p>
-     * If the {@link Publisher} rejects the subscription attempt or otherwise fails it will
+     * If the {@link Flow.Publisher} rejects the subscription attempt or otherwise fails it will
      * signal the error via {@link Subscriber#onError}.
      *
-     * @param subscriber the {@link Subscriber} that will consume signals from this {@link Publisher}
+     * @param subscriber the {@link Subscriber} that will consume signals from this {@link Flow.Publisher}
      */
     @Override
     public void subscribe(
@@ -119,14 +119,14 @@ public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>,
     /* ----------------------------------------------------- */
 
     /**
-     * Invoked after calling {@link Publisher#subscribe(Subscriber)}.
+     * Invoked after calling {@link Flow.Publisher#subscribe(Subscriber)}.
      * <p>
      * No data will start flowing until {@link Subscription#request(long)} is invoked.
      * <p>
      * It is the responsibility of this {@link Subscriber} instance to call {@link Subscription#request(long)} whenever more
      * data is wanted.
      * <p>
-     * The {@link Publisher} will send notifications only in response to {@link Subscription#request(long)}.
+     * The {@link Flow.Publisher} will send notifications only in response to {@link Subscription#request(long)}.
      *
      * @param subscription
      *        {@link Subscription} that allows requesting data via {@link Subscription#request(long)}
@@ -147,7 +147,7 @@ public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>,
     }
 
     /**
-     * Data notification sent by the {@link Publisher} in response to requests to {@link Subscription#request(long)}.
+     * Data notification sent by the {@link Flow.Publisher} in response to requests to {@link Subscription#request(long)}.
      *
      * @param message the element signaled
      */
@@ -219,21 +219,22 @@ public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>,
     /* ----------------------------------------------------- */
 
     /**
-     * No events will be sent by a {@link Publisher} until demand is signaled via this method.
+     * No events will be sent by a {@link Flow.Publisher} until demand is signaled via this method.
      * <p>
      * It can be called however often and whenever needed—but if the outstanding cumulative demand ever becomes Long.MAX_VALUE
      * or more,
-     * it may be treated by the {@link Publisher} as "effectively unbounded".
+     * it may be treated by the {@link Flow.Publisher} as "effectively unbounded".
      * <p>
-     * Whatever has been requested can be sent by the {@link Publisher} so only signal demand for what can be safely handled.
+     * Whatever has been requested can be sent by the {@link Flow.Publisher} so only signal demand for what can be safely
+     * handled.
      * <p>
-     * A {@link Publisher} can send less than is requested if the stream ends but
+     * A {@link Flow.Publisher} can send less than is requested if the stream ends but
      * then must emit either {@link Subscriber#onError(Throwable)} or {@link Subscriber#onComplete()}.
      * <p>
      * <strong>Note that this method is expected to be called only once on a given sender.</strong>
      * </p>
      *
-     * @param l the strictly positive number of elements to requests to the upstream {@link Publisher}
+     * @param l the strictly positive number of elements to requests to the upstream {@link Flow.Publisher}
      */
     @Override
     public void request(long l) {
@@ -244,7 +245,7 @@ public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>,
     }
 
     /**
-     * Request the {@link Publisher} to stop sending data and clean up resources.
+     * Request the {@link Flow.Publisher} to stop sending data and clean up resources.
      * <p>
      * Data may still be sent to meet previously signalled demand after calling cancel.
      */

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ProducingBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ProducingBean.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.rabbitmq;
 
 import java.time.Duration;
+import java.util.concurrent.Flow.Publisher;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -8,7 +9,6 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
 


### PR DESCRIPTION
Mutiny 2.0.0 is based on java.util.concurrent.Flow interfaces instead of Reactive Streams APIs.
This change bumps mutiny to 2.0.0 along with supporting Flow interfaces on method and channel types.

- [x] Needs more tests for support of Flow interfaces
- [x] Replace usages of `via(Processor)` with an alternative
- [x] Bump to Mutiny 2.0.0 final
