### PR TITLE
Bump smallrye-parent to 39

### DIFF
--- a/api/src/main/java/io/smallrye/reactive/messaging/json/JsonMapping.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/json/JsonMapping.java
@@ -7,14 +7,14 @@ public interface JsonMapping {
 
     /**
      * Default priority of corresponding provider.
-     * 
+     *
      * @implNote could be used to control the load/init order in case multiple providers are specified/included.
      */
     int DEFAULT_PRIORITY = 500;
 
     /**
      * Serialize an object to JSON.
-     * 
+     *
      * @param object object to serialize
      * @return JSON representation of the object
      */
@@ -22,7 +22,7 @@ public interface JsonMapping {
 
     /**
      * Deserialize an object from it's JSON string representation.
-     * 
+     *
      * @param str JSON string
      * @param type type of object
      * @param <T> generic parametrization class

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/IncomingConnectorFactory.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/IncomingConnectorFactory.java
@@ -80,7 +80,7 @@ import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
  * The {@link #getPublisherBuilder(Config)} is called for every channel that needs to be created. The {@link Config} object
  * passed to the method contains a subset of the global configuration, and with the prefixes removed. So for the previous
  * configuration, it would be:
- * 
+ *
  * <pre>
  * bootstrap.servers = localhost:9092
  * topic = my-topic

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/OutgoingConnectorFactory.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/OutgoingConnectorFactory.java
@@ -78,7 +78,7 @@ import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
  * The {@link #getSubscriberBuilder(Config)} is called for every <em>channel</em> that needs to be created. The
  * {@link Config} object passed to the method contains a subset of the global configuration, and with the prefixes removed.
  * So for the previous configuration, it would be:
- * 
+ *
  * <pre>
  * bootstrap.servers = localhost:9092
  * topic = my-topic

--- a/examples/kafka-quickstart-kotlin/pom.xml
+++ b/examples/kafka-quickstart-kotlin/pom.xml
@@ -151,7 +151,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 
   <parent>
     <groupId>io.smallrye</groupId>
-    <artifactId>smallrye-jakarta-parent</artifactId>
-    <version>38</version>
+    <artifactId>smallrye-parent</artifactId>
+    <version>39</version>
   </parent>
 
   <groupId>io.smallrye.reactive</groupId>
@@ -103,6 +103,7 @@
     <junit-pioneer.version>2.0.0</junit-pioneer.version>
     <junit-platform-commons.version>1.9.2</junit-platform-commons.version>
 
+    <jakarta.jms.api.version>3.0.0</jakarta.jms.api.version>
     <jackson.version>2.14.2</jackson.version>
     <yasson.version>2.0.3</yasson.version>
 
@@ -254,6 +255,12 @@
         <artifactId>rxjava</artifactId>
         <version>${rxjava.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>jakarta.jms</groupId>
+        <artifactId>jakarta.jms-api</artifactId>
+        <version>${jakarta.jms.api.version}</version>
       </dependency>
 
       <dependency>

--- a/smallrye-connector-attribute-processor/src/test/java/io/smallrye/reactive/messaging/connector/ClassWriterTest.java
+++ b/smallrye-connector-attribute-processor/src/test/java/io/smallrye/reactive/messaging/connector/ClassWriterTest.java
@@ -75,47 +75,47 @@ class ClassWriterTest {
         assertThat(
                 ClassWriter.getTargetDotClassName(
                         new ConnectorAttributeLiteral("a", "a", "boolean", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Boolean.class");
+                .isEqualTo("Boolean.class");
 
         assertThat(
                 ClassWriter.getTargetDotClassName(
                         new ConnectorAttributeLiteral("a", "a", "int", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Integer.class");
+                .isEqualTo("Integer.class");
 
         assertThat(
                 ClassWriter.getTargetDotClassName(
                         new ConnectorAttributeLiteral("a", "a", "double", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Double.class");
+                .isEqualTo("Double.class");
 
         assertThat(
                 ClassWriter.getTargetDotClassName(
                         new ConnectorAttributeLiteral("a", "a", "string", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("String.class");
+                .isEqualTo("String.class");
 
         assertThat(
                 ClassWriter.getTargetDotClassName(
                         new ConnectorAttributeLiteral("a", "a", "float", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Float.class");
+                .isEqualTo("Float.class");
 
         assertThat(
                 ClassWriter.getTargetDotClassName(
                         new ConnectorAttributeLiteral("a", "a", "short", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Short.class");
+                .isEqualTo("Short.class");
 
         assertThat(
                 ClassWriter.getTargetDotClassName(
                         new ConnectorAttributeLiteral("a", "a", "long", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Long.class");
+                .isEqualTo("Long.class");
 
         assertThat(
                 ClassWriter.getTargetDotClassName(
                         new ConnectorAttributeLiteral("a", "a", "byte", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Byte.class");
+                .isEqualTo("Byte.class");
 
         assertThat(
                 ClassWriter.getTargetDotClassName(
                         new ConnectorAttributeLiteral("a", "a", "Other", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Other.class");
+                .isEqualTo("Other.class");
     }
 
     @Test
@@ -123,47 +123,47 @@ class ClassWriterTest {
         assertThat(
                 ClassWriter.getTargetType(
                         new ConnectorAttributeLiteral("a", "a", "boolean", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Boolean");
+                .isEqualTo("Boolean");
 
         assertThat(
                 ClassWriter.getTargetType(
                         new ConnectorAttributeLiteral("a", "a", "int", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Integer");
+                .isEqualTo("Integer");
 
         assertThat(
                 ClassWriter.getTargetType(
                         new ConnectorAttributeLiteral("a", "a", "double", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Double");
+                .isEqualTo("Double");
 
         assertThat(
                 ClassWriter.getTargetType(
                         new ConnectorAttributeLiteral("a", "a", "string", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("String");
+                .isEqualTo("String");
 
         assertThat(
                 ClassWriter.getTargetType(
                         new ConnectorAttributeLiteral("a", "a", "float", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Float");
+                .isEqualTo("Float");
 
         assertThat(
                 ClassWriter.getTargetType(
                         new ConnectorAttributeLiteral("a", "a", "short", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Short");
+                .isEqualTo("Short");
 
         assertThat(
                 ClassWriter.getTargetType(
                         new ConnectorAttributeLiteral("a", "a", "long", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Long");
+                .isEqualTo("Long");
 
         assertThat(
                 ClassWriter.getTargetType(
                         new ConnectorAttributeLiteral("a", "a", "byte", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Byte");
+                .isEqualTo("Byte");
 
         assertThat(
                 ClassWriter.getTargetType(
                         new ConnectorAttributeLiteral("a", "a", "Other", true, ConnectorAttribute.Direction.INCOMING)))
-                                .isEqualTo("Other");
+                .isEqualTo("Other");
     }
 
     @Test

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSourceTest.java
@@ -98,7 +98,7 @@ public class AmqpSourceTest extends AmqpTestBase {
                 .peek(m -> m.ack().toCompletableFuture().join())
                 .map(Message::getPayload)
                 .collect(Collectors.toList()))
-                        .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= msgCount);
 
@@ -190,11 +190,11 @@ public class AmqpSourceTest extends AmqpTestBase {
         assertThat(messages1.stream().peek(m -> m.ack().toCompletableFuture().join())
                 .map(Message::getPayload)
                 .collect(Collectors.toList()))
-                        .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         assertThat(messages2.stream().peek(m -> m.ack().toCompletableFuture().join())
                 .map(Message::getPayload)
                 .collect(Collectors.toList()))
-                        .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> dispositionsReceived.size() >= msgCount);
 
@@ -293,7 +293,7 @@ public class AmqpSourceTest extends AmqpTestBase {
                 .peek(m -> m.ack().toCompletableFuture().join())
                 .map(Message::getPayload)
                 .collect(Collectors.toList()))
-                        .containsExactly("foo".getBytes(StandardCharsets.UTF_8));
+                .containsExactly("foo".getBytes(StandardCharsets.UTF_8));
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> !dispositionsReceived.isEmpty());
 
@@ -335,7 +335,7 @@ public class AmqpSourceTest extends AmqpTestBase {
                 .peek(m -> m.ack().toCompletableFuture().join())
                 .map(Message::getPayload)
                 .collect(Collectors.toList()))
-                        .containsExactly("foo".getBytes(StandardCharsets.UTF_8));
+                .containsExactly("foo".getBytes(StandardCharsets.UTF_8));
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> !dispositionsReceived.isEmpty());
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/RabbitMQBrokerTestBase.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/RabbitMQBrokerTestBase.java
@@ -25,12 +25,12 @@ public class RabbitMQBrokerTestBase {
 
     private static final GenericContainer<?> RABBIT = new GenericContainer<>(
             DockerImageName.parse("rabbitmq:3-management"))
-                    .withExposedPorts(5672, 15672)
-                    .withLogConsumer(of -> LOGGER.info(of.getUtf8String()))
-                    .waitingFor(
-                            Wait.forLogMessage(".*Server startup complete; 4 plugins started.*\\n", 1))
-                    .withFileSystemBind("src/test/resources/rabbitmq/enabled_plugins", "/etc/rabbitmq/enabled_plugins",
-                            BindMode.READ_ONLY);
+            .withExposedPorts(5672, 15672)
+            .withLogConsumer(of -> LOGGER.info(of.getUtf8String()))
+            .waitingFor(
+                    Wait.forLogMessage(".*Server startup complete; 4 plugins started.*\\n", 1))
+            .withFileSystemBind("src/test/resources/rabbitmq/enabled_plugins", "/etc/rabbitmq/enabled_plugins",
+                    BindMode.READ_ONLY);
 
     protected static String host;
     protected static int port;

--- a/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsProperties.java
+++ b/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/JmsProperties.java
@@ -10,7 +10,7 @@ public interface JmsProperties {
 
     /**
      * Creates a builder object to create JMS Properties
-     * 
+     *
      * @return the builder.
      */
     static JmsPropertiesBuilder builder() {

--- a/smallrye-reactive-messaging-kafka-api/src/main/java/io/smallrye/reactive/messaging/kafka/api/KafkaMessageMetadata.java
+++ b/smallrye-reactive-messaging-kafka-api/src/main/java/io/smallrye/reactive/messaging/kafka/api/KafkaMessageMetadata.java
@@ -6,7 +6,7 @@ import org.apache.kafka.common.header.Headers;
 
 /**
  * Common interface for
- * 
+ *
  * @param <K> the Kafka record key type
  */
 public interface KafkaMessageMetadata<K> {

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerGroupsCompanion.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerGroupsCompanion.java
@@ -82,7 +82,7 @@ public class ConsumerGroupsCompanion {
                 new RemoveMembersFromConsumerGroupOptions(Arrays.stream(groupInstanceIds)
                         .map(MemberToRemove::new).collect(Collectors.toList())))
                 .all())
-                        .await().atMost(kafkaApiTimeout);
+                .await().atMost(kafkaApiTimeout);
     }
 
     /*

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/test/ProxiedStrimziKafkaContainer.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/test/ProxiedStrimziKafkaContainer.java
@@ -29,7 +29,7 @@ public class ProxiedStrimziKafkaContainer extends StrimziKafkaContainer {
     private final ToxiproxyContainer toxiproxy = new ToxiproxyContainer(DockerImageName.parse(
             System.getProperty(TOXIPROXY_IMAGE_NAME_PROPERTY_KEY, DEFAULT_TOXIPROXY_IMAGE_NAME))
             .asCompatibleSubstituteFor("shopify/toxiproxy"))
-                    .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS);
+            .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS);
     private KafkaProxy kafkaProxy;
 
     public ProxiedStrimziKafkaContainer() {

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerTest.java
@@ -113,14 +113,14 @@ public class ConsumerTest extends KafkaCompanionTestBase {
         assertThat(companion.consumeWithDeserializers(IntegerDeserializer.class, StringDeserializer.class)
                 .fromTopics(topic, 3)
                 .awaitCompletion().getRecords())
-                        .hasSize(3)
-                        .extracting(ConsumerRecord::key).containsExactly(1, 2, 3);
+                .hasSize(3)
+                .extracting(ConsumerRecord::key).containsExactly(1, 2, 3);
 
         assertThat(companion.consumeWithDeserializers(new IntegerDeserializer(), new StringDeserializer())
                 .fromTopics(topic, 3)
                 .awaitCompletion().getRecords())
-                        .hasSize(3)
-                        .extracting(ConsumerRecord::key).containsExactly(1, 2, 3);
+                .hasSize(3)
+                .extracting(ConsumerRecord::key).containsExactly(1, 2, 3);
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ProducerTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ProducerTest.java
@@ -46,9 +46,9 @@ public class ProducerTest extends KafkaCompanionTestBase {
 
         assertThat(companion.consume(Integer.class, String.class).fromTopics(topic, 10)
                 .awaitCompletion().getRecords())
-                        .hasSize(10)
-                        .allSatisfy(c -> assertThat(c.key()).isEqualTo(1))
-                        .extracting(ConsumerRecord::value).containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+                .hasSize(10)
+                .allSatisfy(c -> assertThat(c.key()).isEqualTo(1))
+                .extracting(ConsumerRecord::value).containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
 
         companion.produceWithSerializers(new IntegerSerializer(), new StringSerializer())
                 .usingGenerator(i -> new ProducerRecord<>(topic, 2, Integer.toString(i)), 10);
@@ -57,9 +57,9 @@ public class ProducerTest extends KafkaCompanionTestBase {
         offsets.put(tp(topic, 0), 10L);
         assertThat(companion.consume(Integer.class, String.class).fromOffsets(offsets, 10)
                 .awaitCompletion().getRecords())
-                        .hasSize(10)
-                        .allSatisfy(c -> assertThat(c.key()).isEqualTo(2))
-                        .extracting(ConsumerRecord::value).containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+                .hasSize(10)
+                .allSatisfy(c -> assertThat(c.key()).isEqualTo(2))
+                .extracting(ConsumerRecord::value).containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaClientService.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaClientService.java
@@ -33,7 +33,7 @@ public interface KafkaClientService {
      * Gets the list of managed Kafka Consumer for the given channel.
      * This method returns a reactive consumers, in the order of creation for multi-consumer channels.
      * <p>
-     * 
+     *
      * @param channel the channel, must not be {@code null}
      * @param <K> the type of the key
      * @param <V> the type of the value

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/transactions/KafkaTransactionsImpl.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/transactions/KafkaTransactionsImpl.java
@@ -95,7 +95,8 @@ public class KafkaTransactionsImpl<T> extends MutinyEmitterImpl<T> implements Ka
                     VOID_UNI,
                     /* after abort */
                     t -> consumer.resetToLastCommittedPositions()
-                            .chain(() -> Uni.createFrom().failure(t))).execute(work);
+                            .chain(() -> Uni.createFrom().failure(t)))
+                    .execute(work);
         }
         throw KafkaExceptions.ex.transactionInProgress(name);
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceTest.java
@@ -460,7 +460,8 @@ public class KafkaSourceTest extends KafkaCompanionTestBase {
         assertThat(
                 getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
                         "my-group-starting-on-fifth-fail-on-first-attempt")
-                                .getRebalanceCount()).isEqualTo(1);
+                        .getRebalanceCount())
+                .isEqualTo(1);
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceWithLegacyMetadataTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/KafkaSourceWithLegacyMetadataTest.java
@@ -459,7 +459,8 @@ public class KafkaSourceWithLegacyMetadataTest extends KafkaCompanionTestBase {
         assertThat(
                 getStartFromFifthOffsetFromLatestConsumerRebalanceListener(
                         "my-group-starting-on-fifth-fail-on-first-attempt")
-                                .getRebalanceCount()).isEqualTo(1);
+                        .getRebalanceCount())
+                .isEqualTo(1);
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MultiTopicsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/MultiTopicsTest.java
@@ -219,24 +219,24 @@ public class MultiTopicsTest extends KafkaCompanionTestBase {
                 .with("value.deserializer", StringDeserializer.class.getName())
                 .with("pattern", true),
                 KafkaConsumer.class))
