### PR TITLE
Force fetch SchemaInfo on Pulsar thread for AutoConsumeSchema

### DIFF
--- a/smallrye-reactive-messaging-pulsar/src/main/java/io/smallrye/reactive/messaging/pulsar/SchemaResolver.java
+++ b/smallrye-reactive-messaging-pulsar/src/main/java/io/smallrye/reactive/messaging/pulsar/SchemaResolver.java
@@ -14,6 +14,7 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
 import io.smallrye.reactive.messaging.providers.helpers.CDIUtils;
+import io.smallrye.reactive.messaging.providers.helpers.Validation;
 
 @ApplicationScoped
 public class SchemaResolver {
@@ -53,6 +54,10 @@ public class SchemaResolver {
 
     public static String getSchemaName(Schema<?> schema) {
         SchemaInfo schemaInfo = schema.getSchemaInfo();
-        return schemaInfo != null ? schemaInfo.getName() : schema.getClass().getSimpleName();
+        if (schemaInfo == null || Validation.isBlank(schemaInfo.getName())) {
+            return schema.getClass().getSimpleName();
+        } else {
+            return schemaInfo.getName();
+        }
     }
 }

--- a/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/auth/PulsarAuthenticationTest.java
+++ b/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/auth/PulsarAuthenticationTest.java
@@ -26,7 +26,6 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.utility.MountableFile;
 
 import io.smallrye.reactive.messaging.pulsar.PulsarConnector;
 import io.smallrye.reactive.messaging.pulsar.base.PulsarContainer;
@@ -42,11 +41,11 @@ public class PulsarAuthenticationTest extends WeldTestBaseWithoutExtension {
     @BeforeAll
     static void beforeAll() throws PulsarClientException, InterruptedException {
         container = new PulsarContainer()
-                .withCopyToContainer(MountableFile.forClasspathResource("htpasswd"), "/pulsar/conf/.htpasswd")
                 .withEnv("PULSAR_PREFIX_authenticationEnabled", "true")
                 .withEnv("PULSAR_PREFIX_authenticationProviders",
                         "org.apache.pulsar.broker.authentication.AuthenticationProviderBasic")
-                .withEnv("PULSAR_PREFIX_basicAuthConf", "file:///pulsar/conf/.htpasswd")
+                // base64 of htpasswd
+                .withEnv("PULSAR_PREFIX_basicAuthConf", "c3VwZXJ1c2VyOiRhcHIxJHpMOHY4VTZsJGNHTWdkckVja25RNHkzeC9ndWROajE=")
                 .withEnv("PULSAR_PREFIX_brokerClientAuthenticationEnabled", "true")
                 .withEnv("PULSAR_PREFIX_brokerClientAuthenticationPlugin",
                         "org.apache.pulsar.client.impl.auth.AuthenticationBasic")

--- a/smallrye-reactive-messaging-pulsar/src/test/resources/htpasswd
+++ b/smallrye-reactive-messaging-pulsar/src/test/resources/htpasswd
@@ -1,1 +1,0 @@
-superuser:$apr1$zL8v8U6l$cGMgdrEcknQ4y3x/gudNj1


### PR DESCRIPTION
In some cases (AutoConsumeSchema or KeyValueSchema) Pulsar schema is fetched lazily, on Message#getValue, and in a blocking way.

This change ensures that the blocking schema fetch happens on pulsar-client-thread and not on event loop thread.

Includes a small fix on how the schema name is shown on logs.