### PR TITLE
Use package private field injection

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/connectors/WorkerPoolRegistry.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/connectors/WorkerPoolRegistry.java
@@ -39,10 +39,10 @@ public class WorkerPoolRegistry {
     private static final String WORKER_CONCURRENCY = "max-concurrency";
 
     @Inject
-    private Instance<ExecutionHolder> executionHolder;
+    Instance<ExecutionHolder> executionHolder;
 
     @Inject
-    private Instance<Config> configInstance;
+    Instance<Config> configInstance;
 
     private final Map<String, Integer> workerConcurrency = new HashMap<>();
     private final Map<String, WorkerExecutor> workerExecutors = new ConcurrentHashMap<>();

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConfiguredChannelFactory.java
@@ -35,7 +35,7 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
     private final ConnectorFactories factories;
 
     @Inject
-    private Instance<PublisherDecorator> publisherDecoratorInstance;
+    Instance<PublisherDecorator> publisherDecoratorInstance;
 
     // CDI requirement for normal scoped beans
     protected ConfiguredChannelFactory() {

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -161,11 +161,11 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
 
     @Inject
     @Any
-    private Instance<RabbitMQOptions> clientOptions;
+    Instance<RabbitMQOptions> clientOptions;
 
     @Inject
     @Any
-    private Instance<CredentialsProvider> credentialsProviders;
+    Instance<CredentialsProvider> credentialsProviders;
 
     RabbitMQConnector() {
         // used for proxies


### PR DESCRIPTION
This is done in order to avoid warnings in Quarkus (which does support private field injection but needs to use reflection)

Relates to: https://github.com/quarkusio/quarkus/issues/28420