### PR TITLE
[RabbitMQ] Add the possibility to configure DLQ DLX and TTL

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -122,9 +122,9 @@ import io.vertx.rabbitmq.RabbitMQPublisherOptions;
 @ConnectorAttribute(name = "dlx.declare", direction = INCOMING, description = "Whether to declare the dead letter exchange binding. Relevant only if auto-bind-dlq is true; set to false if these are expected to be set up independently", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "dead-letter-queue-type", direction = INCOMING, description = "If automatically declare DLQ, we can choose different types of DLQ [quorum, classic, stream]", type = "string")
 @ConnectorAttribute(name = "dead-letter-queue-mode", direction = INCOMING, description = "If automatically declare DLQ, we can choose different modes of DLQ [lazy, default]", type = "string")
-@ConnectorAttribute(name = "dead-letter-ttl", direction = INCOMING, description = "If specified, the time (ms) for which a message can remain in DLQ undelivered before it is dead", type = "long")
-@ConnectorAttribute(name = "dead-letter-dlx", direction = INCOMING, description = "If specified, a DLX to assign to the DLQ", type = "string")
-@ConnectorAttribute(name = "dead-letter-dlx-routing-key", direction = INCOMING, description = "If specified, a dead letter routing key to assign to the DLQ", type = "string")
+@ConnectorAttribute(name = "dead-letter-ttl", direction = INCOMING, description = "If specified, the time (ms) for which a message can remain in DLQ undelivered before it is dead. Relevant only if auto-bind-dlq is true", type = "long")
+@ConnectorAttribute(name = "dead-letter-dlx", direction = INCOMING, description = "If specified, a DLX to assign to the DLQ. Relevant only if auto-bind-dlq is true", type = "string")
+@ConnectorAttribute(name = "dead-letter-dlx-routing-key", direction = INCOMING, description = "If specified, a dead letter routing key to assign to the DLQ. Relevant only if auto-bind-dlq is true", type = "string")
 
 // Message consumer
 @ConnectorAttribute(name = "failure-strategy", direction = INCOMING, description = "The failure strategy to apply when a RabbitMQ message is nacked. Accepted values are `fail`, `accept`, `reject` (default)", type = "string", defaultValue = "reject")

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -122,6 +122,9 @@ import io.vertx.rabbitmq.RabbitMQPublisherOptions;
 @ConnectorAttribute(name = "dlx.declare", direction = INCOMING, description = "Whether to declare the dead letter exchange binding. Relevant only if auto-bind-dlq is true; set to false if these are expected to be set up independently", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "dead-letter-queue-type", direction = INCOMING, description = "If automatically declare DLQ, we can choose different types of DLQ [quorum, classic, stream]", type = "string")
 @ConnectorAttribute(name = "dead-letter-queue-mode", direction = INCOMING, description = "If automatically declare DLQ, we can choose different modes of DLQ [lazy, default]", type = "string")
+@ConnectorAttribute(name = "dead-letter-ttl", direction = INCOMING, description = "If specified, the time (ms) for which a message can remain in DLQ undelivered before it is dead", type = "long")
+@ConnectorAttribute(name = "dead-letter-dlx", direction = INCOMING, description = "If specified, a DLX to assign to the DLQ", type = "string")
+@ConnectorAttribute(name = "dead-letter-dlx-routing-key", direction = INCOMING, description = "If specified, a dead letter routing key to assign to the DLQ", type = "string")
 
 // Message consumer
 @ConnectorAttribute(name = "failure-strategy", direction = INCOMING, description = "The failure strategy to apply when a RabbitMQ message is nacked. Accepted values are `fail`, `accept`, `reject` (default)", type = "string", defaultValue = "reject")
@@ -303,10 +306,22 @@ public class RabbitMQConnector implements InboundConnector, OutboundConnector, H
 
         // Declare the queue (and its binding to the exchange or DLQ type/mode) if we have been asked to do so
         final JsonObject queueArgs = new JsonObject();
+        // x-dead-letter-exchange
+        ic.getDeadLetterDlx().ifPresent(deadLetterDlx -> queueArgs.put("x-dead-letter-exchange", deadLetterDlx));
+        // x-dead-letter-routing-key
+        ic.getDeadLetterDlxRoutingKey().ifPresent(deadLetterDlx -> queueArgs.put("x-dead-letter-routing-key", deadLetterDlx));
         // x-queue-type
         ic.getDeadLetterQueueType().ifPresent(queueType -> queueArgs.put("x-queue-type", queueType));
         // x-queue-mode
         ic.getDeadLetterQueueMode().ifPresent(queueMode -> queueArgs.put("x-queue-mode", queueMode));
+        // x-message-ttl
+        ic.getDeadLetterTtl().ifPresent(queueTtl -> {
+            if (queueTtl >= 0) {
+                queueArgs.put("x-message-ttl", queueTtl);
+            } else {
+                throw ex.illegalArgumentInvalidQueueTtl();
+            }
+        });
         return dlxFlow
                 .onItem().transform(v -> Boolean.TRUE.equals(ic.getAutoBindDlq()) ? null : deadLetterQueueName)
                 .onItem().ifNull().switchTo(

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -217,6 +217,9 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
         final String dlxRoutingKey = "failure";
         final String dlqQueueType = "classic";
         final String dlqQueueMode = "default";
+        final long dlqTtl = 10000L;
+        final String dlqDlx = "dlqIncomingDlx";
+        final String dlqDlxRoutingKey = "failure";
 
         final String routingKeys = "urgent, normal";
 
@@ -241,6 +244,9 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
                 .put("mp.messaging.incoming.data.dead-letter-exchange", dlxName)
                 .put("mp.messaging.incoming.data.dead-letter-exchange-type", dlxType)
                 .put("mp.messaging.incoming.data.dead-letter-routing-key", dlxRoutingKey)
+                .put("mp.messaging.incoming.data.dead-letter-ttl", dlqTtl)
+                .put("mp.messaging.incoming.data.dead-letter-dlx", dlqDlx)
+                .put("mp.messaging.incoming.data.dead-letter-dlx-routing-key", dlqDlxRoutingKey)
                 .put("mp.messaging.incoming.data.dlx.declare", true)
                 .put("mp.messaging.incoming.data.dead-letter-queue-type", dlqQueueType)
                 .put("mp.messaging.incoming.data.dead-letter-queue-mode", dlqQueueMode)
@@ -300,6 +306,9 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
         assertThat(dlqArguments.fieldNames()).isNotNull();
         assertThat(dlqArguments.getString("x-queue-type")).isEqualTo(dlqQueueType);
         assertThat(dlqArguments.getString("x-queue-mode")).isEqualTo(dlqQueueMode);
+        assertThat(dlqArguments.getString("x-dead-letter-exchange")).isEqualTo(dlqDlx);
+        assertThat(dlqArguments.getString("x-dead-letter-routing-key")).isEqualTo(dlqDlxRoutingKey);
+        assertThat(dlqArguments.getLong("x-message-ttl")).isEqualTo(dlqTtl);
 
         // verify bindings
         final JsonArray queueBindings = usage.getBindings(exchangeName, queueName);


### PR DESCRIPTION
Regarding the issue:  https://github.com/smallrye/smallrye-reactive-messaging/issues/2181

Changes:
- dead-letter-ttl attribute added
- dead-letter-dlx attribute added
- dead-letter-dlx-routing-key attribute added