### PR TITLE
kafka: Make microprofile-metrics-api dependency optional

### DIFF
--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -62,6 +62,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>


### PR DESCRIPTION
Fixes #1970.