-                        .isInstanceOf(DeploymentException.class)
-                        .hasCauseInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(DeploymentException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class);
 
         // topics and no topic
         assertThatThrownBy(() -> runApplication(kafkaConfig("mp.messaging.incoming.kafka")
                 .with("value.deserializer", StringDeserializer.class.getName())
                 .with("topic", "my-topic")
                 .with("topics", "a, b, c"), KafkaConsumer.class))
-                        .isInstanceOf(DeploymentException.class)
-                        .hasCauseInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(DeploymentException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class);
 
         // topics and pattern
         assertThatThrownBy(() -> runApplication(kafkaConfig("mp.messaging.incoming.kafka")
                 .with("value.deserializer", StringDeserializer.class.getName())
                 .with("pattern", true)
                 .with("topics", "a, b, c"), KafkaConsumer.class))
-                        .isInstanceOf(DeploymentException.class)
-                        .hasCauseInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(DeploymentException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @ApplicationScoped

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/DoubleInstance.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/DoubleInstance.java
@@ -62,6 +62,16 @@ public class DoubleInstance<T> implements Instance<T> {
     }
 
     @Override
+    public Handle<T> getHandle() {
+        return null;
+    }
+
+    @Override
+    public Iterable<? extends Handle<T>> handles() {
+        return null;
+    }
+
+    @Override
     public Iterator<T> iterator() {
         return Arrays.asList(instance1, instance2).iterator();
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/MultipleInstance.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/MultipleInstance.java
@@ -62,6 +62,16 @@ public class MultipleInstance<T> implements Instance<T> {
     }
 
     @Override
+    public Handle<T> getHandle() {
+        return null;
+    }
+
+    @Override
+    public Iterable<? extends Handle<T>> handles() {
+        return null;
+    }
+
+    @Override
     public Iterator<T> iterator() {
         return instances.values().iterator();
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/SingletonInstance.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/SingletonInstance.java
@@ -60,6 +60,16 @@ public class SingletonInstance<T> implements Instance<T> {
     }
 
     @Override
+    public Handle<T> getHandle() {
+        return null;
+    }
+
+    @Override
+    public Iterable<? extends Handle<T>> handles() {
+        return null;
+    }
+
+    @Override
     public Iterator<T> iterator() {
         return Collections.singleton(instance).iterator();
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/UnsatisfiedInstance.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/UnsatisfiedInstance.java
@@ -52,6 +52,16 @@ public class UnsatisfiedInstance<T> implements Instance<T> {
     }
 
     @Override
+    public Handle<T> getHandle() {
+        return null;
+    }
+
+    @Override
+    public Iterable<? extends Handle<T>> handles() {
+        return null;
+    }
+
+    @Override
     public Iterator<T> iterator() {
         return Collections.emptyIterator();
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSinkWithCloudEventsTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ce/KafkaSinkWithCloudEventsTest.java
@@ -227,7 +227,7 @@ public class KafkaSinkWithCloudEventsTest extends KafkaCompanionTestBase {
 
         assertThatThrownBy(() -> new KafkaSink(oc, CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(),
                 UnsatisfiedInstance.instance()))
-                        .isInstanceOf(IllegalStateException.class);
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -405,7 +405,7 @@ public class CommitStrategiesTest extends WeldTestBase {
                 new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
                 getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1))
-                        .isInstanceOf(AmbiguousResolutionException.class).hasMessageContaining("mine");
+                .isInstanceOf(AmbiguousResolutionException.class).hasMessageContaining("mine");
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/DeprecatedCommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/DeprecatedCommitStrategiesTest.java
@@ -423,7 +423,7 @@ public class DeprecatedCommitStrategiesTest extends WeldTestBase {
                 new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
                 getConsumerRebalanceListeners(),
                 CountKafkaCdiEvents.noCdiEvents, getDeserializationFailureHandlers(), -1))
-                        .isInstanceOf(DeploymentException.class).hasMessageContaining("mine");
+                .isInstanceOf(DeploymentException.class).hasMessageContaining("mine");
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/KeyDeserializerConfigurationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/KeyDeserializerConfigurationTest.java
@@ -224,10 +224,10 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
                                         .isEqualTo(exception.getMessage());
                                 assertThat(
                                         headers.lastHeader(DeserializationFailureHandler.DESERIALIZATION_FAILURE_DATA).value())
-                                                .isEqualTo(data);
+                                        .isEqualTo(data);
                                 assertThat(
                                         getHeader(headers, DeserializationFailureHandler.DESERIALIZATION_FAILURE_DESERIALIZER))
-                                                .isEqualTo(deserializer);
+                                        .isEqualTo(deserializer);
 
                                 return fallback;
                             }
@@ -384,9 +384,9 @@ public class KeyDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1))
-                        .isInstanceOf(KafkaException.class)
-                        .hasCauseInstanceOf(IllegalArgumentException.class)
-                        .hasStackTraceContaining("boom");
+                .isInstanceOf(KafkaException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasStackTraceContaining("boom");
 
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/ValueDeserializerConfigurationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/serde/ValueDeserializerConfigurationTest.java
@@ -238,10 +238,10 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
                                         .isEqualTo(exception.getMessage());
                                 assertThat(
                                         headers.lastHeader(DeserializationFailureHandler.DESERIALIZATION_FAILURE_DATA).value())
-                                                .isEqualTo(data);
+                                        .isEqualTo(data);
                                 assertThat(
                                         getHeader(headers, DeserializationFailureHandler.DESERIALIZATION_FAILURE_DESERIALIZER))
-                                                .isEqualTo(deserializer);
+                                        .isEqualTo(deserializer);
 
                                 return fallback;
                             }
@@ -468,9 +468,9 @@ public class ValueDeserializerConfigurationTest extends KafkaCompanionTestBase {
                 new KafkaConnectorIncomingConfiguration(config), commitHandlerFactories, failureHandlerFactories,
                 UnsatisfiedInstance.instance(),
                 CountKafkaCdiEvents.noCdiEvents, UnsatisfiedInstance.instance(), -1))
