### PR TITLE
Blocking improvements max-concurrency

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
@@ -44,6 +44,7 @@ public abstract class AbstractMediator {
     protected HealthCenter health;
     private Instance<MessageConverter> converters;
     private Instance<KeyValueExtractor> extractors;
+    private int maxConcurrency;
 
     public AbstractMediator(MediatorConfiguration configuration) {
         this.configuration = configuration;
@@ -97,6 +98,10 @@ public abstract class AbstractMediator {
 
     public void setWorkerPoolRegistry(WorkerPoolRegistry workerPoolRegistry) {
         this.workerPoolRegistry = workerPoolRegistry;
+    }
+
+    public void setMaxConcurrency(int maxConcurrency) {
+        this.maxConcurrency = maxConcurrency;
     }
 
     public void run() {
@@ -259,8 +264,11 @@ public abstract class AbstractMediator {
         return extractors;
     }
 
+    public int maxConcurrency() {
+        return maxConcurrency;
+    }
+
     public void terminate() {
         // Do nothing by default.
     }
-
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/PublisherMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/PublisherMediator.java
@@ -143,7 +143,7 @@ public class PublisherMediator extends AbstractMediator {
                         .onItem().transform(o -> (Message<?>) o));
             } else {
                 this.publisher = decorate(MultiUtils.createFromGenerator(this::invokeBlocking)
-                        .onItem().transformToUniAndMerge(u -> u)
+                        .onItem().transformToUni(u -> u).merge(maxConcurrency())
                         .onItem().transform(o -> (Message<?>) o));
             }
         } else {
@@ -163,7 +163,7 @@ public class PublisherMediator extends AbstractMediator {
                         .onItem().transform(Message::of));
             } else {
                 this.publisher = decorate(MultiUtils.createFromGenerator(this::invokeBlocking)
-                        .onItem().transformToUniAndMerge(u -> u)
+                        .onItem().transformToUni(u -> u).merge(maxConcurrency())
                         .onItem().transform(Message::of));
             }
         } else {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/SubscriberMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/SubscriberMediator.java
@@ -165,8 +165,9 @@ public class SubscriberMediator extends AbstractMediator {
                         .invoke(failure -> health.reportApplicationFailure(configuration.methodAsString(), failure));
             } else {
                 this.function = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
-                        .onItem().transformToUniAndMerge(msg -> invokeBlocking(msg, getArguments(msg))
+                        .onItem().transformToUni(msg -> invokeBlocking(msg, getArguments(msg))
                                 .onItemOrFailure().transformToUni(handleInvocationResult(msg)))
+                        .merge(maxConcurrency())
                         .onFailure()
                         .invoke(failure -> health.reportApplicationFailure(configuration.methodAsString(), failure));
             }
@@ -210,7 +211,7 @@ public class SubscriberMediator extends AbstractMediator {
                         .onFailure().invoke(this::reportFailure);
             } else {
                 this.function = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
-                        .onItem().transformToUniAndMerge(this::invokeBlockingAndHandleOutcome)
+                        .onItem().transformToUni(this::invokeBlockingAndHandleOutcome).merge(maxConcurrency())
                         .onFailure().invoke(this::reportFailure);
             }
         } else {
@@ -243,7 +244,7 @@ public class SubscriberMediator extends AbstractMediator {
                         .onFailure().invoke(this::reportFailure);
             } else {
                 this.function = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
-                        .onItem().transformToUniAndMerge(this::invokeBlockingAndHandleOutcome)
+                        .onItem().transformToUni(this::invokeBlockingAndHandleOutcome).merge(maxConcurrency())
                         .onFailure().invoke(this::reportFailure);
             }
         } else {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/connectors/WorkerPoolRegistry.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/connectors/WorkerPoolRegistry.java
@@ -35,8 +35,8 @@ import io.vertx.mutiny.core.WorkerExecutor;
 
 @ApplicationScoped
 public class WorkerPoolRegistry {
-    private static final String WORKER_CONFIG_PREFIX = "smallrye.messaging.worker";
-    private static final String WORKER_CONCURRENCY = "max-concurrency";
+    public static final String WORKER_CONFIG_PREFIX = "smallrye.messaging.worker";
+    public static final String WORKER_CONCURRENCY = "max-concurrency";
 
     @Inject
     Instance<ExecutionHolder> executionHolder;


### PR DESCRIPTION
Draft PR for discussions

Currently, Reactive Messaging controls the `@Blocking` method max concurrency level using the pool size attribute of the vertx worker pool created for the blocking execution.

However, there is a second aspect that affects the max concurrency which is the mutiny concurrency level when merging multiple Uni's into a Multi: https://smallrye.io/smallrye-mutiny/2.3.1/tutorials/transforming-items-asynchronously/#transforming-items-from-multi-the-merge-vs-concatenate-dilemma

This last control how many items will be requested upstream in parallel and effective only when blocking with ordered=false.


This PR changes how the Mutiny merge concurrency is configured : 
- When available the `max-concurrency` is used to configure the Mutiny merge concurrency.
- If not it falls back to the current default value of `Queues.BUFFER_S`.
