### PR TITLE
MQTT add overflow strategy to avoid overflow buffer full

### DIFF
--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
@@ -57,6 +57,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "buffer-size", direction = INCOMING, description = "The size buffer of incoming messages waiting to be processed", type = "int", defaultValue = "128")
 @ConnectorAttribute(name = "unsubscribe-on-disconnection", direction = INCOMING_AND_OUTGOING, description = "This flag restore the old behavior to unsubscribe from the broken on disconnection", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "overflow-strategy", direction = INCOMING_AND_OUTGOING, description = "Provides a way to control the overflow strategy, can be [`buffer`, `drop`, `drop-prev`]", type = "string", defaultValue = "buffer")
 public class MqttConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
 
     static final String CONNECTOR_NAME = "smallrye-mqtt";

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
@@ -56,6 +56,7 @@ public class MqttSource {
                     }
                     return multi;
                 });
+        // overflow strategy
         String ofs = config.getOverflowStrategy();
         if ("drop".equals(ofs)) {
             mqtt = mqtt.onOverflow().drop();

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
@@ -6,6 +6,7 @@ import static io.smallrye.reactive.messaging.mqtt.i18n.MqttLogging.log;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
+import io.smallrye.mutiny.Multi;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 
@@ -46,28 +47,34 @@ public class MqttSource {
                 .onComplete(outcome -> log.info("Subscription outcome: " + outcome))
                 .onSuccess(ignore -> ready.set(true));
 
-        this.source = ReactiveStreams.fromPublisher(
-                holder.stream()
-                        .select().where(m -> matches(topic, m))
-                        .onItem().transform(m -> new ReceivingMqttMessage(m, onNack))
-                        .stage(multi -> {
-                            if (broadcast) {
-                                return multi.broadcast().toAllSubscribers();
-                            }
-                            return multi;
-                        })
-                        .onOverflow().buffer(config.getBufferSize())
-                        .onCancellation().call(() -> {
-                            ready.set(false);
-                            if (config.getUnsubscribeOnDisconnection())
-                                return Uni
-                                        .createFrom()
-                                        .completionStage(holder.getClient()
-                                                .unsubscribe(topic).toCompletionStage());
-                            else
-                                return Uni.createFrom().voidItem();
-                        })
-                        .onFailure().invoke(log::unableToConnectToBroker));
+        Multi<ReceivingMqttMessage> mqtt = holder.stream()
+                .select().where(m -> matches(topic, m))
+                .onItem().transform(m -> new ReceivingMqttMessage(m, onNack))
+                .stage(multi -> {
+                    if (broadcast) {
+                        return multi.broadcast().toAllSubscribers();
+                    }
+                    return multi;
+                });
+        String ofs = config.getOverflowStrategy();
+        if ("drop".equals(ofs)) {
+            mqtt = mqtt.onOverflow().drop();
+        } else if ("drop-prev".equals(ofs)) {
+            mqtt = mqtt.onOverflow().dropPreviousItems();
+        } else {
+            mqtt = mqtt.onOverflow().buffer(config.getBufferSize());
+        }
+        this.source = ReactiveStreams.fromPublisher(mqtt.onCancellation().call(() -> {
+                    ready.set(false);
+                    if (config.getUnsubscribeOnDisconnection())
+                        return Uni
+                                .createFrom()
+                                .completionStage(holder.getClient()
+                                        .unsubscribe(topic).toCompletionStage());
+                    else
+                        return Uni.createFrom().voidItem();
+                })
+                .onFailure().invoke(log::unableToConnectToBroker));
     }
 
     /**

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
@@ -56,7 +56,7 @@ public class MqttSource {
                     }
                     return multi;
                 });
-        // overflow strategy
+        // overflow strategy can be drop, drop-prev or default buffer
         String ofs = config.getOverflowStrategy();
         if ("drop".equals(ofs)) {
             mqtt = mqtt.onOverflow().drop();


### PR DESCRIPTION
For fix issue https://github.com/smallrye/smallrye-reactive-messaging/issues/1945
Add a overflow strategy config to change `onOverflow()` implementation