### PR TITLE
RabbitMQ - Send to default exchange

### DIFF
--- a/documentation/src/main/docs/rabbitmq/sending-messages-to-rabbitmq.md
+++ b/documentation/src/main/docs/rabbitmq/sending-messages-to-rabbitmq.md
@@ -138,3 +138,12 @@ mp.messaging.outgoing.people-out.exchange.declare=true
     exchange or have a different default routing key, then the
     `exchange.type` and `default-routing-key` properties need to be
     explicitly specified.
+
+## Sending to specific queues via the default exchange
+
+To send a message to a specific queue (usually a reply queue), you have to configure the default exchange as an outgoing channel and set the name of the queue as routing key in the message metadata.
+
+```properties
+mp.messaging.outgoing.channel-name-for-default-exchange.connector=smallrye-rabbitmq
+mp.messaging.outgoing.channel-name-for-default-exchange.exchange.is-default=true
+```

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageSender.java
@@ -49,7 +49,8 @@ public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>,
             final Uni<RabbitMQPublisher> retrieveSender) {
         this.retrieveSender = retrieveSender;
         this.configuration = oc;
-        this.configuredExchange = oc.getExchangeName().orElseGet(oc::getChannel);
+        this.configuredExchange = Boolean.TRUE.equals(oc.getExchangeIsDefault()) ? ""
+                : oc.getExchangeName().orElseGet(oc::getChannel);
         this.isTracingEnabled = oc.getTracingEnabled();
         this.inflights = oc.getMaxInflightMessages();
         this.defaultTtl = oc.getDefaultTtl();


### PR DESCRIPTION
This PR fixes #1641.

To address specific queues on RabbitMQ, e.g. when using the [RPC pattern](https://www.rabbitmq.com/tutorials/tutorial-six-java.html), the message has to be sent to the *default exchange*.

Currently, it is not possible to send message to the *default exchange*, as its implicit name is `""`, and Microprofile Config does not allow setting configuration parameters to `""`. Furthermore, the *default exchange* should not be declared again, so a separate treatment is required.

The proposed solution adds a new configuration parameter for outgoing RabbitMQ channels `exchange.is-default`. When the parameter is set to `true` the exchange is
1. not declared (so all other parameters concerning the exchange are ignored) and
2. `""` is used as exchange name when sending messages to RabbitMQ.


The change does not break existing configurations.