### PR TITLE
HealtCheck on MQTT Connector

### DIFF
--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/Clients.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/Clients.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.mqtt;
 
+import static io.smallrye.reactive.messaging.mqtt.i18n.MqttLogging.log;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,6 +36,7 @@ public class Clients {
                 + "<" + (server == null ? "" : server)
                 + ">-[" + (clientId != null ? clientId : "") + "]";
         return clients.computeIfAbsent(id, key -> {
+            log.infof("Create MQTT Client for %s.", id);
             MqttClientSession client = MqttClientSession.create(vertx.getDelegate(), options);
             return new ClientHolder(client);
         });

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
@@ -22,6 +22,9 @@ import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 
 import io.smallrye.reactive.messaging.annotations.ConnectorAttribute;
+import io.smallrye.reactive.messaging.annotations.ConnectorAttribute.Direction;
+import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.health.HealthReporter;
 import io.smallrye.reactive.messaging.mqtt.session.MqttClientSessionOptions;
 import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;
 import io.vertx.mutiny.core.Vertx;
@@ -31,6 +34,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "client-id", type = "string", direction = INCOMING_AND_OUTGOING, description = "Set the client identifier")
 @ConnectorAttribute(name = "auto-generated-client-id", type = "boolean", direction = INCOMING_AND_OUTGOING, description = "Set if the MQTT client must generate clientId automatically", defaultValue = "true")
 @ConnectorAttribute(name = "auto-keep-alive", type = "boolean", direction = INCOMING_AND_OUTGOING, description = "Set if the MQTT client must handle `PINGREQ` automatically", defaultValue = "true")
+@ConnectorAttribute(name = "health-enabled", type = "boolean", direction = Direction.INCOMING_AND_OUTGOING, description = "Whether health reporting is enabled (default) or disabled", defaultValue = "true")
 @ConnectorAttribute(name = "ssl", type = "boolean", direction = INCOMING_AND_OUTGOING, description = "Set whether SSL/TLS is enabled", defaultValue = "false")
 @ConnectorAttribute(name = "ssl.keystore.type", type = "string", direction = INCOMING_AND_OUTGOING, description = "Set the keystore type [`pkcs12`, `jks`, `pem`]", defaultValue = "pkcs12")
 @ConnectorAttribute(name = "ssl.keystore.location", type = "string", direction = INCOMING_AND_OUTGOING, description = "Set the keystore location. In case of `pem` type this is the server ca cert path")
@@ -61,12 +65,12 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "buffer-size", direction = INCOMING, description = "The size buffer of incoming messages waiting to be processed", type = "int", defaultValue = "128")
 @ConnectorAttribute(name = "unsubscribe-on-disconnection", direction = INCOMING_AND_OUTGOING, description = "This flag restore the old behavior to unsubscribe from the broken on disconnection", type = "boolean", defaultValue = "false")
-public class MqttConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
+public class MqttConnector implements IncomingConnectorFactory, OutgoingConnectorFactory, HealthReporter {
 
     static final String CONNECTOR_NAME = "smallrye-mqtt";
 
     @Inject
-    private ExecutionHolder executionHolder;
+    ExecutionHolder executionHolder;
 
     @Inject
     @Any
@@ -95,22 +99,41 @@ public class MqttConnector implements IncomingConnectorFactory, OutgoingConnecto
         return sink.getSink();
     }
 
