### PR TITLE
Fix ContextDecorator for Kafka connector

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpConnector.java
@@ -59,6 +59,7 @@ import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.health.HealthReporter;
 import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.providers.locals.ContextOperator;
 import io.vertx.amqp.AmqpClientOptions;
 import io.vertx.amqp.AmqpReceiverOptions;
 import io.vertx.amqp.AmqpSenderOptions;
@@ -253,7 +254,7 @@ public class AmqpConnector implements IncomingConnectorFactory, OutgoingConnecto
             multi = multi.broadcast().toAllSubscribers();
         }
 
-        return ReactiveStreams.fromPublisher(multi);
+        return ReactiveStreams.fromPublisher(multi.plug(ContextOperator::apply));
     }
 
     @Override

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/LocalPropagationTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/LocalPropagationTest.java
@@ -29,7 +29,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
 import io.smallrye.reactive.messaging.annotations.Merge;
@@ -167,6 +170,22 @@ public class LocalPropagationTest extends AmqpBrokerTestBase {
     @Test
     public void testLinearPipelineWithAckOnCustomThread() {
         LinearPipelineWithAckOnCustomThread bean = runApplication(dataconfig(), LinearPipelineWithAckOnCustomThread.class);
+        await().until(() -> isAmqpConnectorReady(container));
+        await().until(() -> isAmqpConnectorAlive(container));
+        produceIntegers();
+
+        await().atMost(20, TimeUnit.SECONDS).until(() -> {
+            List<Integer> results = bean.getResults();
+            System.out.println(results);
+            return results.size() >= 5;
+        });
+        assertThat(bean.getResults()).containsExactly(2, 3, 4, 5, 6);
+
+    }
+
+    @Test
+    public void testPipelineWithAnAsyncStage() {
+        PipelineWithAnAsyncStage bean = runApplication(dataconfig(), PipelineWithAnAsyncStage.class);
         await().until(() -> isAmqpConnectorReady(container));
         await().until(() -> isAmqpConnectorAlive(container));
         produceIntegers();
@@ -577,6 +596,66 @@ public class LocalPropagationTest extends AmqpBrokerTestBase {
             assertThat(uuid).isNotNull();
 
             int p = Vertx.currentContext().getLocal("input");
+            assertThat(p + 1).isEqualTo(val);
+            list.add(val);
+        }
+
+        public List<Integer> getResults() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PipelineWithAnAsyncStage {
+
+        private final List<Integer> list = new CopyOnWriteArrayList<>();
+        private final Set<String> uuids = new ConcurrentHashSet<>();
+
+        @Incoming("data")
+        @Outgoing("process")
+        @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+        public Message<Integer> process(Message<Integer> input) {
+            String value = UUID.randomUUID().toString();
+            assertThat((String) ContextLocals.get("uuid", null)).isNull();
+            ContextLocals.put("uuid", value);
+            ContextLocals.put("input", input.getPayload());
+
+            assertThat(input.getMetadata(LocalContextMetadata.class)).isPresent();
+
+            return input.withPayload(input.getPayload() + 1);
+        }
+
+        @Incoming("process")
+        @Outgoing("after-process")
+        public Uni<Integer> handle(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            assertThat(uuids.add(uuid)).isTrue();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return Uni.createFrom().item(() -> payload)
+                    .runSubscriptionOn(Infrastructure.getDefaultExecutor());
+        }
+
+        @Incoming("after-process")
+        @Outgoing("sink")
+        public Integer afterProcess(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("sink")
+        public void sink(int val) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
             assertThat(p + 1).isEqualTo(val);
             list.add(val);
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -259,7 +259,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
      */
     @Override
     public <K, V> Uni<Void> handle(final IncomingKafkaRecord<K, V> record) {
-        return Uni.createFrom().completionStage(VertxContext.runOnContext(context.getDelegate(), f -> {
+        return Uni.createFrom().completionStage(VertxContext.runOnEventLoopContext(context.getDelegate(), f -> {
             TopicPartition topicPartition = getTopicPartition(record);
             OffsetStore store = offsetStores
                     .get(topicPartition);

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -31,6 +31,7 @@ import io.smallrye.reactive.messaging.kafka.*;
 import io.smallrye.reactive.messaging.kafka.commit.*;
 import io.smallrye.reactive.messaging.kafka.fault.KafkaFailureHandler;
 import io.smallrye.reactive.messaging.kafka.health.KafkaSourceHealth;
+import io.smallrye.reactive.messaging.providers.locals.ContextOperator;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.mutiny.core.Vertx;
@@ -158,7 +159,8 @@ public class KafkaSource<K, V> {
                 incomingMulti = incomingMulti.onItem().invoke(record -> incomingTrace(record, false));
             }
             this.stream = incomingMulti
-                    .onFailure().invoke(t -> reportFailure(t, false));
+                    .onFailure().invoke(t -> reportFailure(t, false))
+                    .plug(ContextOperator::apply);
             this.batchStream = null;
         } else {
             Multi<ConsumerRecords<K, V>> multi;
@@ -188,7 +190,8 @@ public class KafkaSource<K, V> {
                 incomingMulti = incomingMulti.onItem().invoke(this::incomingTrace);
             }
             this.batchStream = incomingMulti
-                    .onFailure().invoke(t -> reportFailure(t, false));
+                    .onFailure().invoke(t -> reportFailure(t, false))
+                    .plug(ContextOperator::apply);
             this.stream = null;
         }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
@@ -37,7 +37,6 @@ import io.smallrye.reactive.messaging.providers.extension.ReactiveMessagingExten
 import io.smallrye.reactive.messaging.providers.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.providers.impl.ConnectorFactories;
 import io.smallrye.reactive.messaging.providers.impl.InternalChannelRegistry;
-import io.smallrye.reactive.messaging.providers.locals.ContextDecorator;
 import io.smallrye.reactive.messaging.providers.metrics.MetricDecorator;
 import io.smallrye.reactive.messaging.providers.metrics.MicrometerDecorator;
 import io.smallrye.reactive.messaging.providers.wiring.Wiring;
@@ -94,7 +93,6 @@ public class WeldTestBase {
         weld.addBeanClass(KafkaClientServiceImpl.class);
         weld.addBeanClass(MetricDecorator.class);
         weld.addBeanClass(MicrometerDecorator.class);
-        weld.addBeanClass(ContextDecorator.class);
         weld.disableDiscovery();
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
@@ -236,14 +236,14 @@ public class KafkaCommitHandlerTest extends KafkaCompanionTestBase {
                 .with("group.id", "test-source-with-throttled-latest-processed-commit")
                 .with("value.deserializer", IntegerDeserializer.class.getName())
                 .with("commit-strategy", "throttled")
-                .with("throttled.unprocessed-record-max-age.ms", 1);
+                .with("throttled.unprocessed-record-max-age.ms", 100);
 
         MapBasedConfig config2 = newCommonConfigForSource()
                 .with("client.id", UUID.randomUUID().toString())
                 .with("group.id", "test-source-with-throttled-latest-processed-commit")
                 .with("value.deserializer", IntegerDeserializer.class.getName())
                 .with("commit-strategy", "throttled")
-                .with("throttled.unprocessed-record-max-age.ms", 1);
+                .with("throttled.unprocessed-record-max-age.ms", 100);
 
         KafkaConnectorIncomingConfiguration ic1 = new KafkaConnectorIncomingConfiguration(config1);
         KafkaConnectorIncomingConfiguration ic2 = new KafkaConnectorIncomingConfiguration(config2);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/ThrottledCommitStrategyTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/ThrottledCommitStrategyTest.java
@@ -1,0 +1,144 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.smallrye.reactive.messaging.kafka.KafkaRecord;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class ThrottledCommitStrategyTest extends KafkaCompanionTestBase {
+
+    @Test
+    public void testWithPartitions() {
+        companion.topics().createAndWait(topic, 3);
+        String sinkTopic = topic + "-sink";
+        companion.topics().createAndWait(sinkTopic, 3);
+        String groupId = UUID.randomUUID().toString();
+
+        MapBasedConfig config = kafkaConfig("mp.messaging.incoming.kafka")
+                .with("group.id", groupId)
+                .with("topic", topic)
+                .with("partitions", 3)
+                .with("auto.offset.reset", "earliest")
+                .with("commit-strategy", "throttled")
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .withPrefix("mp.messaging.outgoing.sink")
+                .with("connector", "smallrye-kafka")
+                .with("topic", sinkTopic)
+                .with("value.serializer", IntegerSerializer.class.getName());
+
+        ProcessorBean application = runApplication(config, ProcessorBean.class);
+
+        int expected = 3000;
+        Random random = new Random();
+        companion.produceIntegers().usingGenerator(i -> {
+            int p = random.nextInt(3);
+            return new ProducerRecord<>(topic, p, Integer.toString(p), i);
+        }, expected).awaitCompletion(Duration.ofMinutes(1));
+
+        await().atMost(1, TimeUnit.MINUTES)
+                .until(() -> application.count() >= expected);
+
+        companion.consumeIntegers().fromTopics(sinkTopic, expected)
+                .awaitCompletion(Duration.ofMinutes(1));
+    }
+
+    @Test
+    public void testWithPartitionsBlockingUnordered() {
+        companion.topics().createAndWait(topic, 3);
+        String groupId = UUID.randomUUID().toString();
+
+        MapBasedConfig config = kafkaConfig("mp.messaging.incoming.kafka")
+                .with("group.id", groupId)
+                .with("topic", topic)
+                .with("partitions", 3)
+                .with("auto.offset.reset", "earliest")
+                .with("commit-strategy", "throttled")
+                .with("value.deserializer", IntegerDeserializer.class.getName());
+
+        BlockingBean application = runApplication(config, BlockingBean.class);
+
+        int expected = 3000;
+        Random random = new Random();
+        companion.produceIntegers().usingGenerator(i -> {
+            int p = random.nextInt(3);
+            return new ProducerRecord<>(topic, p, Integer.toString(p), i);
+        }, expected).awaitCompletion(Duration.ofMinutes(1));
+
+        await().atMost(1, TimeUnit.MINUTES)
+                .until(() -> application.count() >= expected);
+    }
+
+    @ApplicationScoped
+    public static class ProcessorBean {
+        private final AtomicLong count = new AtomicLong();
+        private final Map<String, List<Integer>> received = new ConcurrentHashMap<>();
+
+        @Incoming("kafka")
+        @Outgoing("sink")
+        public Message<Integer> consume(KafkaRecord<String, Integer> msg) {
+            String k = Thread.currentThread().getName();
+            List<Integer> list = received.computeIfAbsent(k, s -> new CopyOnWriteArrayList<>());
+            list.add(msg.getPayload());
+            count.incrementAndGet();
+            return msg.withPayload(msg.getPayload() + 1)
+                    .addMetadata(OutgoingKafkaRecordMetadata.builder().withPartition(msg.getPartition()).build());
+        }
+
+        public Map<String, List<Integer>> getReceived() {
+            return received;
+        }
+
+        public long count() {
+            return count.get();
+        }
+    }
+
+    @ApplicationScoped
+    public static class BlockingBean {
+        private final AtomicLong count = new AtomicLong();
+        private final Map<String, List<Integer>> received = new ConcurrentHashMap<>();
+
+        @Incoming("kafka")
+        @Blocking(ordered = false)
+        public CompletionStage<Void> consume(Message<Integer> msg) throws InterruptedException {
+            String k = Thread.currentThread().getName();
+            List<Integer> list = received.computeIfAbsent(k, s -> new CopyOnWriteArrayList<>());
+            list.add(msg.getPayload());
+            count.incrementAndGet();
+            return msg.ack();
+        }
+
+        public Map<String, List<Integer>> getReceived() {
+            return received;
+        }
+
+        public long count() {
+            return count.get();
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
@@ -13,6 +13,7 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.mqtt.session.MqttClientSessionOptions;
 import io.smallrye.reactive.messaging.mqtt.session.RequestedQoS;
+import io.smallrye.reactive.messaging.providers.locals.ContextOperator;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.mqtt.messages.MqttPublishMessage;
 
@@ -74,7 +75,7 @@ public class MqttSource {
                                 .unsubscribe(topic).toCompletionStage());
             else
                 return Uni.createFrom().voidItem();
-        })
+        }).plug(ContextOperator::apply)
                 .onFailure().invoke(log::unableToConnectToBroker));
     }
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttTestBase.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttTestBase.java
@@ -27,7 +27,6 @@ import io.smallrye.reactive.messaging.providers.extension.ReactiveMessagingExten
 import io.smallrye.reactive.messaging.providers.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.providers.impl.ConnectorFactories;
 import io.smallrye.reactive.messaging.providers.impl.InternalChannelRegistry;
-import io.smallrye.reactive.messaging.providers.locals.ContextDecorator;
 import io.smallrye.reactive.messaging.providers.wiring.Wiring;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 import io.vertx.mqtt.MqttClientOptions;
@@ -129,7 +128,6 @@ public class MqttTestBase {
         weld.addPackages(EmitterImpl.class.getPackage());
         weld.addExtension(new ReactiveMessagingExtension());
         weld.addBeanClass(MqttConnector.class);
-        weld.addBeanClass(ContextDecorator.class);
         weld.addBeanClass(EmitterFactoryImpl.class);
         weld.addBeanClass(MutinyEmitterFactoryImpl.class);
         weld.addBeanClass(LegacyEmitterFactoryImpl.class);

--- a/smallrye-reactive-messaging-provider/revapi.json
+++ b/smallrye-reactive-messaging-provider/revapi.json
@@ -30,7 +30,11 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [  {
+        "code": "java.class.removed",
+        "old": "class io.smallrye.reactive.messaging.providers.locals.ContextDecorator",
+        "justification": "ContextDecorator no longer an implementation of PublisherDecorator, replaced by ContextOperator"
+    } ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/VertxContext.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/VertxContext.java
@@ -41,6 +41,12 @@ public class VertxContext {
         return future;
     }
 
+    public static <V> CompletionStage<V> runOnEventLoopContext(Context context, Consumer<CompletableFuture<V>> runnable) {
+        CompletableFuture<V> future = new CompletableFuture<>();
+        runOnEventLoopContext(context, () -> runnable.accept(future));
+        return future;
+    }
+
     public static <V> CompletionStage<V> callOnContext(Context context, Callable<V> callable) {
         return runOnContext(context, future -> {
             try {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
@@ -35,7 +35,6 @@ import io.smallrye.reactive.messaging.providers.extension.ReactiveMessagingExten
 import io.smallrye.reactive.messaging.providers.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.providers.impl.ConnectorFactories;
 import io.smallrye.reactive.messaging.providers.impl.InternalChannelRegistry;
-import io.smallrye.reactive.messaging.providers.locals.ContextDecorator;
 import io.smallrye.reactive.messaging.providers.metrics.MetricDecorator;
 import io.smallrye.reactive.messaging.providers.metrics.MicrometerDecorator;
 import io.smallrye.reactive.messaging.providers.wiring.Wiring;
@@ -111,7 +110,6 @@ public class WeldTestBaseWithoutTails {
                 MicrometerDecorator.class,
                 MetricDecorator.class,
                 HealthCenter.class,
-                ContextDecorator.class,
                 // Messaging provider
                 MyDummyConnector.class,
                 // Emitter factories

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/extension/AlternativeAnalysisTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/extension/AlternativeAnalysisTest.java
@@ -28,7 +28,6 @@ import io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.providers.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.providers.impl.ConnectorFactories;
 import io.smallrye.reactive.messaging.providers.impl.InternalChannelRegistry;
-import io.smallrye.reactive.messaging.providers.locals.ContextDecorator;
 import io.smallrye.reactive.messaging.providers.wiring.Wiring;
 
 /**
@@ -60,7 +59,6 @@ public class AlternativeAnalysisTest {
                 ConfiguredChannelFactory.class,
                 ConnectorFactories.class,
                 HealthCenter.class,
-                ContextDecorator.class,
                 // Messaging provider
                 MyDummyConnector.class,
 

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -42,6 +42,7 @@ import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.health.HealthReporter;
 import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;
+import io.smallrye.reactive.messaging.providers.locals.ContextOperator;
 import io.smallrye.reactive.messaging.rabbitmq.ack.RabbitMQAck;
 import io.smallrye.reactive.messaging.rabbitmq.ack.RabbitMQAckHandler;
 import io.smallrye.reactive.messaging.rabbitmq.ack.RabbitMQAutoAck;
@@ -249,7 +250,7 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
             multi = multi.broadcast().toAllSubscribers();
         }
 
-        return ReactiveStreams.fromPublisher(multi);
+        return ReactiveStreams.fromPublisher(multi.plug(ContextOperator::apply));
     }
 
     private Uni<RabbitMQConsumer> createConsumer(RabbitMQConnectorIncomingConfiguration ic, RabbitMQClient client) {

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/LocalPropagationTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/LocalPropagationTest.java
@@ -21,6 +21,9 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.common.vertx.ContextLocals;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
 import io.smallrye.reactive.messaging.annotations.Merge;
@@ -95,6 +98,16 @@ public class LocalPropagationTest extends WeldTestBase {
     @Test
     public void testLinearPipelineWithAckOnCustomThread() {
         LinearPipelineWithAckOnCustomThread bean = runApplication(dataconfig(), LinearPipelineWithAckOnCustomThread.class);
+        produceIntegers();
+
+        await().until(() -> bean.getResults().size() >= 5);
+        assertThat(bean.getResults()).containsExactly(2, 3, 4, 5, 6);
+
+    }
+
+    @Test
+    public void testPipelineWithAnAsyncStage() {
+        PipelineWithAnAsyncStage bean = runApplication(dataconfig(), PipelineWithAnAsyncStage.class);
         produceIntegers();
 
         await().until(() -> bean.getResults().size() >= 5);
@@ -501,6 +514,67 @@ public class LocalPropagationTest extends WeldTestBase {
             assertThat(uuid).isNotNull();
 
             int p = Vertx.currentContext().getLocal("input");
+            assertThat(p + 1).isEqualTo(val);
+            list.add(val);
+        }
+
+        public List<Integer> getResults() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PipelineWithAnAsyncStage {
+
+        private final List<Integer> list = new CopyOnWriteArrayList<>();
+        private final Set<String> uuids = new ConcurrentHashSet<>();
+
+        @Incoming("data")
+        @Outgoing("process")
+        @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+        public Message<Integer> process(Message<String> input) {
+            String value = UUID.randomUUID().toString();
+            int intPayload = Integer.parseInt(input.getPayload());
+            assertThat((String) ContextLocals.get("uuid", null)).isNull();
+            ContextLocals.put("uuid", value);
+            ContextLocals.put("input", intPayload);
+
+            assertThat(input.getMetadata(LocalContextMetadata.class)).isPresent();
+
+            return input.withPayload(intPayload + 1);
+        }
+
+        @Incoming("process")
+        @Outgoing("after-process")
+        public Uni<Integer> handle(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            assertThat(uuids.add(uuid)).isTrue();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return Uni.createFrom().item(() -> payload)
+                    .runSubscriptionOn(Infrastructure.getDefaultExecutor());
+        }
+
+        @Incoming("after-process")
+        @Outgoing("sink")
+        public Integer afterProcess(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("sink")
+        public void sink(int val) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
             assertThat(p + 1).isEqualTo(val);
             list.add(val);
         }

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/WeldTestBase.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/WeldTestBase.java
@@ -26,7 +26,6 @@ import io.smallrye.reactive.messaging.providers.extension.ReactiveMessagingExten
 import io.smallrye.reactive.messaging.providers.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.providers.impl.ConnectorFactories;
 import io.smallrye.reactive.messaging.providers.impl.InternalChannelRegistry;
-import io.smallrye.reactive.messaging.providers.locals.ContextDecorator;
 import io.smallrye.reactive.messaging.providers.metrics.MetricDecorator;
 import io.smallrye.reactive.messaging.providers.metrics.MicrometerDecorator;
 import io.smallrye.reactive.messaging.providers.wiring.Wiring;
@@ -68,7 +67,6 @@ public class WeldTestBase extends RabbitMQBrokerTestBase {
         weld.addBeanClass(RabbitMQConnector.class);
         weld.addBeanClass(MetricDecorator.class);
         weld.addBeanClass(MicrometerDecorator.class);
-        weld.addBeanClass(ContextDecorator.class);
         weld.disableDiscovery();
     }
 


### PR DESCRIPTION
- ContextDecorator renamed to ContextOperator, applied as an operator on connectors instead of PublisherDecorator.
- Fixes an issue, reproduced in `ThrottledCommitStrategyTest`, blocking Kafka message consumption when `partitions` > 1.