### PR TITLE
Companion improvements

### DIFF
--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
@@ -820,6 +820,29 @@ public class ConsumerBuilder<K, V> implements ConsumerRebalanceListener, Closeab
         return fromTopics(Collections.singleton(topic), until(numberOfRecords, during, null));
     }
 
+    public ConsumerTask<K, V> fromPrevious(KafkaTask<?, ?> task,
+            Function<Multi<ConsumerRecord<K, V>>, Multi<ConsumerRecord<K, V>>> plugFunction) {
+        Map<TopicPartition, Long> offsets = task.latestOffsets().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() + 1));
+        return fromOffsets(offsets, plugFunction);
+    }
+
+    public ConsumerTask<K, V> fromPrevious(KafkaTask<?, ?> task) {
+        return fromPrevious(task, Function.identity());
+    }
+
+    public ConsumerTask<K, V> fromPrevious(KafkaTask<?, ?> task, long numberOfRecords) {
+        return fromPrevious(task, until(numberOfRecords));
+    }
+
+    public ConsumerTask<K, V> fromPrevious(KafkaTask<?, ?> task, Duration during) {
+        return fromPrevious(task, until(during));
+    }
+
+    public ConsumerTask<K, V> fromPrevious(KafkaTask<?, ?> task, long numberOfRecords, Duration during) {
+        return fromPrevious(task, until(numberOfRecords, during, null));
+    }
+
     /**
      * Commit the given offset and close the consumer
      *

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerGroupsCompanion.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerGroupsCompanion.java
@@ -97,6 +97,15 @@ public class ConsumerGroupsCompanion {
 
     /**
      * @param groupId consumer group id
+     * @return the map of topic partitions to offset
+     */
+    public Map<TopicPartition, OffsetAndMetadata> offsets(String groupId) {
+        return toUni(adminClient.listConsumerGroupOffsets(groupId).partitionsToOffsetAndMetadata())
+                .await().atMost(kafkaApiTimeout);
+    }
+
+    /**
+     * @param groupId consumer group id
      * @param topicPartitions list of topic partitions
      * @return the map of topic partitions to offset
      */

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/KafkaTask.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/KafkaTask.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.Spliterator;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.apache.kafka.common.TopicPartition;
 
@@ -267,8 +269,16 @@ public abstract class KafkaTask<T, SELF extends KafkaTask<T, SELF>> implements I
         return offset(lastRecord);
     }
 
