### PR TITLE
Fix MQTT message lost when using Persistent Session - Issues  #1935 and #1939

### DIFF
--- a/documentation/src/main/docs/mqtt/receiving-mqtt-messages.md
+++ b/documentation/src/main/docs/mqtt/receiving-mqtt-messages.md
@@ -78,3 +78,26 @@ you can pass any attribute supported by this client.
     A single instance of `MqttClient` and a single connection is used for
     each `host` / `port` / `server-name` / `client-id`. This client is
     reused for both the inbound and outbound connectors.
+    
+!!!important
+	Using `auto-clean-session=false` the MQTT Connector send Subscribe requests
+	to the broken only if a Persistent Session is not present (like on the first 
+	connection). This means that if a Session is already present (maybe for a 
+	previous run) and you add a new incoming channel, this will not be subscribed.
+	Beware to check always the subscription present on Broker when use 
+	`auto-clean-session=false`.
+	
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
@@ -56,6 +56,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "failure-strategy", type = "string", direction = INCOMING, description = "Specify the failure strategy to apply when a message produced from a MQTT message is nacked. Values can be `fail` (default), or `ignore`", defaultValue = "fail")
 @ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "buffer-size", direction = INCOMING, description = "The size buffer of incoming messages waiting to be processed", type = "int", defaultValue = "128")
+@ConnectorAttribute(name = "unsubscribe-on-disconnection", direction = INCOMING_AND_OUTGOING, description = "This flag restore the old behavior to unsubscribe from the broken on disconnection", type = "boolean", defaultValue = "false")
 public class MqttConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
 
     static final String CONNECTOR_NAME = "smallrye-mqtt";

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttHelpers.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttHelpers.java
@@ -43,6 +43,7 @@ public class MqttHelpers {
         options.setWillQoS(config.getWillQos());
         options.setWillFlag(config.getWillFlag());
         options.setWillRetain(config.getWillRetain());
+        options.setUnsubscribeOnDisconnect(config.getUnsubscribeOnDisconnection().booleanValue());
         return options;
     }
 

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/MqttClientSessionOptions.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/MqttClientSessionOptions.java
@@ -13,6 +13,7 @@ public class MqttClientSessionOptions extends MqttClientOptions {
     private Optional<String> serverName = DEFAULT_SERVER_NAME;
     private int port = MqttClientOptions.DEFAULT_PORT;
     private ReconnectDelayOptions reconnectDelay = DEFAULT_RECONNECT_DELAY;
+    private boolean unsubscribeOnDisconnect = false;
 
     /**
      * Default constructor
@@ -69,4 +70,13 @@ public class MqttClientSessionOptions extends MqttClientOptions {
         this.serverName = serverName;
         return this;
     }
+
+    public boolean isUnsubscribeOnDisconnect() {
+        return unsubscribeOnDisconnect;
+    }
+
+    public void setUnsubscribeOnDisconnect(boolean unsubscribeOnDisconnect) {
+        this.unsubscribeOnDisconnect = unsubscribeOnDisconnect;
+    }
+
 }


### PR DESCRIPTION
This commit fixes the two issues on the subject. 

I also added a note on documentation about persistent sessions.

I'm sorry, I tried to implement a test but I have not found a solution to disconnect the client without restarting it.