### PR TITLE
Sending error on messages stream block next messages in case of reconnection

### DIFF
--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/Clients.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/Clients.java
@@ -56,7 +56,6 @@ public class Clients {
             this.client = client;
             messages = BroadcastProcessor.create();
             client.messageHandler(m -> messages.onNext(MqttPublishMessage.newInstance(m)));
-            client.exceptionHandler(messages::onError);
         }
 
         public Future<Void> start() {


### PR DESCRIPTION
I remove the notification of a connection error on the message processor. 

Calling _onError_ stop the execution of the stream andMQTT client call the handler in case of a reconnection. So, for example, if I reboot the broker I didn't receive no more messages.