### PR TITLE
Add Sonatype s01 snapshots configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,6 +582,16 @@
 
   <repositories>
     <repository>
+      <id>sonatype-snapshots</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>microprofile-snapshots</id>
       <url>https://repo.eclipse.org/content/repositories/microprofile-snapshots</url>
       <releases>


### PR DESCRIPTION
This is needed in order to use Vert.x snapshots