-                        .isInstanceOf(KafkaException.class)
-                        .hasCauseInstanceOf(IllegalArgumentException.class)
-                        .hasStackTraceContaining("boom");
+                .isInstanceOf(KafkaException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasStackTraceContaining("boom");
 
     }
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MqttSourceTest.java
@@ -56,7 +56,7 @@ public class MqttSourceTest extends MqttTestBase {
                 .map(x -> (byte[]) x)
                 .map(bytes -> Integer.valueOf(new String(bytes)))
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     @Test
@@ -83,7 +83,7 @@ public class MqttSourceTest extends MqttTestBase {
                 .map(x -> (byte[]) x)
                 .map(bytes -> Integer.valueOf(new String(bytes)))
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     @Test
@@ -118,14 +118,14 @@ public class MqttSourceTest extends MqttTestBase {
                 .map(x -> (byte[]) x)
                 .map(bytes -> Integer.valueOf(new String(bytes)))
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
         assertThat(messages2.stream()
                 .map(Message::getPayload)
                 .map(x -> (byte[]) x)
                 .map(bytes -> Integer.valueOf(new String(bytes)))
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     @Test
@@ -156,7 +156,7 @@ public class MqttSourceTest extends MqttTestBase {
                 .map(Message::getPayload)
                 .map(x -> (byte[]) x)
                 .collect(Collectors.toList()))
-                        .contains(large);
+                .contains(large);
     }
 
     static MapBasedConfig getConfig() {

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MutualTlsMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/MutualTlsMqttSourceTest.java
@@ -60,7 +60,7 @@ public class MutualTlsMqttSourceTest extends MutualTlsMqttTestBase {
                 .map(x -> (byte[]) x)
                 .map(bytes -> Integer.valueOf(new String(bytes)))
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     void pause() {

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/SecureMqttSourceTest.java
@@ -62,7 +62,7 @@ public class SecureMqttSourceTest extends SecureMqttTestBase {
                 .map(x -> (byte[]) x)
                 .map(bytes -> Integer.valueOf(new String(bytes)))
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     @Test

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/TlsMqttSourceTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/TlsMqttSourceTest.java
@@ -60,7 +60,7 @@ public class TlsMqttSourceTest extends TlsMqttTestBase {
                 .map(x -> (byte[]) x)
                 .map(bytes -> Integer.valueOf(new String(bytes)))
                 .collect(Collectors.toList()))
-                        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     void pause() {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MetadataInjectableMessage.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MetadataInjectableMessage.java
@@ -11,7 +11,7 @@ public interface MetadataInjectableMessage<T> extends Message<T> {
 
     /**
      * Inject the given metadata object
-     * 
+     *
      * @param metadataObject metadata object
      */
     void injectMetadata(Object metadataObject);

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MediatorConfigurationSupportTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MediatorConfigurationSupportTest.java
@@ -408,18 +408,20 @@ public class MediatorConfigurationSupportTest {
 
         assertThat(
                 new MediatorConfigurationSupport("mymethod", Multi.class, new Class[] { Publisher.class }, null, null)
-                        .determineShape(Collections.singletonList("incoming"), "outgoing")).isEqualTo(Shape.STREAM_TRANSFORMER);
+                        .determineShape(Collections.singletonList("incoming"), "outgoing"))
+                .isEqualTo(Shape.STREAM_TRANSFORMER);
 
         assertThat(
                 new MediatorConfigurationSupport("mymethod", PublisherBuilder.class, new Class[] { PublisherBuilder.class },
                         null, null)
-                                .determineShape(Collections.singletonList("incoming"), "outgoing"))
-                                        .isEqualTo(Shape.STREAM_TRANSFORMER);
+                        .determineShape(Collections.singletonList("incoming"), "outgoing"))
+                .isEqualTo(Shape.STREAM_TRANSFORMER);
 
         assertThat(
                 new MediatorConfigurationSupport("mymethod", PublisherBuilder.class, new Class[] { String.class }, null,
                         null)
-                                .determineShape(Collections.singletonList("incoming"), "outgoing")).isEqualTo(Shape.PROCESSOR);
+                        .determineShape(Collections.singletonList("incoming"), "outgoing"))
+                .isEqualTo(Shape.PROCESSOR);
 
         assertThat(new MediatorConfigurationSupport("mymethod", String.class, new Class[0], null, null)
                 .determineShape(Collections.emptyList(), "outgoing")).isEqualTo(Shape.PUBLISHER);
@@ -435,7 +437,7 @@ public class MediatorConfigurationSupportTest {
 
         assertThat(support
                 .processSuppliedAcknowledgement(Collections.singletonList("hello"), () -> Acknowledgment.Strategy.MANUAL))
-                        .isEqualTo(Acknowledgment.Strategy.MANUAL);
+                .isEqualTo(Acknowledgment.Strategy.MANUAL);
 
         assertThat(support.processSuppliedAcknowledgement(Collections.singletonList("hello"), () -> null))
                 .isNull();
@@ -445,7 +447,7 @@ public class MediatorConfigurationSupportTest {
 
         assertThatThrownBy(
                 () -> support.processSuppliedAcknowledgement(Collections.emptyList(), () -> Acknowledgment.Strategy.MANUAL))
-                        .isInstanceOf(DefinitionException.class);
+                .isInstanceOf(DefinitionException.class);
     }
 
     @Test
@@ -455,33 +457,33 @@ public class MediatorConfigurationSupportTest {
 
         assertThat(support.processDefaultAcknowledgement(Shape.SUBSCRIBER, MediatorConfiguration.Consumption.PAYLOAD,
                 MediatorConfiguration.Production.NONE))
-                        .isEqualTo(Acknowledgment.Strategy.POST_PROCESSING);
+                .isEqualTo(Acknowledgment.Strategy.POST_PROCESSING);
         assertThat(support.processDefaultAcknowledgement(Shape.SUBSCRIBER, MediatorConfiguration.Consumption.MESSAGE,
                 MediatorConfiguration.Production.NONE))
-                        .isEqualTo(Acknowledgment.Strategy.MANUAL);
+                .isEqualTo(Acknowledgment.Strategy.MANUAL);
 
         assertThat(support.processDefaultAcknowledgement(Shape.PROCESSOR, MediatorConfiguration.Consumption.PAYLOAD,
                 MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD))
-                        .isEqualTo(Acknowledgment.Strategy.POST_PROCESSING);
+                .isEqualTo(Acknowledgment.Strategy.POST_PROCESSING);
         assertThat(support.processDefaultAcknowledgement(Shape.PROCESSOR, MediatorConfiguration.Consumption.MESSAGE,
                 MediatorConfiguration.Production.INDIVIDUAL_MESSAGE))
-                        .isEqualTo(Acknowledgment.Strategy.MANUAL);
+                .isEqualTo(Acknowledgment.Strategy.MANUAL);
         assertThat(support.processDefaultAcknowledgement(Shape.PROCESSOR, MediatorConfiguration.Consumption.PAYLOAD,
                 MediatorConfiguration.Production.STREAM_OF_MESSAGE))
-                        .isEqualTo(Acknowledgment.Strategy.PRE_PROCESSING);
+                .isEqualTo(Acknowledgment.Strategy.PRE_PROCESSING);
         assertThat(support.processDefaultAcknowledgement(Shape.PROCESSOR, MediatorConfiguration.Consumption.PAYLOAD,
                 MediatorConfiguration.Production.STREAM_OF_PAYLOAD))
-                        .isEqualTo(Acknowledgment.Strategy.PRE_PROCESSING);
+                .isEqualTo(Acknowledgment.Strategy.PRE_PROCESSING);
 
         assertThat(support.processDefaultAcknowledgement(Shape.STREAM_TRANSFORMER,
                 MediatorConfiguration.Consumption.STREAM_OF_MESSAGE, MediatorConfiguration.Production.STREAM_OF_MESSAGE))
-                        .isEqualTo(Acknowledgment.Strategy.MANUAL);
+                .isEqualTo(Acknowledgment.Strategy.MANUAL);
         assertThat(support.processDefaultAcknowledgement(Shape.STREAM_TRANSFORMER,
                 MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD, MediatorConfiguration.Production.STREAM_OF_PAYLOAD))
-                        .isEqualTo(Acknowledgment.Strategy.PRE_PROCESSING);
+                .isEqualTo(Acknowledgment.Strategy.PRE_PROCESSING);
         assertThat(support.processDefaultAcknowledgement(Shape.STREAM_TRANSFORMER,
                 MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD, MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD))
-                        .isEqualTo(Acknowledgment.Strategy.PRE_PROCESSING);
+                .isEqualTo(Acknowledgment.Strategy.PRE_PROCESSING);
     }
 
     @Test
@@ -519,12 +521,13 @@ public class MediatorConfigurationSupportTest {
 
         assertThatThrownBy(() -> support.validateBlocking(
                 new MediatorConfigurationSupport.ValidationOutput(MediatorConfiguration.Production.STREAM_OF_PAYLOAD,
-                        MediatorConfiguration.Consumption.PAYLOAD, String.class))).isInstanceOf(DefinitionException.class);
+                        MediatorConfiguration.Consumption.PAYLOAD, String.class)))
+                .isInstanceOf(DefinitionException.class);
 
         assertThatThrownBy(() -> support.validateBlocking(
                 new MediatorConfigurationSupport.ValidationOutput(MediatorConfiguration.Production.INDIVIDUAL_PAYLOAD,
                         MediatorConfiguration.Consumption.STREAM_OF_MESSAGE, String.class)))
-                                .isInstanceOf(DefinitionException.class);
+                .isInstanceOf(DefinitionException.class);
 
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/InjectionWithoutSubscriberTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/InjectionWithoutSubscriberTest.java
@@ -38,8 +38,8 @@ public class InjectionWithoutSubscriberTest extends WeldTestBaseWithoutTails {
         assertThatThrownBy(() -> app.emitter().send(Message.of("test",
                 () -> CompletableFuture.completedFuture(null),
                 t -> CompletableFuture.completedFuture(null))))
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("no subscriber");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no subscriber");
 
         app.channel().subscribe().with(list::add);
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MetadataTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MetadataTest.java
@@ -57,17 +57,17 @@ public class MetadataTest {
     public void cannotCreateFromNull() {
         assertThatThrownBy(
                 () -> Metadata.of((Object) null))
-                        .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(
                 () -> Metadata.of(new MessageTest.MyMetadata<>("a"), null, "hello"))
-                        .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(IllegalArgumentException.class);
 
         // Test with duplicated keys
         assertThatThrownBy(() -> Metadata
                 .of(new MessageTest.MyMetadata<>("a"),
                         "hello",
                         new MessageTest.MyMetadata<>("b")))
-                                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/PublisherBuilderPropagationTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/PublisherBuilderPropagationTest.java
@@ -30,7 +30,7 @@ public class PublisherBuilderPropagationTest extends WeldTestBaseWithoutTails {
                     .map(m -> m.v)).hasValue("hello");
             assertThat(message.getMetadata(SimplePropagationTest.CounterMetadata.class)
                     .map(SimplePropagationTest.CounterMetadata::getCount))
-                            .hasValueSatisfying(x -> assertThat(x).isNotEqualTo(0));
+                    .hasValueSatisfying(x -> assertThat(x).isNotEqualTo(0));
             assertThat(message.getMetadata()).hasSize(3);
         }).hasSize(40);
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/PublisherPropagationTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/PublisherPropagationTest.java
@@ -31,7 +31,7 @@ public class PublisherPropagationTest extends WeldTestBaseWithoutTails {
                     .map(m -> m.v)).hasValue("hello");
             assertThat(message.getMetadata(SimplePropagationTest.CounterMetadata.class)
                     .map(SimplePropagationTest.CounterMetadata::getCount))
-                            .hasValueSatisfying(x -> assertThat(x).isNotEqualTo(0));
+                    .hasValueSatisfying(x -> assertThat(x).isNotEqualTo(0));
             assertThat(message.getMetadata()).hasSize(3);
         }).hasSize(40);
     }

--- a/smallrye-reactive-messaging-rabbitmq/pom.xml
+++ b/smallrye-reactive-messaging-rabbitmq/pom.xml
@@ -84,7 +84,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
         <configuration>
           <generatedSourcesDirectory>${project.build.directory}/generated-sources/</generatedSourcesDirectory>
           <annotationProcessors>

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ack/RabbitMQAckHandler.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ack/RabbitMQAckHandler.java
@@ -24,7 +24,7 @@ public interface RabbitMQAckHandler {
 
     /**
      * Handle the request to acknowledge a message.
-     * 
+     *
      * @param message the message to acknowledge
      * @param context the {@link Context} in which the acknowledgement should take place
      * @param <V> message body type

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQBrokerTestBase.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQBrokerTestBase.java
@@ -32,11 +32,11 @@ public class RabbitMQBrokerTestBase {
 
     private static final GenericContainer<?> RABBIT = new GenericContainer<>(
             DockerImageName.parse("rabbitmq:3-management"))
-                    .withExposedPorts(5672, 15672)
-                    .withLogConsumer(of -> LOGGER.info(of.getUtf8String()))
-                    .waitingFor(Wait.forLogMessage(".*Server startup complete.*\\n", 1))
-                    .withCopyFileToContainer(MountableFile.forClasspathResource("rabbitmq/enabled_plugins"),
-                            "/etc/rabbitmq/enabled_plugins");
+            .withExposedPorts(5672, 15672)
+            .withLogConsumer(of -> LOGGER.info(of.getUtf8String()))
+            .waitingFor(Wait.forLogMessage(".*Server startup complete.*\\n", 1))
+            .withCopyFileToContainer(MountableFile.forClasspathResource("rabbitmq/enabled_plugins"),
+                    "/etc/rabbitmq/enabled_plugins");
 
     protected static String host;
     protected static int port;


### PR DESCRIPTION
The `smallrye-parent` now defines jakarta dependencies (except jms-api)
Seems like the formatter rules have changed