-    public boolean isReady() {
-        boolean ready = isSourceReady();
-
-        for (MqttSink sink : sinks) {
-            ready = ready && sink.isReady();
+    @Override
+    public HealthReport getStartup() {
+        HealthReport.HealthReportBuilder builder = HealthReport.builder();
+        for (MqttSource source : sources) {
+            source.isStarted(builder);
         }
-
-        return ready;
+        for (MqttSink sink : sinks) {
+            sink.isStarted(builder);
+        }
+        return builder.build();
     }
 
-    public boolean isSourceReady() {
-        boolean ready = true;
+    @Override
+    public HealthReport getReadiness() {
+        HealthReport.HealthReportBuilder builder = HealthReport.builder();
         for (MqttSource source : sources) {
-            ready = ready && source.isReady();
+            source.isReady(builder);
         }
-        return ready;
+        for (MqttSink sink : sinks) {
+            sink.isReady(builder);
+        }
+        return builder.build();
+
+    }
+
+    @Override
+    public HealthReport getLiveness() {
+        HealthReport.HealthReportBuilder builder = HealthReport.builder();
+        for (MqttSource source : sources) {
+            source.isAlive(builder);
+        }
+        for (MqttSink sink : sinks) {
+            sink.isAlive(builder);
+        }
+        return builder.build();
     }
 
     public void destroy(@Observes @Destroyed(ApplicationScoped.class) final Object context) {

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
@@ -72,7 +72,7 @@ public class MqttSink {
     }
 
     private Uni<? extends Message<?>> send(Message<?> msg) {
-        MqttClientSession client = reference.get().getClient();
+        final MqttClientSession client = reference.get().getClient();
         final String actualTopicToBeUsed;
         final MqttQoS actualQoS;
         final boolean isRetain;
@@ -88,7 +88,7 @@ public class MqttSink {
             isRetain = false;
             actualQoS = MqttQoS.valueOf(this.qos);
         }
-
+        
         if (actualTopicToBeUsed == null) {
             log.ignoringNoTopicSet();
             return Uni.createFrom().item(msg);

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
@@ -81,7 +81,6 @@ public class MqttSink {
 
         @Override
         public void subscribe(Subscriber<? super Message<?>> subscriber) {
-            System.out.println("subscribe");
             this.subscriber = subscriber;
             subscriber.onSubscribe(new Subscription() {
                 @Override
@@ -108,7 +107,6 @@ public class MqttSink {
 
         @Override
         public void onSubscribe(Subscription subscription) {
-            System.out.println("onSubscribe");
             this.subscription = subscription;
             ClientHolder client = Clients.getHolder(vertx, options);
             reference.set(client);
@@ -168,17 +166,17 @@ public class MqttSink {
 
         return AsyncResultUni
                 .<Integer> toUni(h -> {
-                    reference.get().getClient()
-                            .publish(actualTopicToBeUsed, convert(msg.getPayload()).getDelegate(), actualQoS, false, isRetain)
-                            .onComplete(h);
+            reference.get().getClient()
+                    .publish(actualTopicToBeUsed, convert(msg.getPayload()).getDelegate(), actualQoS, false, isRetain)
+                    .onComplete(h);
                 })
                 .onItemOrFailure().transformToUni((s, f) -> {
-                    if (f != null) {
-                        return Uni.createFrom().completionStage(msg.nack(f).thenApply(x -> msg));
-                    } else {
-                        OutgoingMessageMetadata.setResultOnMessage(msg, s);
-                        return Uni.createFrom().completionStage(msg.ack().thenApply(x -> msg));
-                    }
+            if (f != null) {
+                return Uni.createFrom().completionStage(msg.nack(f).thenApply(x -> msg));
+            } else {
+                OutgoingMessageMetadata.setResultOnMessage(msg, s);
+                return Uni.createFrom().completionStage(msg.ack().thenApply(x -> msg));
+            }
                 })
                 .subscribeAsCompletionStage();
     }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
@@ -146,10 +146,6 @@ public class MqttSink {
         return reference.get() != null && reference.get().getClient().isConnected();
     }
 
-    private boolean isDisconnected() {
-        return reference.get() != null && reference.get().getClient().isDisconnected();
-    }
-
     public void isStarted(HealthReportBuilder builder) {
         if (healthEnabled)
             builder.add(channel, started.get());
@@ -162,7 +158,7 @@ public class MqttSink {
 
     public void isAlive(HealthReportBuilder builder) {
         if (healthEnabled)
-            builder.add(channel, !isDisconnected());
+            builder.add(channel, alive.get());
     }
 
 }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
@@ -12,6 +12,7 @@ import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 
 import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.health.HealthReport.HealthReportBuilder;
 import io.smallrye.reactive.messaging.mqtt.internal.MqttHelpers;
 import io.smallrye.reactive.messaging.mqtt.internal.MqttTopicHelper;
 import io.smallrye.reactive.messaging.mqtt.session.MqttClientSessionOptions;
@@ -20,17 +21,26 @@ import io.vertx.mutiny.core.Vertx;
 
 public class MqttSource {
 
-    private final PublisherBuilder<MqttMessage<?>> source;
-    private final AtomicBoolean ready = new AtomicBoolean();
+    private final String channel;
     private final Pattern pattern;
+    private final boolean healthEnabled;
+
+    private final PublisherBuilder<MqttMessage<?>> source;
+
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean ready = new AtomicBoolean();
+    private final Clients.ClientHolder holder;
 
     public MqttSource(Vertx vertx, MqttConnectorIncomingConfiguration config,
             Instance<MqttClientSessionOptions> instances) {
         MqttClientSessionOptions options = MqttHelpers.createClientOptions(config, instances);
 
-        String topic = config.getTopic().orElseGet(config::getChannel);
+        channel = config.getChannel();
+        String topic = config.getTopic().orElse(channel);
         int qos = config.getQos();
         boolean broadcast = config.getBroadcast();
+        healthEnabled = config.getHealthEnabled();
+
         MqttFailureHandler.Strategy strategy = MqttFailureHandler.Strategy.from(config.getFailureStrategy());
         MqttFailureHandler onNack = createFailureHandler(strategy, config.getChannel());
 
@@ -43,21 +53,23 @@ public class MqttSource {
             pattern = null;
         }
 
-        Clients.ClientHolder holder = Clients.getHolder(vertx, options);
-        holder.start();
+        holder = Clients.getHolder(vertx, options);
+        holder.start().onSuccess(ignore -> started.set(true));
         holder.getClient()
                 .subscribe(topic, RequestedQoS.valueOf(qos))
-                .onComplete(outcome -> log.info("Subscription outcome: " + outcome))
-                .onSuccess(ignore -> ready.set(true));
+                .onFailure(outcome -> log.info("Subscription failed!"))
+                .onSuccess(outcome -> {
+                    log.info("Subscription success on topic " + topic + ", Max QoS " + outcome + ".");
+                    ready.set(true);
+                });
 
         this.source = ReactiveStreams.fromPublisher(
                 holder.stream()
                         .select().where(m -> MqttTopicHelper.matches(topic, pattern, m))
                         .onItem().transform(m -> new ReceivingMqttMessage(m, onNack))
                         .stage(multi -> {
-                            if (broadcast) {
+                            if (broadcast)
                                 return multi.broadcast().toAllSubscribers();
-                            }
                             return multi;
                         })
                         .onOverflow().buffer(config.getBufferSize())
@@ -89,8 +101,19 @@ public class MqttSource {
         return source;
     }
 
-    public boolean isReady() {
-        return ready.get();
+    public void isStarted(HealthReportBuilder builder) {
+        if (healthEnabled)
+            builder.add(channel, started.get());
+    }
+
+    public void isReady(HealthReportBuilder builder) {
+        if (healthEnabled)
+            builder.add(channel, ready.get());
+    }
+
+    public void isAlive(HealthReportBuilder builder) {
+        if (healthEnabled)
+            builder.add(channel, holder.getClient().isConnected());
     }
 
 }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
@@ -111,12 +111,12 @@ public class MqttSource {
 
     public void isReady(HealthReportBuilder builder) {
         if (healthEnabled)
-            builder.add(channel, alive.get());
+            builder.add(channel, holder.getClient().isConnected());
     }
 
     public void isAlive(HealthReportBuilder builder) {
         if (healthEnabled)
-            builder.add(channel, !holder.getClient().isDisconnected());
+            builder.add(channel, alive.get());
     }
 
 }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/MqttClientSession.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/MqttClientSession.java
@@ -129,6 +129,15 @@ public interface MqttClientSession {
     }
 
     /**
+     * Check if the session is currently disconnected.
+     *
+     * @return {@code true} if the session is currently disconnected, {@code false} otherwise.
+     */
+    default boolean isDisconnected() {
+        return getState() == SessionState.DISCONNECTED;
+    }
+
+    /**
      * Subscribes to a single topic with related QoS level.
      *
      * @param topic The topic to subscribe to.

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/MqttClientSession.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/MqttClientSession.java
@@ -129,15 +129,6 @@ public interface MqttClientSession {
     }
 
     /**
-     * Check if the session is currently disconnected.
-     *
-     * @return {@code true} if the session is currently disconnected, {@code false} otherwise.
-     */
-    default boolean isDisconnected() {
-        return getState() == SessionState.DISCONNECTED;
-    }
-
-    /**
      * Subscribes to a single topic with related QoS level.
      *
      * @param topic The topic to subscribe to.

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ConnectionSharingTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ConnectionSharingTest.java
@@ -41,11 +41,9 @@ public class ConnectionSharingTest extends MqttTestBase {
         container = weld.initialize();
 
         App bean = container.getBeanManager().createInstance().select(App.class).get();
+        MqttConnector mqttConnector = this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get();
 
-        await()
-                .until(
-                        () -> this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());
-
+        await().until(() -> mqttConnector.getReadiness().isOk());
         await().atMost(2, TimeUnit.MINUTES).until(() -> bean.prices().size() >= 10);
         assertThat(bean.prices()).isNotEmpty();
     }

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/FailureHandlerTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/FailureHandlerTest.java
@@ -52,7 +52,7 @@ public class FailureHandlerTest extends MqttTestBase {
 
         MqttConnector connector = container.getBeanManager().createInstance().select(MqttConnector.class,
                 ConnectorLiteral.of(MqttConnector.CONNECTOR_NAME)).get();
-        await().until(connector::isReady);
+        await().until(() -> connector.getReadiness().isOk());
 
         usage.produceStrings("fail", 10, null, () -> Integer.toString(counter.getAndIncrement()));
 
@@ -69,7 +69,7 @@ public class FailureHandlerTest extends MqttTestBase {
 
         MqttConnector connector = container.getBeanManager().createInstance().select(MqttConnector.class,
                 ConnectorLiteral.of(MqttConnector.CONNECTOR_NAME)).get();
-        await().until(connector::isReady);
+        await().until(() -> connector.getReadiness().isOk());
 
         usage.produceStrings("ignore", 10, null, () -> Integer.toString(counter.getAndIncrement()));
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/HealthCheckTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/HealthCheckTest.java
@@ -59,10 +59,10 @@ public class HealthCheckTest extends MqttTestBase {
 
         await()
                 .pollInterval(Duration.ofSeconds(1))
-                .until(() -> !connector.getLiveness().isOk());
+                .until(() -> !connector.getReadiness().isOk());
 
         liveness = getHealth().getLiveness();
-        assertThat(liveness.isOk()).isFalse();
+        assertThat(liveness.isOk()).isTrue();
 
     }
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/HealthCheckTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/HealthCheckTest.java
@@ -1,0 +1,134 @@
+package io.smallrye.reactive.messaging.mqtt;
+
+import static io.smallrye.reactive.messaging.mqtt.MqttConnector.CONNECTOR_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.health.HealthReport;
+import io.smallrye.reactive.messaging.providers.extension.HealthCenter;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class HealthCheckTest extends MqttTestBase {
+
+    private WeldContainer container;
+
+    @AfterEach
+    public void cleanup() {
+        if (container != null) {
+            container.close();
+        }
+    }
+
+    private void awaitAndVerify() {
+
+        container.getBeanManager().createInstance().select(JustToStartConnector.class).get();
+        MqttConnector connector = this.container.select(MqttConnector.class, ConnectorLiteral.of(CONNECTOR_NAME)).get();
+
+        await()
+                .pollInterval(Duration.ofSeconds(1))
+                .until(() -> connector.getReadiness().isOk());
+
+        HealthReport startup = getHealth().getStartup();
+        HealthReport liveness = getHealth().getLiveness();
+        HealthReport readiness = getHealth().getReadiness();
+
+        assertThat(startup.isOk()).isTrue();
+        assertThat(liveness.isOk()).isTrue();
+        assertThat(readiness.isOk()).isTrue();
+
+        assertThat(liveness.getChannels().size()).isEqualTo(2);
+
+        mosquitto.stop();
+
+        await()
+                .pollInterval(Duration.ofSeconds(1))
+                .until(() -> !connector.getLiveness().isOk());
+
+        liveness = getHealth().getLiveness();
+        assertThat(liveness.isOk()).isFalse();
+
+    }
+
+    @Test
+    public void testWithDash() {
+        Weld weld = baseWeld(getConfig());
+        weld.addBeanClass(JustToStartConnector.class);
+
+        container = weld.initialize();
+
+        awaitAndVerify();
+    }
+
+    private MapBasedConfig getConfig() {
+        String prefix = "mp.messaging.outgoing.out.";
+        Map<String, Object> config = new HashMap<>();
+        config.put(prefix + "connector", CONNECTOR_NAME);
+        config.put(prefix + "host", System.getProperty("mqtt-host"));
+        config.put(prefix + "port", Integer.valueOf(System.getProperty("mqtt-port")));
+        if (System.getProperty("mqtt-user") != null) {
+            config.put(prefix + "username", System.getProperty("mqtt-user"));
+            config.put(prefix + "password", System.getProperty("mqtt-pwd"));
+        }
+
+        prefix = "mp.messaging.incoming.in.";
+        config.put(prefix + "connector", CONNECTOR_NAME);
+        config.put(prefix + "host", System.getProperty("mqtt-host"));
+        config.put(prefix + "port", Integer.valueOf(System.getProperty("mqtt-port")));
+        if (System.getProperty("mqtt-user") != null) {
+            config.put(prefix + "username", System.getProperty("mqtt-user"));
+            config.put(prefix + "password", System.getProperty("mqtt-pwd"));
+        }
+        return new MapBasedConfig(config);
+    }
+
+    public HealthCenter getHealth() {
+        if (container == null) {
+            throw new IllegalStateException("Application not started");
+        }
+        return container.getBeanManager().createInstance().select(HealthCenter.class).get();
+    }
+
+    public boolean isStarted() {
+        return getHealth().getStartup().isOk();
+    }
+
+    public boolean isReady() {
+        return getHealth().getReadiness().isOk();
+    }
+
+    public boolean isAlive() {
+        return getHealth().getLiveness().isOk();
+    }
+
+    @ApplicationScoped
+    public static class JustToStartConnector {
+
+        @Inject
+        @Channel("out")
+        Emitter<String> emitter;
+
+        @Incoming("in")
+        public CompletionStage<Void> received(MqttMessage<byte[]> message) {
+            return message.ack();
+        }
+
+    }
+
+}

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/LocalPropagationAckTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/LocalPropagationAckTest.java
@@ -70,7 +70,7 @@ public class LocalPropagationAckTest extends MqttTestBase {
     public void waitUntilReady(WeldContainer container) {
         MqttConnector connector = container.select(MqttConnector.class,
                 ConnectorLiteral.of(MqttConnector.CONNECTOR_NAME)).get();
-        await().until(connector::isReady);
+        await().until(() -> connector.getReadiness().isOk());
     }
 
     @BeforeEach

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/LocalPropagationTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/LocalPropagationTest.java
@@ -80,7 +80,7 @@ public class LocalPropagationTest extends MqttTestBase {
     public void waitUntilReady(WeldContainer container) {
         MqttConnector connector = container.select(MqttConnector.class,
                 ConnectorLiteral.of(MqttConnector.CONNECTOR_NAME)).get();
-        await().until(connector::isReady);
+        await().until(() -> connector.getReadiness().isOk());
     }
 
     @BeforeEach

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttCustomOptionTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttCustomOptionTest.java
@@ -48,7 +48,7 @@ public class MqttCustomOptionTest extends MqttTestBase {
             MqttConnector connector = container.getBeanManager().createInstance().select(MqttConnector.class,
                     ConnectorLiteral.of(MqttConnector.CONNECTOR_NAME)).get();
 
-            await().pollDelay(Duration.ofSeconds(1)).until(() -> !connector.isReady());
+            await().pollDelay(Duration.ofSeconds(1)).until(() -> !connector.getReadiness().isOk());
         }
     }
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSinkTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSinkTest.java
@@ -15,7 +15,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 
@@ -116,7 +115,6 @@ public class MqttSinkTest extends MqttTestBase {
         assertThat(expected).hasValue(10);
     }
 
-    @RepeatedTest(5)
     @Test
     public void testABeanProducingMessagesSentToMQTT() throws InterruptedException {
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSinkTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSinkTest.java
@@ -52,6 +52,7 @@ public class MqttSinkTest extends MqttTestBase {
         MqttSink sink = new MqttSink(vertx, new MqttConnectorOutgoingConfiguration(new MapBasedConfig(config)), null);
 
         Subscriber<? extends Message<?>> subscriber = sink.getSink().build();
+
         Multi.createFrom().range(0, 10)
                 .map(Message::of)
                 .subscribe((Subscriber<? super Message<Integer>>) subscriber);
@@ -63,7 +64,7 @@ public class MqttSinkTest extends MqttTestBase {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testSinkUsingChannelName() throws InterruptedException {
+    public void testSinkUsingIntegerAndChannelNameAsTopic() throws InterruptedException {
         String topic = UUID.randomUUID().toString();
         CountDownLatch latch = new CountDownLatch(1);
         AtomicInteger expected = new AtomicInteger(0);
@@ -116,8 +117,9 @@ public class MqttSinkTest extends MqttTestBase {
     }
 
     @RepeatedTest(5)
+    @Test
     public void testABeanProducingMessagesSentToMQTT() throws InterruptedException {
-        Clients.clear();
+
         Weld weld = baseWeld(getConfig());
         weld.addBeanClass(ProducingBean.class);
 
@@ -127,7 +129,9 @@ public class MqttSinkTest extends MqttTestBase {
                 v -> latch.countDown());
 
         container = weld.initialize();
-        assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
     }
 
     private MapBasedConfig getConfig() {

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
@@ -44,7 +44,8 @@ public class MqttSourceTest extends MqttTestBase {
         List<MqttMessage<?>> messages = new ArrayList<>();
         PublisherBuilder<MqttMessage<?>> stream = source.getSource();
         stream.forEach(messages::add).run();
-        await().until(source::isReady);
+        awaitUntilReady(source);
+
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(topic, 10, null,
                 counter::getAndIncrement)).start();
@@ -71,7 +72,7 @@ public class MqttSourceTest extends MqttTestBase {
         List<MqttMessage<?>> messages = new ArrayList<>();
         PublisherBuilder<MqttMessage<?>> stream = source.getSource();
         stream.forEach(messages::add).run();
-        await().until(source::isReady);
+        awaitUntilReady(source);
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(topic, 10, null,
                 counter::getAndIncrement)).start();
@@ -104,7 +105,7 @@ public class MqttSourceTest extends MqttTestBase {
         stream.forEach(messages1::add).run();
         stream.forEach(messages2::add).run();
 
-        await().until(source::isReady);
+        awaitUntilReady(source);
 
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(topic, 10, null,
@@ -146,7 +147,7 @@ public class MqttSourceTest extends MqttTestBase {
         List<MqttMessage<?>> messages = new ArrayList<>();
         PublisherBuilder<MqttMessage<?>> stream = source.getSource();
         stream.forEach(messages::add).run();
-        await().until(source::isReady);
+        awaitUntilReady(source);
         new Thread(() -> usage.produce(topic, 10, null,
                 () -> large)).start();
 
@@ -176,8 +177,9 @@ public class MqttSourceTest extends MqttTestBase {
     public void testABeanConsumingTheMQTTMessages() {
         ConsumptionBean bean = deploy();
 
-        await()
-                .until(() -> container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());
+        MqttConnector mqttConnector = this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get();
+
+        await().until(() -> mqttConnector.getReadiness().isOk());
 
         List<Integer> list = bean.getResults();
         assertThat(list).isEmpty();

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MultipleTopicsConsumptionTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MultipleTopicsConsumptionTest.java
@@ -41,10 +41,9 @@ public class MultipleTopicsConsumptionTest extends MqttTestBase {
         container = weld.initialize();
 
         Consumers bean = container.getBeanManager().createInstance().select(Consumers.class).get();
+        MqttConnector mqttConnector = this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get();
 
-        await()
-                .until(
-                        () -> this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());
+        await().until(() -> mqttConnector.getReadiness().isOk());
 
         assertThat(bean.prices()).isEmpty();
         assertThat(bean.products()).isEmpty();
@@ -68,10 +67,9 @@ public class MultipleTopicsConsumptionTest extends MqttTestBase {
         container = weld.initialize();
 
         Consumers bean = container.getBeanManager().createInstance().select(Consumers.class).get();
+        MqttConnector mqttConnector = this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get();
 
-        await()
-                .until(
-                        () -> this.container.select(MqttConnector.class, ConnectorLiteral.of("smallrye-mqtt")).get().isReady());
+        await().until(() -> mqttConnector.getReadiness().isOk());
 
         assertThat(bean.prices()).isEmpty();
         assertThat(bean.products()).isEmpty();

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MutualTlsMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MutualTlsMqttSourceTest.java
@@ -47,7 +47,7 @@ public class MutualTlsMqttSourceTest extends MutualTlsMqttTestBase {
         List<MqttMessage<?>> messages = new ArrayList<>();
         PublisherBuilder<MqttMessage<?>> stream = source.getSource();
         stream.forEach(messages::add).run();
-        await().until(source::isReady);
+        awaitUntilReady(source);
         pause();
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(topic, 10, null,

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MutualTlsMqttTestBase.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MutualTlsMqttTestBase.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.mqtt;
 
 import static io.smallrye.reactive.messaging.mqtt.MqttTestBase.awaitForMosquittoToBeReady;
+import static org.awaitility.Awaitility.await;
 
 import java.util.Properties;
 
@@ -16,6 +17,7 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.health.HealthReport;
 import io.vertx.mutiny.core.Vertx;
 
 public class MutualTlsMqttTestBase {
@@ -36,6 +38,14 @@ public class MutualTlsMqttTestBase {
     public static void startBroker() {
         mosquitto.start();
         awaitForMosquittoToBeReady(mosquitto);
+    }
+
+    public void awaitUntilReady(MqttSource source) {
+        await().until(() -> {
+            HealthReport.HealthReportBuilder builder = HealthReport.builder();
+            source.isReady(builder);
+            return builder.build().isOk();
+        });
     }
 
     @AfterAll

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
@@ -49,7 +49,7 @@ public class SecureMqttSourceTest extends SecureMqttTestBase {
         List<MqttMessage<?>> messages = new ArrayList<>();
         PublisherBuilder<MqttMessage<?>> stream = source.getSource();
         stream.forEach(messages::add).run();
-        await().until(source::isReady);
+        awaitUntilReady(source);
         pause();
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(topic, 10, null,

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttTestBase.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttTestBase.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.mqtt;
 
 import static io.smallrye.reactive.messaging.mqtt.MqttTestBase.awaitForMosquittoToBeReady;
+import static org.awaitility.Awaitility.await;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterAll;
@@ -14,6 +15,7 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.health.HealthReport;
 import io.vertx.mutiny.core.Vertx;
 
 public class SecureMqttTestBase {
@@ -33,6 +35,14 @@ public class SecureMqttTestBase {
     public static void startBroker() {
         mosquitto.start();
         awaitForMosquittoToBeReady(mosquitto);
+    }
+
+    public void awaitUntilReady(MqttSource source) {
+        await().until(() -> {
+            HealthReport.HealthReportBuilder builder = HealthReport.builder();
+            source.isReady(builder);
+            return builder.build().isOk();
+        });
     }
 
     @AfterAll

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/TlsMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/TlsMqttSourceTest.java
@@ -43,7 +43,7 @@ public class TlsMqttSourceTest extends TlsMqttTestBase {
         List<MqttMessage<?>> messages = new ArrayList<>();
         PublisherBuilder<MqttMessage<?>> stream = source.getSource();
         stream.forEach(messages::add).run();
-        await().until(source::isReady);
+        awaitUntilReady(source);
         pause();
         AtomicInteger counter = new AtomicInteger();
         new Thread(() -> usage.produceIntegers(topic, 10, null,

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/TlsMqttTestBase.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/TlsMqttTestBase.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.mqtt;
 
 import static io.smallrye.reactive.messaging.mqtt.MqttTestBase.awaitForMosquittoToBeReady;
+import static org.awaitility.Awaitility.await;
 
 import java.util.Properties;
 
@@ -16,6 +17,7 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.reactive.messaging.health.HealthReport;
 import io.vertx.mutiny.core.Vertx;
 
 public class TlsMqttTestBase {
@@ -40,6 +42,14 @@ public class TlsMqttTestBase {
     @AfterAll
     public static void stopBroker() {
         mosquitto.stop();
+    }
+
+    public void awaitUntilReady(MqttSource source) {
+        await().until(() -> {
+            HealthReport.HealthReportBuilder builder = HealthReport.builder();
+            source.isReady(builder);
+            return builder.build().isOk();
+        });
     }
 
     @BeforeEach


### PR DESCRIPTION
Please double-check the class MqttSink, since I've changed the MQTT client startup.

As per javadoc on OutboundConnection ("Note that the connection to the transport or broker is generally postponed until the subscription." ) I've implemented a Processor and, on subscribe, I start the MQTT client.

Before this change, the connection was made on the first message out, but I need to get the connection's health also when no messages are sent.

(Is the same PR as 2024, but by mistake I had to create a new one)