### PR TITLE
Decouple OpenTelemetry instrumenter

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/tracing/AmqpOpenTelemetryInstrumenter.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/tracing/AmqpOpenTelemetryInstrumenter.java
@@ -1,0 +1,61 @@
+package io.smallrye.reactive.messaging.amqp.tracing;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingSpanNameExtractor;
+import io.smallrye.reactive.messaging.amqp.AmqpMessage;
+import io.smallrye.reactive.messaging.tracing.TracingUtils;
+
+public class AmqpOpenTelemetryInstrumenter {
+    private final Instrumenter<AmqpMessage<?>, Void> instrumenter;
+
+    private AmqpOpenTelemetryInstrumenter(Instrumenter<AmqpMessage<?>, Void> instrumenter) {
+        this.instrumenter = instrumenter;
+    }
+
+    public static AmqpOpenTelemetryInstrumenter createForConnector() {
+        return create(false);
+    }
+
+    public static AmqpOpenTelemetryInstrumenter createForSender() {
+        return create(true);
+    }
+
+    private static AmqpOpenTelemetryInstrumenter create(boolean sender) {
+        MessageOperation messageOperation = sender ? MessageOperation.SEND : MessageOperation.RECEIVE;
+        AmqpAttributesExtractor amqpAttributesExtractor = new AmqpAttributesExtractor();
+        MessagingAttributesGetter<AmqpMessage<?>, Void> messagingAttributesGetter = amqpAttributesExtractor
+                .getMessagingAttributesGetter();
+        InstrumenterBuilder<AmqpMessage<?>, Void> builder = Instrumenter.builder(GlobalOpenTelemetry.get(),
+                "io.smallrye.reactive.messaging",
+                MessagingSpanNameExtractor.create(messagingAttributesGetter, messageOperation));
+
+        builder
+                .addAttributesExtractor(
+                        MessagingAttributesExtractor.create(messagingAttributesGetter, messageOperation))
+                .addAttributesExtractor(amqpAttributesExtractor)
+                .buildProducerInstrumenter(AmqpMessageTextMapSetter.INSTANCE);
+
+        Instrumenter<AmqpMessage<?>, Void> instrumenter;
+        if (sender) {
+            instrumenter = builder.buildProducerInstrumenter(AmqpMessageTextMapSetter.INSTANCE);
+        } else {
+            instrumenter = builder.buildConsumerInstrumenter(AmqpMessageTextMapGetter.INSTANCE);
+        }
+        return new AmqpOpenTelemetryInstrumenter(instrumenter);
+    }
+
+    public Message<?> traceIncoming(Message<?> m, AmqpMessage<?> trace) {
+        return TracingUtils.traceIncoming(instrumenter, m, (AmqpMessage<?>) trace);
+    }
+
+    public void traceOutgoing(Message<?> msg, AmqpMessage<Object> trace) {
+        TracingUtils.traceOutgoing(instrumenter, msg, trace);
+    }
+}

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/AmqpSinkTest.java
@@ -1264,7 +1264,6 @@ public class AmqpSinkTest extends AmqpTestBase {
     private Flow.Subscriber<? extends Message<?>> getSubscriberBuilder(Map<String, Object> config) {
         this.provider = new AmqpConnector();
         provider.setup(executionHolder);
-        provider.init();
         return this.provider.getSubscriber(new MapBasedConfig(config));
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/tracing/KafkaOpenTelemetryInstrumenter.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/tracing/KafkaOpenTelemetryInstrumenter.java
@@ -1,0 +1,67 @@
+package io.smallrye.reactive.messaging.kafka.tracing;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingSpanNameExtractor;
+import io.smallrye.reactive.messaging.tracing.TracingUtils;
+
+/**
+ * Encapsulates the OpenTelemetry instrumentation API so that those classes are only needed if
+ * users explicitly enable tracing.
+ */
+public class KafkaOpenTelemetryInstrumenter {
+
+    private final Instrumenter<KafkaTrace, Void> instrumenter;
+
+    private KafkaOpenTelemetryInstrumenter(Instrumenter<KafkaTrace, Void> instrumenter) {
+        this.instrumenter = instrumenter;
+    }
+
+    public static KafkaOpenTelemetryInstrumenter createForSource() {
+        return create(true);
+    }
+
+    public static KafkaOpenTelemetryInstrumenter createForSink() {
+        return create(false);
+    }
+
+    private static KafkaOpenTelemetryInstrumenter create(boolean source) {
+
+        MessageOperation messageOperation = source ? MessageOperation.RECEIVE : MessageOperation.SEND;
+
+        KafkaAttributesExtractor kafkaAttributesExtractor = new KafkaAttributesExtractor();
+        MessagingAttributesGetter<KafkaTrace, Void> messagingAttributesGetter = kafkaAttributesExtractor
+                .getMessagingAttributesGetter();
+        InstrumenterBuilder<KafkaTrace, Void> builder = Instrumenter.builder(GlobalOpenTelemetry.get(),
+                "io.smallrye.reactive.messaging",
+                MessagingSpanNameExtractor.create(messagingAttributesGetter, messageOperation));
+
+        builder
+                .addAttributesExtractor(
+                        MessagingAttributesExtractor.create(messagingAttributesGetter, messageOperation))
+                .addAttributesExtractor(kafkaAttributesExtractor);
+
+        Instrumenter<KafkaTrace, Void> instrumenter;
+        if (source) {
+            instrumenter = builder.buildConsumerInstrumenter(KafkaTraceTextMapGetter.INSTANCE);
+        } else {
+            instrumenter = builder.buildProducerInstrumenter(KafkaTraceTextMapSetter.INSTANCE);
+        }
+
+        return new KafkaOpenTelemetryInstrumenter(instrumenter);
+    }
+
+    public Message<?> traceIncoming(Message<?> kafkaRecord, KafkaTrace kafkaTrace, boolean makeCurrent) {
+        return TracingUtils.traceIncoming(instrumenter, kafkaRecord, kafkaTrace, makeCurrent);
+    }
+
+    public void traceOutgoing(Message<?> message, KafkaTrace kafkaTrace) {
+        TracingUtils.traceOutgoing(instrumenter, message, kafkaTrace);
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageConverter.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMessageConverter.java
@@ -14,9 +14,8 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.BasicProperties;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
-import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.smallrye.reactive.messaging.rabbitmq.tracing.RabbitMQOpenTelemetryInstrumenter;
 import io.smallrye.reactive.messaging.rabbitmq.tracing.RabbitMQTrace;
-import io.smallrye.reactive.messaging.tracing.TracingUtils;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -55,7 +54,7 @@ public class RabbitMQMessageConverter {
      * @return an {@link OutgoingRabbitMQMessage}
      */
     public static OutgoingRabbitMQMessage convert(
-            final Instrumenter<RabbitMQTrace, Void> instrumenter,
+            final RabbitMQOpenTelemetryInstrumenter instrumenter,
             final Message<?> message,
             final String exchange,
             final String defaultRoutingKey,
@@ -78,8 +77,7 @@ public class RabbitMQMessageConverter {
             if (isTracingEnabled) {
                 // Create a new span for the outbound message and record updated tracing information in
                 // the headers; this has to be done before we build the properties below
-                TracingUtils.traceOutgoing(instrumenter, message,
-                        RabbitMQTrace.traceExchange(exchange, routingKey, sourceHeaders));
+                instrumenter.traceOutgoing(message, RabbitMQTrace.traceExchange(exchange, routingKey, sourceHeaders));
             }
 
             // Reconstruct the properties from the source, except with the (possibly) modified headers;
@@ -121,8 +119,7 @@ public class RabbitMQMessageConverter {
             if (isTracingEnabled) {
                 // Create a new span for the outbound message and record updated tracing information in
                 // the message headers; this has to be done before we build the properties below
-                TracingUtils.traceOutgoing(instrumenter, message,
-                        RabbitMQTrace.traceExchange(exchange, routingKey, metadata.getHeaders()));
+                instrumenter.traceOutgoing(message, RabbitMQTrace.traceExchange(exchange, routingKey, metadata.getHeaders()));
             }
 
             final Date timestamp = (metadata.getTimestamp() != null) ? Date.from(metadata.getTimestamp().toInstant()) : null;

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQOpenTelemetryInstrumenter.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQOpenTelemetryInstrumenter.java
@@ -1,0 +1,60 @@
+package io.smallrye.reactive.messaging.rabbitmq.tracing;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingSpanNameExtractor;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.smallrye.reactive.messaging.tracing.TracingUtils;
+
+public class RabbitMQOpenTelemetryInstrumenter {
+    private final Instrumenter<RabbitMQTrace, Void> instrumenter;
+
+    protected RabbitMQOpenTelemetryInstrumenter(Instrumenter<RabbitMQTrace, Void> instrumenter) {
+        this.instrumenter = instrumenter;
+    }
+
+    public static RabbitMQOpenTelemetryInstrumenter createForSender() {
+        return create(true);
+    }
+
+    public static RabbitMQOpenTelemetryInstrumenter createForConnector() {
+        return create(false);
+    }
+
+    private static RabbitMQOpenTelemetryInstrumenter create(boolean sender) {
+        MessageOperation messageOperation = sender ? MessageOperation.SEND : MessageOperation.RECEIVE;
+
+        RabbitMQTraceAttributesExtractor rabbitMQAttributesExtractor = new RabbitMQTraceAttributesExtractor();
+        MessagingAttributesGetter<RabbitMQTrace, Void> messagingAttributesGetter = rabbitMQAttributesExtractor
+                .getMessagingAttributesGetter();
+        InstrumenterBuilder<RabbitMQTrace, Void> builder = Instrumenter.builder(
+                GlobalOpenTelemetry.get(),
+                "io.smallrye.reactive.messaging",
+                MessagingSpanNameExtractor.create(messagingAttributesGetter, messageOperation));
+
+        builder.addAttributesExtractor(rabbitMQAttributesExtractor)
+                .addAttributesExtractor(
+                        MessagingAttributesExtractor.create(messagingAttributesGetter, messageOperation));
+        Instrumenter<RabbitMQTrace, Void> instrumenter;
+        if (sender) {
+            instrumenter = builder.buildProducerInstrumenter(RabbitMQTraceTextMapSetter.INSTANCE);
+        } else {
+            instrumenter = builder.buildConsumerInstrumenter(RabbitMQTraceTextMapGetter.INSTANCE);
+        }
+        return new RabbitMQOpenTelemetryInstrumenter(instrumenter);
+    }
+
+    public void traceOutgoing(Message<?> message, RabbitMQTrace trace) {
+        TracingUtils.traceOutgoing(instrumenter, message, trace);
+    }
+
+    public void traceIncoming(IncomingRabbitMQMessage<Object> msg, RabbitMQTrace trace) {
+        TracingUtils.traceIncoming(instrumenter, msg, trace);
+    }
+}


### PR DESCRIPTION
If tracing is not enabled, it should be possible to use the Kafka and AMQP connectors without needing to include the OpenTelemetry instrumentor classes on the classpath.