+    public Stream<T> stream() {
+        return StreamSupport.stream(spliterator(), false);
+    }
+
     public Map<TopicPartition, List<T>> byTopicPartition() {
-        return getRecords().stream().collect(Collectors.groupingBy(this::topicPartition));
+        return stream().collect(Collectors.groupingBy(this::topicPartition));
+    }
+
+    public Map<TopicPartition, Long> latestOffsets() {
+        return stream().collect(Collectors.toMap(this::topicPartition, this::offset, Math::max));
     }
 
     protected abstract long offset(T record);

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/TopicsCompanion.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/TopicsCompanion.java
@@ -89,6 +89,7 @@ public class TopicsCompanion {
     public Uni<TopicDescription> waitForTopic(String topic) {
         AtomicInteger retries = new AtomicInteger(0);
         return Uni.createFrom().item(this::describeAll)
+                .onItem().ifNull().continueWith(Collections.emptyMap())
                 .repeat()
                 .withDelay(Duration.ofMillis(1000))
                 .until(topics -> {
@@ -98,7 +99,7 @@ public class TopicsCompanion {
                     }
                     return !checkIfTheTopicIsCreated(topic, topics);
                 })
-                .select().where(Objects::nonNull)
+                .select().first(Objects::nonNull)
                 .toUni()
                 .map(topics -> topics.get(topic));
     }

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerTest.java
@@ -53,7 +53,9 @@ public class ConsumerTest extends KafkaCompanionTestBase {
 
     @Test
     void testConsumeParallel() {
-        companion.produceIntegers().usingGenerator(i -> record(topic, i), 1000)
+        companion.produceIntegers()
+                .withConcurrency()
+                .usingGenerator(i -> record(topic, i), 1000)
                 .awaitCompletion(Duration.ofSeconds(10));
 
         AtomicInteger records = new AtomicInteger();
@@ -123,7 +125,9 @@ public class ConsumerTest extends KafkaCompanionTestBase {
 
     @Test
     void testConsumeFromOffsets() {
-        companion.produceStrings().usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 100)
+        companion.produceStrings()
+                .withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 100)
                 .awaitCompletion();
 
         Map<TopicPartition, Long> offsets = new HashMap<>();
@@ -141,7 +145,9 @@ public class ConsumerTest extends KafkaCompanionTestBase {
 
     @Test
     void testConsumeFromOffsetsWithDuration() {
-        companion.produceStrings().usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 100)
+        companion.produceStrings()
+                .withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 100)
                 .awaitCompletion();
 
         Map<TopicPartition, Long> offsets = new HashMap<>();
@@ -158,7 +164,9 @@ public class ConsumerTest extends KafkaCompanionTestBase {
 
     @Test
     void testConsumerWithCommitAsync() {
-        companion.produceStrings().usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 108)
+        companion.produceStrings()
+                .withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 108)
                 .awaitCompletion();
 
         ConsumerBuilder<String, String> consumer = companion.consumeStrings()
@@ -171,7 +179,9 @@ public class ConsumerTest extends KafkaCompanionTestBase {
 
     @Test
     void testConsumerWithCommitAsyncCallback() {
-        companion.produceStrings().usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 108)
+        companion.produceStrings()
+                .withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 108)
                 .awaitCompletion();
 
         List<Map<TopicPartition, OffsetAndMetadata>> commits = new CopyOnWriteArrayList<>();
@@ -198,7 +208,9 @@ public class ConsumerTest extends KafkaCompanionTestBase {
 
     @Test
     void testConsumerWithCommitSync() {
-        companion.produceStrings().usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 108)
+        companion.produceStrings()
+                .withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>(topic, "t" + i), 108)
                 .awaitCompletion();
 
         ConsumerBuilder<String, String> consumer = companion.consumeStrings()
@@ -253,7 +265,7 @@ public class ConsumerTest extends KafkaCompanionTestBase {
         ConsumerBuilder<String, String> consumer = companion.consumeStrings();
 
         try (ConsumerTask<String, String> records = consumer.fromTopics(topic)) {
-            companion.produceStrings().usingGenerator(i -> record(topic, "v" + i), 200);
+            companion.produceStrings().withConcurrency().usingGenerator(i -> record(topic, "v" + i), 200);
 
             records.awaitRecords(100, Duration.ofMinutes(1));
 
@@ -270,7 +282,7 @@ public class ConsumerTest extends KafkaCompanionTestBase {
                 .withCommitSyncWhen(cr -> true);
 
         try (ConsumerTask<String, String> records = consumer.fromTopics(topic)) {
-            companion.produceStrings().usingGenerator(i -> record(topic, "v" + i), 200);
+            companion.produceStrings().withConcurrency().usingGenerator(i -> record(topic, "v" + i), 200);
 
             records.awaitRecords(100);
             await().untilAsserted(() -> assertThat(consumer.committed(tp(topic, 0)).offset())
@@ -288,7 +300,7 @@ public class ConsumerTest extends KafkaCompanionTestBase {
 
         ConsumerTask<String, String> records = consumer.fromTopics(topic, 100);
 
-        companion.produceStrings().usingGenerator(i -> record(topic, "v-" + i), 400);
+        companion.produceStrings().withConcurrency().usingGenerator(i -> record(topic, "v-" + i), 400);
 
         assertThat(records.awaitCompletion().count()).isEqualTo(100);
         await().untilAsserted(() -> assertThat(consumer.committed(tp(topic, 0)).offset()).isEqualTo(100L));
@@ -323,7 +335,9 @@ public class ConsumerTest extends KafkaCompanionTestBase {
 
     @Test
     void testPauseResume() throws InterruptedException {
-        companion.produceIntegers().usingGenerator(i -> record(topic, i), 400);
+        companion.produceIntegers()
+                .withConcurrency()
+                .usingGenerator(i -> record(topic, i), 400);
 
         ConsumerBuilder<String, Integer> consumer = companion.consumeIntegers();
 
@@ -349,6 +363,7 @@ public class ConsumerTest extends KafkaCompanionTestBase {
     void testCommitAndClose() {
         // produce records
         companion.produceIntegers()
+                .withConcurrency()
                 .usingGenerator(i -> new ProducerRecord<>(topic, i), 100)
                 .awaitCompletion();
 

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/OffsetsTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/OffsetsTest.java
@@ -23,7 +23,9 @@ public class OffsetsTest extends KafkaCompanionTestBase {
 
     @Test
     void testOffsetReset() {
-        companion.produceStrings().usingGenerator(i -> new ProducerRecord<>(topic, "" + i), 500)
+        companion.produceStrings()
+                .withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>(topic, "" + i), 500)
                 .awaitCompletion();
 
         String groupId = UUID.randomUUID().toString();

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/RecordsTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/RecordsTest.java
@@ -15,7 +15,8 @@ public class RecordsTest extends KafkaCompanionTestBase {
 
     @Test
     void testDeleteRecords() {
-        companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i), 100)
+        companion.produceIntegers().withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>(topic, i), 100)
                 .awaitCompletion();
 
         long offset = companion.offsets().get(tp(topic, 0), OffsetSpec.latest()).offset();
@@ -31,7 +32,9 @@ public class RecordsTest extends KafkaCompanionTestBase {
 
     @Test
     void testClearRecords() {
-        companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, i), 100)
+        companion.produceIntegers()
+                .withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>(topic, i), 100)
                 .awaitCompletion();
 
         assertThat(companion.consumeIntegers().fromTopics(topic, 100).awaitCompletion().count()).isEqualTo(100L);

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/test/EmbeddedKafkaTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/test/EmbeddedKafkaTest.java
@@ -92,7 +92,9 @@ public class EmbeddedKafkaTest {
         // create topic and wait
         companion.topics().createAndWait("messages", 3);
         // produce messages
-        companion.produceStrings().usingGenerator(i -> new ProducerRecord<>("messages", i % 3, "k", "" + i), 100);
+        companion.produceStrings()
+                .withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>("messages", i % 3, "k", "" + i), 100);
         // consume messages
         companion.consumeStrings().fromTopics("messages", 100).awaitCompletion();
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/SourceCloseTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/SourceCloseTest.java
@@ -21,7 +21,8 @@ public class SourceCloseTest extends KafkaCompanionTestBase {
 
     @Test
     public void testNoLostMessagesOnClose() {
-        companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, null, i), 1000)
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, null, i), 1000)
                 .awaitCompletion();
 
         String groupId = UUID.randomUUID().toString();

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/PartitionTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/PartitionTest.java
@@ -12,7 +12,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -51,20 +50,15 @@ public class PartitionTest extends KafkaCompanionTestBase {
                 .until(() -> application.count() == expected);
         assertThat(application.getReceived().keySet()).hasSizeGreaterThanOrEqualTo(getMaxNumberOfEventLoop(3));
 
-        Properties properties = new Properties();
-        properties.put("bootstrap.servers", companion.getBootstrapServers());
-        Admin admin = Admin.create(properties);
-
         await().until(() -> {
-            Map<TopicPartition, OffsetAndMetadata> map = admin.listConsumerGroupOffsets(groupId)
-                    .partitionsToOffsetAndMetadata().get();
+            Map<TopicPartition, OffsetAndMetadata> map = companion.consumerGroups().offsets(groupId);
             long c = map.values().stream().map(OffsetAndMetadata::offset).mapToLong(l -> l).sum();
             return map.size() == 3 && c == expected;
         });
     }
 
     @Test
-    public void testWithMoreConsumersThanPartitions() throws InterruptedException {
+    public void testWithMoreConsumersThanPartitions() {
         companion.topics().createAndWait(topic, 3);
         String groupId = UUID.randomUUID().toString();
         MapBasedConfig config = kafkaConfig("mp.messaging.incoming.kafka")
@@ -88,20 +82,15 @@ public class PartitionTest extends KafkaCompanionTestBase {
                 .until(() -> application.count() == expected);
         assertThat(application.getReceived().keySet()).hasSizeGreaterThanOrEqualTo(getMaxNumberOfEventLoop(3));
 
-        Properties properties = new Properties();
-        properties.put("bootstrap.servers", companion.getBootstrapServers());
-        Admin admin = Admin.create(properties);
-
         await().until(() -> {
-            Map<TopicPartition, OffsetAndMetadata> map = admin.listConsumerGroupOffsets(groupId)
-                    .partitionsToOffsetAndMetadata().get();
+            Map<TopicPartition, OffsetAndMetadata> map = companion.consumerGroups().offsets(groupId);
             long c = map.values().stream().map(OffsetAndMetadata::offset).mapToLong(l -> l).sum();
             return map.size() == 3 && c == expected;
         });
     }
 
     @Test
-    public void testWithMorePartitionsThanConsumers() throws InterruptedException {
+    public void testWithMorePartitionsThanConsumers() {
         companion.topics().createAndWait(topic, 3);
         String groupId = UUID.randomUUID().toString();
 
@@ -126,13 +115,8 @@ public class PartitionTest extends KafkaCompanionTestBase {
                 .until(() -> application.count() == expected);
         assertThat(application.getReceived().keySet()).hasSizeGreaterThanOrEqualTo(getMaxNumberOfEventLoop(2));
 
-        Properties properties = new Properties();
-        properties.put("bootstrap.servers", companion.getBootstrapServers());
-        Admin admin = Admin.create(properties);
-
         await().until(() -> {
-            Map<TopicPartition, OffsetAndMetadata> map = admin.listConsumerGroupOffsets(groupId)
-                    .partitionsToOffsetAndMetadata().get();
+            Map<TopicPartition, OffsetAndMetadata> map = companion.consumerGroups().offsets(groupId);
             long c = map.values().stream().map(OffsetAndMetadata::offset).mapToLong(l -> l).sum();
             return map.size() == 3 && c == expected;
         });

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/EndToEndPayloadPerfTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/EndToEndPayloadPerfTest.java
@@ -51,7 +51,9 @@ public class EndToEndPayloadPerfTest extends KafkaCompanionTestBase {
 
     @BeforeAll
     static void insertRecords() {
-        companion.produce(String.class, byte[].class).withClientId("payload-producer")
+        companion.produce(String.class, byte[].class)
+                .withConcurrency()
+                .withClientId("payload-producer")
                 .usingGenerator(i -> new ProducerRecord<>(input_topic, "key", generateRandomPayload(10000)), COUNT) // 10kb
                 .awaitCompletion(Duration.ofMinutes(5));
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/EndToEndPerfTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/EndToEndPerfTest.java
@@ -47,7 +47,9 @@ public class EndToEndPerfTest extends KafkaCompanionTestBase {
 
     @BeforeAll
     static void insertRecords() {
-        companion.produceStrings().usingGenerator(i -> new ProducerRecord<>(input_topic, "key", Long.toString(i)), COUNT)
+        companion.produceStrings()
+                .withConcurrency()
+                .usingGenerator(i -> new ProducerRecord<>(input_topic, "key", Long.toString(i)), COUNT)
                 .awaitCompletion(Duration.ofMinutes(5));
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/PauseResumePerfTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/PauseResumePerfTest.java
@@ -39,7 +39,7 @@ public class PauseResumePerfTest extends KafkaCompanionTestBase {
     @BeforeAll
     static void insertRecords() {
         expected = new ArrayList<>();
-        companion.produceStrings().usingGenerator(i -> {
+        companion.produceStrings().withConcurrency().usingGenerator(i -> {
             expected.add(Long.toString(i));
             return new ProducerRecord<>(topic, "key", Long.toString(i));
         }, COUNT).awaitCompletion(Duration.ofMinutes(5));

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/PerformanceConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/perf/PerformanceConsumerTest.java
@@ -35,7 +35,7 @@ public class PerformanceConsumerTest extends KafkaCompanionTestBase {
     @BeforeAll
     static void insertRecords() {
         expected = new ArrayList<>();
-        companion.produceStrings().usingGenerator(i -> {
+        companion.produceStrings().withConcurrency().usingGenerator(i -> {
             expected.add(Integer.toString(i));
             return new ProducerRecord<>(topic, "key", Long.toString(i));
         }, COUNT).awaitCompletion(Duration.ofMinutes(2));


### PR DESCRIPTION
- Option for companion producers to write to kafka concurrently, default concurrency is still 1
- ProducerTask and ConsumerTask get `latestOffsets` returning the latest offset per topic-partition
- Improve stability for topics createAndWait
- Added `companion.consumerGroups().offsets(groupId)`