### PR TITLE
Mqtt outgoing message holds overridable info in metadata instead of message

### DIFF
--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttMessage.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttMessage.java
@@ -9,27 +9,36 @@ import io.smallrye.reactive.messaging.providers.locals.ContextAwareMessage;
 public interface MqttMessage<T> extends ContextAwareMessage<T> {
 
     static <T> MqttMessage<T> of(T payload) {
-        return new SendingMqttMessage<>(null, payload, null, false, null);
+        return new SendingMqttMessage<>(payload, new SendingMqttMessageMetadata(null, null, false), null);
+    }
+
+    static <T> MqttMessage<T> of(SendingMqttMessageMetadata metadata, T payload) {
+        return new SendingMqttMessage<>(payload, metadata, null);
+    }
+
+    static <T> MqttMessage<T> of(SendingMqttMessageMetadata metadata, T payload, Supplier<CompletionStage<Void>> ack) {
+        return new SendingMqttMessage<>(payload, metadata, ack);
     }
 
     static <T> MqttMessage<T> of(String topic, T payload) {
-        return new SendingMqttMessage<>(topic, payload, null, false, null);
+        return new SendingMqttMessage<>(payload, new SendingMqttMessageMetadata(topic, null, false), null);
     }
 
     static <T> MqttMessage<T> of(String topic, T payload, Supplier<CompletionStage<Void>> ack) {
-        return new SendingMqttMessage<>(topic, payload, null, false, ack);
+        return new SendingMqttMessage<>(payload, new SendingMqttMessageMetadata(topic, null, false), ack);
     }
 
     static <T> MqttMessage<T> of(String topic, T payload, MqttQoS qos) {
-        return new SendingMqttMessage<>(topic, payload, qos, false);
+        return new SendingMqttMessage<>(payload, new SendingMqttMessageMetadata(topic, qos, false));
     }
 
     static <T> MqttMessage<T> of(String topic, T payload, MqttQoS qos, boolean retain) {
-        return new SendingMqttMessage<>(topic, payload, qos, retain);
+        return new SendingMqttMessage<>(payload, new SendingMqttMessageMetadata(topic, qos, retain));
     }
 
     default MqttMessage<T> withAck(Supplier<CompletionStage<Void>> ack) {
-        return new SendingMqttMessage<>(getTopic(), getPayload(), getQosLevel(), isRetain(), ack);
+        return new SendingMqttMessage<>(getPayload(), new SendingMqttMessageMetadata(getTopic(), getQosLevel(), isRetain()),
+                ack);
     }
 
     int getMessageId();

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttMessageMetadata.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttMessageMetadata.java
@@ -1,0 +1,22 @@
+package io.smallrye.reactive.messaging.mqtt;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+
+public interface MqttMessageMetadata {
+
+    /**
+     * @return topic of the MQTT message
+     */
+    String getTopic();
+
+    /**
+     * @return the qos level of the MQTT message
+     */
+    MqttQoS getQosLevel();
+
+    /**
+     * @return {@code true} if the MQTT message is retained
+     */
+    boolean isRetain();
+
+}

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.mqtt;
 
 import static io.smallrye.reactive.messaging.mqtt.i18n.MqttLogging.log;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -68,8 +69,9 @@ public class MqttSink {
         final MqttQoS actualQoS;
         final boolean isRetain;
 
-        if (msg instanceof SendingMqttMessage) {
-            MqttMessage<?> mm = ((SendingMqttMessage<?>) msg);
+        Optional<SendingMqttMessageMetadata> metadata = msg.getMetadata(SendingMqttMessageMetadata.class);
+        if (metadata.isPresent()) {
+            SendingMqttMessageMetadata mm = metadata.get();
             actualTopicToBeUsed = mm.getTopic() == null ? this.topic : mm.getTopic();
             actualQoS = mm.getQosLevel() == null ? MqttQoS.valueOf(this.qos) : mm.getQosLevel();
             isRetain = mm.isRetain();

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/ReceivingMqttMessage.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/ReceivingMqttMessage.java
@@ -14,11 +14,13 @@ public class ReceivingMqttMessage implements MqttMessage<byte[]> {
     final MqttPublishMessage message;
     final MqttFailureHandler onNack;
     final Metadata metadata;
+    private final ReceivingMqttMessageMetadata receivingMetadata;
 
     ReceivingMqttMessage(MqttPublishMessage message, MqttFailureHandler onNack) {
         this.message = message;
         this.onNack = onNack;
-        this.metadata = captureContextMetadata();
+        this.receivingMetadata = new ReceivingMqttMessageMetadata(this.message);
+        this.metadata = captureContextMetadata(receivingMetadata);
     }
 
     @Override
@@ -31,24 +33,29 @@ public class ReceivingMqttMessage implements MqttMessage<byte[]> {
         return metadata;
     }
 
+    @Override
     public int getMessageId() {
-        return message.messageId();
+        return receivingMetadata.getMessageId();
     }
 
+    @Override
     public MqttQoS getQosLevel() {
-        return message.qosLevel();
+        return receivingMetadata.getQosLevel();
     }
 
+    @Override
     public boolean isDuplicate() {
-        return message.isDup();
+        return receivingMetadata.isDuplicate();
     }
 
+    @Override
     public boolean isRetain() {
-        return message.isRetain();
+        return receivingMetadata.isRetain();
     }
 
+    @Override
     public String getTopic() {
-        return message.topicName();
+        return receivingMetadata.getTopic();
     }
 
     @Override

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/ReceivingMqttMessageMetadata.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/ReceivingMqttMessageMetadata.java
@@ -1,0 +1,46 @@
+package io.smallrye.reactive.messaging.mqtt;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.vertx.mutiny.mqtt.messages.MqttPublishMessage;
+
+/**
+ * Used to represent MQTT metadata of an incoming message.
+ */
+public class ReceivingMqttMessageMetadata implements MqttMessageMetadata {
+
+    private final MqttPublishMessage message;
+
+    public ReceivingMqttMessageMetadata(MqttPublishMessage message) {
+        this.message = message;
+    }
+
+    /**
+     * @return the message id of the MQTT message
+     */
+    public int getMessageId() {
+        return message.messageId();
+    }
+
+    @Override
+    public String getTopic() {
+        return message.topicName();
+    }
+
+    @Override
+    public MqttQoS getQosLevel() {
+        return message.qosLevel();
+    }
+
+    @Override
+    public boolean isRetain() {
+        return message.isRetain();
+    }
+
+    /**
+     * @return {@code true} if the message is a duplicate
+     */
+    public boolean isDuplicate() {
+        return message.isDup();
+    }
+
+}

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessage.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessage.java
@@ -4,26 +4,31 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
 import io.netty.handler.codec.mqtt.MqttQoS;
 
 public final class SendingMqttMessage<T> implements MqttMessage<T> {
 
-    private final String topic;
     private final T payload;
-    private final MqttQoS qos;
-    private final boolean isRetain;
     private final Supplier<CompletionStage<Void>> ack;
+    private final SendingMqttMessageMetadata sendingMetadata;
+    private final Metadata metadata;
 
     SendingMqttMessage(String topic, T payload, MqttQoS qos, boolean isRetain, Supplier<CompletionStage<Void>> ack) {
-        this.topic = topic;
         this.payload = payload;
-        this.qos = qos;
-        this.isRetain = isRetain;
         this.ack = ack;
+        this.sendingMetadata = new SendingMqttMessageMetadata(topic, qos, isRetain);
+        this.metadata = Metadata.of(sendingMetadata);
     }
 
     SendingMqttMessage(String topic, T payload, MqttQoS qos, boolean isRetain) {
         this(topic, payload, qos, isRetain, null);
+    }
+
+    @Override
+    public Metadata getMetadata() {
+        return metadata;
     }
 
     @Override
@@ -48,7 +53,7 @@ public final class SendingMqttMessage<T> implements MqttMessage<T> {
     }
 
     public MqttQoS getQosLevel() {
-        return qos;
+        return sendingMetadata.getQosLevel();
     }
 
     public boolean isDuplicate() {
@@ -56,10 +61,10 @@ public final class SendingMqttMessage<T> implements MqttMessage<T> {
     }
 
     public boolean isRetain() {
-        return isRetain;
+        return sendingMetadata.isRetain();
     }
 
     public String getTopic() {
-        return topic;
+        return sendingMetadata.getTopic();
     }
 }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessage.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessage.java
@@ -15,15 +15,15 @@ public final class SendingMqttMessage<T> implements MqttMessage<T> {
     private final SendingMqttMessageMetadata sendingMetadata;
     private final Metadata metadata;
 
-    SendingMqttMessage(String topic, T payload, MqttQoS qos, boolean isRetain, Supplier<CompletionStage<Void>> ack) {
+    SendingMqttMessage(T payload, SendingMqttMessageMetadata metadata, Supplier<CompletionStage<Void>> ack) {
         this.payload = payload;
         this.ack = ack;
-        this.sendingMetadata = new SendingMqttMessageMetadata(topic, qos, isRetain);
+        this.sendingMetadata = metadata;
         this.metadata = Metadata.of(sendingMetadata);
     }
 
-    SendingMqttMessage(String topic, T payload, MqttQoS qos, boolean isRetain) {
-        this(topic, payload, qos, isRetain, null);
+    SendingMqttMessage(T payload, SendingMqttMessageMetadata metadata) {
+        this(payload, metadata, null);
     }
 
     @Override
@@ -44,26 +44,32 @@ public final class SendingMqttMessage<T> implements MqttMessage<T> {
         return this::ack;
     }
 
+    @Override
     public T getPayload() {
         return payload;
     }
 
+    @Override
     public int getMessageId() {
         return -1;
     }
 
+    @Override
     public MqttQoS getQosLevel() {
         return sendingMetadata.getQosLevel();
     }
 
+    @Override
     public boolean isDuplicate() {
         return false;
     }
 
+    @Override
     public boolean isRetain() {
         return sendingMetadata.isRetain();
     }
 
+    @Override
     public String getTopic() {
         return sendingMetadata.getTopic();
     }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessageMetadata.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessageMetadata.java
@@ -5,7 +5,7 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 /**
  * Used to represent MQTT metadata in on outgoing message.
  */
-public final class SendingMqttMessageMetadata {
+public final class SendingMqttMessageMetadata implements MqttMessageMetadata {
 
     private final String topic;
     private final MqttQoS qos;
@@ -17,15 +17,18 @@ public final class SendingMqttMessageMetadata {
         this.isRetain = isRetain;
     }
 
+    @Override
+    public String getTopic() {
+        return topic;
+    }
+
+    @Override
     public MqttQoS getQosLevel() {
         return qos;
     }
 
+    @Override
     public boolean isRetain() {
         return isRetain;
-    }
-
-    public String getTopic() {
-        return topic;
     }
 }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessageMetadata.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessageMetadata.java
@@ -1,0 +1,31 @@
+package io.smallrye.reactive.messaging.mqtt;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+
+/**
+ * Used to represent MQTT metadata in on outgoing message.
+ */
+public final class SendingMqttMessageMetadata {
+
+    private final String topic;
+    private final MqttQoS qos;
+    private final boolean isRetain;
+
+    public SendingMqttMessageMetadata(String topic, MqttQoS qos, boolean isRetain) {
+        this.topic = topic;
+        this.qos = qos;
+        this.isRetain = isRetain;
+    }
+
+    public MqttQoS getQosLevel() {
+        return qos;
+    }
+
+    public boolean isRetain() {
+        return isRetain;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+}

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicTopicEmitterProducingBean.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/DynamicTopicEmitterProducingBean.java
@@ -1,0 +1,45 @@
+package io.smallrye.reactive.messaging.mqtt;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.reactivestreams.Publisher;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+
+@ApplicationScoped
+public class DynamicTopicEmitterProducingBean {
+
+    private final List<String> topics = new ArrayList<>(10);
+
+    @Inject
+    @Channel("sink")
+    MutinyEmitter<String> emitter;
+
+    @Incoming("dyn-data")
+    public Uni<Void> process(Message<Integer> input) {
+        String topic = "T" + input.getPayload();
+        topics.add(topic);
+        return emitter.sendMessage(MqttMessage.of(topic, input.getPayload().toString(), MqttQoS.AT_LEAST_ONCE, false))
+                .chain(() -> Uni.createFrom().completionStage(input::ack));
+    }
+
+    @Outgoing("dyn-data")
+    public Publisher<Integer> source() {
+        return Multi.createFrom().range(0, 10);
+    }
+
+    public List<String> getTopics() {
+        return topics;
+    }
+}

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttMessageTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttMessageTest.java
@@ -69,4 +69,18 @@ public class MqttMessageTest {
         assertThat(message.isDuplicate()).isFalse();
         assertThat(message.isRetain()).isTrue();
     }
+
+    @Test
+    void testOfMetadata() {
+        MqttMessage<String> message = MqttMessage.of(
+                new SendingMqttMessageMetadata("topic3", MqttQoS.EXACTLY_ONCE, true),
+                "testWithRetain");
+
+        assertThat(message.getPayload()).isEqualTo("testWithRetain");
+        assertThat(message.getTopic()).isEqualTo("topic3");
+        assertThat(message.getMessageId()).isEqualTo(-1);
+        assertThat(message.getQosLevel()).isEqualTo(MqttQoS.EXACTLY_ONCE);
+        assertThat(message.isDuplicate()).isFalse();
+        assertThat(message.isRetain()).isTrue();
+    }
 }


### PR DESCRIPTION
Prevents losing the info when Message modifiers are used.

Issue reported in https://github.com/quarkusio/quarkus/issues/29064