### PR TITLE
Upgrade to OTel 1.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 
     <kafka.version>3.4.0</kafka.version>
 
-    <opentelemetry.version>1.22.1-alpha</opentelemetry.version>
+    <opentelemetry.version>1.23.0-alpha</opentelemetry.version>
 
     <smallrye-vertx-mutiny-clients.version>3.0.0</smallrye-vertx-mutiny-clients.version>
     <smallrye-reactive-converters.version>3.0.0</smallrye-reactive-converters.version>

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAmqpToAppToAmqpTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/TracingAmqpToAppToAmqpTest.java
@@ -2,11 +2,9 @@ package io.smallrye.reactive.messaging.amqp;
 
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION_KIND;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_PROTOCOL;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_SYSTEM;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -130,10 +128,8 @@ public class TracingAmqpToAppToAmqpTest extends AmqpBrokerTestBase {
             SpanData consumer = parentSpans.get(0);
             assertEquals(CONSUMER, consumer.getKind());
             assertEquals("AMQP 1.0", consumer.getAttributes().get(MESSAGING_SYSTEM));
-            assertEquals("AMQP", consumer.getAttributes().get(MESSAGING_PROTOCOL));
-            assertEquals("1.0", consumer.getAttributes().get(MESSAGING_PROTOCOL_VERSION));
             assertEquals("queue", consumer.getAttributes().get(MESSAGING_DESTINATION_KIND));
-            assertEquals("parent-topic", consumer.getAttributes().get(MESSAGING_DESTINATION));
+            assertEquals("parent-topic", consumer.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertEquals("parent-topic receive", consumer.getName());
             assertEquals("receive", consumer.getAttributes().get(MESSAGING_OPERATION));
 
@@ -141,7 +137,7 @@ public class TracingAmqpToAppToAmqpTest extends AmqpBrokerTestBase {
                     .get();
             assertEquals(PRODUCER, producer.getKind());
             assertEquals("queue", producer.getAttributes().get(MESSAGING_DESTINATION_KIND));
-            assertEquals("result-topic", producer.getAttributes().get(MESSAGING_DESTINATION));
+            assertEquals("result-topic", producer.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertEquals("result-topic send", producer.getName());
             assertNull(producer.getAttributes().get(MESSAGING_OPERATION));
         });

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/TracingPropagationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/tracing/TracingPropagationTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.reactive.messaging.kafka.tracing;
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION_KIND;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_SYSTEM;
 import static io.smallrye.reactive.messaging.kafka.companion.RecordQualifiers.until;
 import static java.util.stream.Collectors.toList;
@@ -113,7 +113,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
             assertEquals(SpanKind.PRODUCER, span.getKind());
             assertEquals("kafka", span.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", span.getAttributes().get(MESSAGING_DESTINATION_KIND));
-            assertEquals(topic, span.getAttributes().get(MESSAGING_DESTINATION));
+            assertEquals(topic, span.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertEquals(topic + " send", span.getName());
         });
     }
@@ -147,7 +147,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
             assertEquals(SpanKind.PRODUCER, span.getKind());
             assertEquals("kafka", span.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", span.getAttributes().get(MESSAGING_DESTINATION_KIND));
-            assertEquals(topic, span.getAttributes().get(MESSAGING_DESTINATION));
+            assertEquals(topic, span.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertEquals(topic + " send", span.getName());
         });
     }
@@ -181,7 +181,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
             assertEquals(SpanKind.PRODUCER, span.getKind());
             assertEquals("kafka", span.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", span.getAttributes().get(MESSAGING_DESTINATION_KIND));
-            assertEquals(topic, span.getAttributes().get(MESSAGING_DESTINATION));
+            assertEquals(topic, span.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertEquals(topic + " send", span.getName());
         });
     }
@@ -223,7 +223,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
             SpanData consumer = parentSpans.get(0);
             assertEquals(SpanKind.CONSUMER, consumer.getKind());
             assertEquals("topic", consumer.getAttributes().get(MESSAGING_DESTINATION_KIND));
-            assertEquals(parentTopic, consumer.getAttributes().get(MESSAGING_DESTINATION));
+            assertEquals(parentTopic, consumer.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertEquals(parentTopic + " receive", consumer.getName());
 
             SpanData producer = spans.stream().filter(spanData -> spanData.getParentSpanId().equals(consumer.getSpanId()))
@@ -231,7 +231,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
             assertEquals(SpanKind.PRODUCER, producer.getKind());
             assertEquals("kafka", producer.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", producer.getAttributes().get(MESSAGING_DESTINATION_KIND));
-            assertEquals(resultTopic, producer.getAttributes().get(MESSAGING_DESTINATION));
+            assertEquals(resultTopic, producer.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertEquals(resultTopic + " send", producer.getName());
         });
     }
@@ -282,7 +282,7 @@ public class TracingPropagationTest extends KafkaCompanionTestBase {
                     .findFirst().get();
             assertEquals("kafka", consumer.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("topic", consumer.getAttributes().get(MESSAGING_DESTINATION_KIND));
-            assertEquals(parentTopic, consumer.getAttributes().get(MESSAGING_DESTINATION));
+            assertEquals(parentTopic, consumer.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertEquals(parentTopic + " receive", consumer.getName());
         });
     }

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/TracingTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/TracingTest.java
@@ -1,7 +1,7 @@
 package io.smallrye.reactive.messaging.rabbitmq;
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION_KIND;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_PROTOCOL;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_SYSTEM;
@@ -98,7 +98,7 @@ public class TracingTest extends WeldTestBase {
             assertNull(consumer.getAttributes().get(MESSAGING_PROTOCOL));
             assertNull(consumer.getAttributes().get(MESSAGING_PROTOCOL_VERSION));
             assertEquals("queue", consumer.getAttributes().get(MESSAGING_DESTINATION_KIND));
-            assertEquals(queue, consumer.getAttributes().get(MESSAGING_DESTINATION));
+            assertEquals(queue, consumer.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertEquals(queue + " receive", consumer.getName());
         });
     }


### PR DESCRIPTION
Changed names and deprecated MESSAGING_PROTOCOL and MESSAGING_PROTOCOL_VERSION are not returning data anymore. 
