### PR TITLE
Configure missing tracing attributes for kafka, amqp rabbitmq.

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/tracing/AmqpAttributesExtractor.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/tracing/AmqpAttributesExtractor.java
@@ -4,7 +4,6 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
-import io.smallrye.reactive.messaging.amqp.AmqpConnector;
 import io.smallrye.reactive.messaging.amqp.AmqpMessage;
 
 public class AmqpAttributesExtractor implements AttributesExtractor<AmqpMessage<?>, Void> {
@@ -39,7 +38,7 @@ public class AmqpAttributesExtractor implements AttributesExtractor<AmqpMessage<
         // Required
         @Override
         public String system(final AmqpMessage<?> amqpMessage) {
-            return AmqpConnector.CONNECTOR_NAME;
+            return "AMQP 1.0";
         }
 
         // Required if the message destination is either a queue or topic

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAmqpToAppToAmqpTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAmqpToAppToAmqpTest.java
@@ -129,7 +129,7 @@ public class TracingAmqpToAppToAmqpTest extends AmqpBrokerTestBase {
 
             SpanData consumer = parentSpans.get(0);
             assertEquals(CONSUMER, consumer.getKind());
-            assertEquals("smallrye-amqp", consumer.getAttributes().get(MESSAGING_SYSTEM));
+            assertEquals("AMQP 1.0", consumer.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("AMQP", consumer.getAttributes().get(MESSAGING_PROTOCOL));
             assertEquals("1.0", consumer.getAttributes().get(MESSAGING_PROTOCOL_VERSION));
             assertEquals("queue", consumer.getAttributes().get(MESSAGING_DESTINATION_KIND));

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -273,6 +273,7 @@ public class KafkaSource<K, V> {
             KafkaTrace kafkaTrace = new KafkaTrace.Builder()
                     .withPartition(kafkaRecord.getPartition())
                     .withTopic(kafkaRecord.getTopic())
+                    .withOffset(kafkaRecord.getOffset())
                     .withHeaders(kafkaRecord.getHeaders())
                     .withGroupId(client.get(ConsumerConfig.GROUP_ID_CONFIG))
                     .withClientId(client.get(ConsumerConfig.CLIENT_ID_CONFIG))

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/tracing/KafkaAttributesExtractor.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/tracing/KafkaAttributesExtractor.java
@@ -3,13 +3,13 @@ package io.smallrye.reactive.messaging.kafka.tracing;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_CONSUMER_ID;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_KAFKA_CLIENT_ID;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_KAFKA_PARTITION;
 
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
-import io.smallrye.reactive.messaging.kafka.KafkaConnector;
 
 public class KafkaAttributesExtractor implements AttributesExtractor<KafkaTrace, Void> {
     private final MessagingAttributesGetter<KafkaTrace, Void> messagingAttributesGetter;
@@ -22,6 +22,9 @@ public class KafkaAttributesExtractor implements AttributesExtractor<KafkaTrace,
     public void onStart(final AttributesBuilder attributes, final Context parentContext, final KafkaTrace kafkaTrace) {
         if (kafkaTrace.getPartition() != -1) {
             attributes.put(MESSAGING_KAFKA_PARTITION, kafkaTrace.getPartition());
+        }
+        if (kafkaTrace.getOffset() != -1) {
+            attributes.put(MESSAGING_KAFKA_MESSAGE_OFFSET, kafkaTrace.getOffset());
         }
 
         String groupId = kafkaTrace.getGroupId();
@@ -58,7 +61,7 @@ public class KafkaAttributesExtractor implements AttributesExtractor<KafkaTrace,
     private static final class KafkaMessagingAttributesGetter implements MessagingAttributesGetter<KafkaTrace, Void> {
         @Override
         public String system(final KafkaTrace kafkaTrace) {
-            return KafkaConnector.CONNECTOR_NAME;
+            return "kafka";
         }
 
         @Override

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/tracing/KafkaTrace.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/tracing/KafkaTrace.java
@@ -7,14 +7,16 @@ public class KafkaTrace {
     private final String clientId;
     private final int partition;
     private final String topic;
+    private final long offset;
     private final Headers headers;
 
     private KafkaTrace(final String groupId, final String clientId, final int partition, final String topic,
-            final Headers headers) {
+            final long offset, final Headers headers) {
         this.groupId = groupId;
         this.clientId = clientId;
         this.partition = partition;
         this.topic = topic;
+        this.offset = offset;
         this.headers = headers;
     }
 
@@ -38,11 +40,16 @@ public class KafkaTrace {
         return headers;
     }
 
+    public long getOffset() {
+        return offset;
+    }
+
     public static class Builder {
         private String groupId;
         private String clientId;
         private int partition;
         private String topic;
+        private long offset;
         private Headers headers;
 
         public Builder withGroupId(final String groupId) {
@@ -65,13 +72,18 @@ public class KafkaTrace {
             return this;
         }
 
+        public Builder withOffset(final long offset) {
+            this.offset = offset;
+            return this;
+        }
+
         public Builder withHeaders(final Headers headers) {
             this.headers = headers;
             return this;
         }
 
         public KafkaTrace build() {
-            return new KafkaTrace(groupId, clientId, partition, topic, headers);
+            return new KafkaTrace(groupId, clientId, partition, topic, offset, headers);
         }
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/TracingPropagationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/TracingPropagationTest.java
@@ -111,7 +111,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
 
             SpanData span = spans.get(0);
             assertEquals(SpanKind.PRODUCER, span.getKind());
-            assertEquals("smallrye-kafka", span.getAttributes().get(MESSAGING_SYSTEM));
+            assertEquals("kafka", span.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", span.getAttributes().get(MESSAGING_DESTINATION_KIND));
             assertEquals(topic, span.getAttributes().get(MESSAGING_DESTINATION));
             assertEquals(topic + " send", span.getName());
@@ -145,7 +145,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
 
             SpanData span = spans.get(0);
             assertEquals(SpanKind.PRODUCER, span.getKind());
-            assertEquals("smallrye-kafka", span.getAttributes().get(MESSAGING_SYSTEM));
+            assertEquals("kafka", span.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", span.getAttributes().get(MESSAGING_DESTINATION_KIND));
             assertEquals(topic, span.getAttributes().get(MESSAGING_DESTINATION));
             assertEquals(topic + " send", span.getName());
@@ -179,7 +179,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
 
             SpanData span = spans.get(0);
             assertEquals(SpanKind.PRODUCER, span.getKind());
-            assertEquals("smallrye-kafka", span.getAttributes().get(MESSAGING_SYSTEM));
+            assertEquals("kafka", span.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", span.getAttributes().get(MESSAGING_DESTINATION_KIND));
             assertEquals(topic, span.getAttributes().get(MESSAGING_DESTINATION));
             assertEquals(topic + " send", span.getName());
@@ -229,7 +229,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
             SpanData producer = spans.stream().filter(spanData -> spanData.getParentSpanId().equals(consumer.getSpanId()))
                     .findFirst().get();
             assertEquals(SpanKind.PRODUCER, producer.getKind());
-            assertEquals("smallrye-kafka", producer.getAttributes().get(MESSAGING_SYSTEM));
+            assertEquals("kafka", producer.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", producer.getAttributes().get(MESSAGING_DESTINATION_KIND));
             assertEquals(resultTopic, producer.getAttributes().get(MESSAGING_DESTINATION));
             assertEquals(resultTopic + " send", producer.getName());
@@ -280,7 +280,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
 
             SpanData consumer = spans.stream().filter(spanData -> spanData.getParentSpanId().equals(producer.getSpanId()))
                     .findFirst().get();
-            assertEquals("smallrye-kafka", consumer.getAttributes().get(MESSAGING_SYSTEM));
+            assertEquals("kafka", consumer.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", consumer.getAttributes().get(MESSAGING_DESTINATION_KIND));
             assertEquals(parentTopic, consumer.getAttributes().get(MESSAGING_DESTINATION));
             assertEquals(parentTopic + " receive", consumer.getName());

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -217,7 +217,8 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
                 .plug(m -> {
                     if (isTracingEnabled) {
                         return m.map(msg -> {
-                            TracingUtils.traceIncoming(instrumenter, msg, RabbitMQTrace.trace(queueName, msg.getHeaders()));
+                            TracingUtils.traceIncoming(instrumenter, msg, RabbitMQTrace.traceQueue(queueName,
+                                    msg.message.envelope().getRoutingKey(), msg.getHeaders()));
                             return msg;
                         });
                     }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageConverter.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageConverter.java
@@ -78,7 +78,8 @@ public class RabbitMQMessageConverter {
             if (isTracingEnabled) {
                 // Create a new span for the outbound message and record updated tracing information in
                 // the headers; this has to be done before we build the properties below
-                TracingUtils.traceOutgoing(instrumenter, message, RabbitMQTrace.trace(exchange, sourceHeaders));
+                TracingUtils.traceOutgoing(instrumenter, message,
+                        RabbitMQTrace.traceExchange(exchange, routingKey, sourceHeaders));
             }
 
             // Reconstruct the properties from the source, except with the (possibly) modified headers;
@@ -120,7 +121,8 @@ public class RabbitMQMessageConverter {
             if (isTracingEnabled) {
                 // Create a new span for the outbound message and record updated tracing information in
                 // the message headers; this has to be done before we build the properties below
-                TracingUtils.traceOutgoing(instrumenter, message, RabbitMQTrace.trace(exchange, metadata.getHeaders()));
+                TracingUtils.traceOutgoing(instrumenter, message,
+                        RabbitMQTrace.traceExchange(exchange, routingKey, metadata.getHeaders()));
             }
 
             final Date timestamp = (metadata.getTimestamp() != null) ? Date.from(metadata.getTimestamp().toInstant()) : null;

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQTrace.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQTrace.java
@@ -3,25 +3,46 @@ package io.smallrye.reactive.messaging.rabbitmq.tracing;
 import java.util.Map;
 
 public class RabbitMQTrace {
+    private final String destinationKind;
     private final String destination;
+    private final String routingKey;
     private final Map<String, Object> headers;
 
-    private RabbitMQTrace(final String destination, final Map<String, Object> headers) {
+    private RabbitMQTrace(final String destinationKind, final String destination, final String routingKey,
+            final Map<String, Object> headers) {
         this.destination = destination;
+        this.routingKey = routingKey;
         this.headers = headers;
+        this.destinationKind = destinationKind;
+    }
+
+    public String getDestinationKind() {
+        return destinationKind;
     }
 
     public String getDestination() {
         return destination;
     }
 
+    public String getRoutingKey() {
+        return routingKey;
+    }
+
     public Map<String, Object> getHeaders() {
         return headers;
     }
 
-    public static RabbitMQTrace trace(
+    public static RabbitMQTrace traceQueue(
             final String destination,
+            final String routingKey,
             final Map<String, Object> headers) {
-        return new RabbitMQTrace(destination, headers);
+        return new RabbitMQTrace("queue", destination, routingKey, headers);
+    }
+
+    public static RabbitMQTrace traceExchange(
+            final String destination,
+            final String routingKey,
+            final Map<String, Object> headers) {
+        return new RabbitMQTrace("exchange", destination, routingKey, headers);
     }
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQTraceAttributesExtractor.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQTraceAttributesExtractor.java
@@ -1,10 +1,11 @@
 package io.smallrye.reactive.messaging.rabbitmq.tracing;
 
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY;
+
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
-import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
 
 public class RabbitMQTraceAttributesExtractor implements AttributesExtractor<RabbitMQTrace, Void> {
     private final MessagingAttributesGetter<RabbitMQTrace, Void> messagingAttributesGetter;
@@ -21,9 +22,7 @@ public class RabbitMQTraceAttributesExtractor implements AttributesExtractor<Rab
     public void onStart(
             final AttributesBuilder attributes,
             final Context parentContext, final RabbitMQTrace rabbitMQTrace) {
-        // TODO - radcortez - What to add here?
-        // attributes.put(MESSAGING_CONSUMER_ID, null);
-        // attributes.put(MESSAGING_RABBITMQ_ROUTING_KEY, null);
+        attributes.put(MESSAGING_RABBITMQ_ROUTING_KEY, rabbitMQTrace.getRoutingKey());
     }
 
     @Override
@@ -36,12 +35,12 @@ public class RabbitMQTraceAttributesExtractor implements AttributesExtractor<Rab
     private final static class RabbitMQMessagingAttributesGetter implements MessagingAttributesGetter<RabbitMQTrace, Void> {
         @Override
         public String system(final RabbitMQTrace rabbitMQTrace) {
-            return RabbitMQConnector.CONNECTOR_NAME;
+            return "rabbitmq";
         }
 
         @Override
         public String destinationKind(final RabbitMQTrace rabbitMQTrace) {
-            return "queue";
+            return rabbitMQTrace.getDestinationKind();
         }
 
         @Override
@@ -56,12 +55,12 @@ public class RabbitMQTraceAttributesExtractor implements AttributesExtractor<Rab
 
         @Override
         public String protocol(final RabbitMQTrace rabbitMQTrace) {
-            return "AMQP";
+            return null;
         }
 
         @Override
         public String protocolVersion(final RabbitMQTrace rabbitMQTrace) {
-            return "1.0";
+            return null;
         }
 
         @Override

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/TracingTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/TracingTest.java
@@ -10,6 +10,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -93,9 +94,9 @@ public class TracingTest extends WeldTestBase {
 
             SpanData consumer = spans.get(0);
             assertEquals(SpanKind.CONSUMER, consumer.getKind());
-            assertEquals("smallrye-rabbitmq", consumer.getAttributes().get(MESSAGING_SYSTEM));
-            assertEquals("AMQP", consumer.getAttributes().get(MESSAGING_PROTOCOL));
-            assertEquals("1.0", consumer.getAttributes().get(MESSAGING_PROTOCOL_VERSION));
+            assertEquals("rabbitmq", consumer.getAttributes().get(MESSAGING_SYSTEM));
+            assertNull(consumer.getAttributes().get(MESSAGING_PROTOCOL));
+            assertNull(consumer.getAttributes().get(MESSAGING_PROTOCOL_VERSION));
             assertEquals("queue", consumer.getAttributes().get(MESSAGING_DESTINATION_KIND));
             assertEquals(queue, consumer.getAttributes().get(MESSAGING_DESTINATION));
             assertEquals(queue + " receive", consumer.getName());


### PR DESCRIPTION
Restore system attributes from connector name to messaging system name

@radcortez I noticed that messaging.system attribute where changed, please review these fixes.