### PR TITLE
Update OpenTelemetry dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
 
     <kafka.version>3.3.1</kafka.version>
 
-    <opentelemetry.version>1.21.0</opentelemetry.version>
-    <opentelemetry-semver.version>1.21.0-alpha</opentelemetry-semver.version>
+    <opentelemetry.version>1.22.0</opentelemetry.version>
+    <opentelemetry-semver.version>1.22.0-alpha</opentelemetry-semver.version>
 
     <smallrye-vertx-mutiny-clients.version>2.26.0</smallrye-vertx-mutiny-clients.version>
     <smallrye-reactive-converters.version>2.6.0</smallrye-reactive-converters.version>


### PR DESCRIPTION
* Bumps opentelemetry.version from 1.21.0 to 1.22.0.
* Bumps opentelemetry-semconv from 1.21.0-alpha to 1.22.0-alpha.

Supersedes #2035 and #2036
