### PR TITLE
Jakarta script: remove Java 8 from workflows

### DIFF
--- a/jakarta/0004-remove-Java-8-build-from-GH-workflows.diff
+++ b/jakarta/0004-remove-Java-8-build-from-GH-workflows.diff
@@ -1,0 +1,37 @@
+From 3e71de793475072d60ed0924eb2652058b9bb137 Mon Sep 17 00:00:00 2001
+From: Ozan Gunalp <ozangunalp@gmail.com>
+Date: Mon, 19 Sep 2022 08:18:36 +0100
+Subject: [PATCH] Remove Java 8 build from GH workflows
+
+---
+ .github/workflows/build-main-branches.yml | 1 -
+ .github/workflows/build-pull.yml          | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/.github/workflows/build-main-branches.yml b/.github/workflows/build-main-branches.yml
+index ce543af1a..59a6d30fe 100644
+--- a/.github/workflows/build-main-branches.yml
++++ b/.github/workflows/build-main-branches.yml
+@@ -17,7 +17,6 @@ jobs:
+         strategy:
+             matrix:
+                 java: [
+-                    {'version': '8'},
+                     {'version': '11'},
+                     {
+                         'version': '11',
+diff --git a/.github/workflows/build-pull.yml b/.github/workflows/build-pull.yml
+index 4f38cc997..b30f4e7a0 100644
+--- a/.github/workflows/build-pull.yml
++++ b/.github/workflows/build-pull.yml
+@@ -14,7 +14,6 @@ jobs:
+         strategy:
+             matrix:
+                 java: [
+-                    {'version': '8'},
+                     {'version': '11'},
+                     {
+                         'version': '11',
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
smallrye jakarta parent is on java 11. For reactive messaging it is planned for 3.20.0.