### PR TITLE
Restore PublisherDecorator to the providers package.

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/PublisherDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/PublisherDecorator.java
@@ -1,0 +1,30 @@
+package io.smallrye.reactive.messaging.providers;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Multi;
+
+/**
+ * SPI to allow extension of publishers (Multi) included in the final graph
+ *
+ * @deprecated use {@link io.smallrye.reactive.messaging.PublisherDecorator} instead
+ */
+@Deprecated
+public interface PublisherDecorator extends io.smallrye.reactive.messaging.PublisherDecorator {
+
+    @Override
+    default Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, String channelName,
+            boolean isConnector) {
+        return decorate(publisher, channelName);
+    }
+
+    /**
+     * Decorate a Multi
+     *
+     * @param publisher the multi to decorate
+     * @param channelName the name of the channel to which this publisher publishes
+     * @return the extended multi
+     */
+    Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, String channelName);
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/AppendingDeprecatedDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/AppendingDeprecatedDecorator.java
@@ -1,0 +1,26 @@
+package io.smallrye.reactive.messaging.decorator;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Multi;
+
+@ApplicationScoped
+public class AppendingDeprecatedDecorator implements io.smallrye.reactive.messaging.providers.PublisherDecorator {
+
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, String channelName) {
+        return publisher.map(m -> this.appendString(m, channelName));
+    }
+
+    private Message<?> appendString(Message<?> message, String string) {
+        if (message.getPayload() instanceof String) {
+            String payload = (String) message.getPayload();
+            return Message.of(payload + "-" + string, message::ack);
+        } else {
+            return message;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/DecoratorTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/DecoratorTest.java
@@ -32,6 +32,22 @@ public class DecoratorTest extends WeldTestBase {
     }
 
     @Test
+    void testDeprecatedPublisherDecorator() {
+        addBeanClass(AppendingDeprecatedDecorator.class, SimpleProducerBean.class);
+        initialize();
+
+        MyCollector collector = container.select(MyCollector.class).get();
+
+        // Expect the values in the stream to have "-sink" appended by the decorator
+        List<String> expected = SimpleProducerBean.TEST_STRINGS.stream()
+                .map((s) -> s + "-sink")
+                .collect(Collectors.toList());
+
+        await().until(collector::payloads, hasSize(expected.size()));
+        assertEquals(expected, collector.payloads());
+    }
+
+    @Test
     public void testMultiStage() {
         addBeanClass(AppendingDecorator.class, MultiStageBean.class);
         initialize();
@@ -71,5 +87,4 @@ public class DecoratorTest extends WeldTestBase {
         // five times
         assertEquals(MultiStageBean.TEST_STRINGS.size() * 5, countingDecorator.getMessageCount());
     }
-
 }


### PR DESCRIPTION
Delegate from the new API method to the previous interface.

Fixes #1911