### PR TITLE
Rollback opentelemetry "instrumentation" api version to 1.21.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
 
     <kafka.version>3.3.1</kafka.version>
 
-    <opentelemetry.version>1.22.0</opentelemetry.version>
-    <opentelemetry-semver.version>1.22.0-alpha</opentelemetry-semver.version>
+    <opentelemetry.version>1.21.0</opentelemetry.version>
+    <opentelemetry-semver.version>1.21.0-alpha</opentelemetry-semver.version>
 
     <smallrye-vertx-mutiny-clients.version>2.26.0</smallrye-vertx-mutiny-clients.version>
     <smallrye-reactive-converters.version>2.6.0</smallrye-reactive-converters.version>


### PR DESCRIPTION
opentelemetry api was bumped to 1.22.x but opentelemetry-instrumentation artifacts is still on 1.21.x. 
