### PR TITLE
Fix the synchronization protocol of the InternalChannelRegistry – Backport 3.x

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/InternalChannelRegistry.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/InternalChannelRegistry.java
@@ -2,7 +2,13 @@ package io.smallrye.reactive.messaging.providers.impl;
 
 import static io.smallrye.reactive.messaging.providers.i18n.ProviderMessages.msg;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -18,13 +24,13 @@ import io.smallrye.reactive.messaging.MutinyEmitter;
 @ApplicationScoped
 public class InternalChannelRegistry implements ChannelRegistry {
 
-    private final Map<String, List<Publisher<? extends Message<?>>>> publishers = new HashMap<>();
-    private final Map<String, List<Subscriber<? extends Message<?>>>> subscribers = new HashMap<>();
+    private final Map<String, List<Publisher<? extends Message<?>>>> publishers = new ConcurrentHashMap<>();
+    private final Map<String, List<Subscriber<? extends Message<?>>>> subscribers = new ConcurrentHashMap<>();
 
-    private final Map<String, Boolean> outgoing = new HashMap<>();
-    private final Map<String, Boolean> incoming = new HashMap<>();
+    private final Map<String, Boolean> outgoing = new ConcurrentHashMap<>();
+    private final Map<String, Boolean> incoming = new ConcurrentHashMap<>();
 
-    private final Map<Class<?>, Map<String, Object>> emitters = new HashMap<>();
+    private final Map<Class<?>, Map<String, Object>> emitters = new ConcurrentHashMap<>();
 
     @Override
     public Publisher<? extends Message<?>> register(String name,
@@ -37,7 +43,7 @@ public class InternalChannelRegistry implements ChannelRegistry {
     }
 
     @Override
-    public synchronized Subscriber<? extends Message<?>> register(String name,
+    public Subscriber<? extends Message<?>> register(String name,
             Subscriber<? extends Message<?>> subscriber, boolean merge) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         Objects.requireNonNull(subscriber, msg.subscriberMustBeSet());
@@ -47,47 +53,48 @@ public class InternalChannelRegistry implements ChannelRegistry {
     }
 
     @Override
-    public synchronized void register(String name, Emitter<?> emitter) {
+    public void register(String name, Emitter<?> emitter) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         Objects.requireNonNull(emitter, msg.emitterMustBeSet());
         register(name, Emitter.class, emitter);
     }
 
     @Override
-    public synchronized void register(String name, MutinyEmitter<?> emitter) {
+    public void register(String name, MutinyEmitter<?> emitter) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         Objects.requireNonNull(emitter, msg.emitterMustBeSet());
         register(name, MutinyEmitter.class, emitter);
     }
 
     @Override
-    public synchronized <T> void register(String name, Class<T> emitterType, T emitter) {
+    public <T> void register(String name, Class<T> emitterType, T emitter) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         Objects.requireNonNull(emitter, msg.emitterMustBeSet());
-        Map<String, Object> map = emitters.computeIfAbsent(emitterType, key -> new HashMap<>());
+        Map<String, Object> map = emitters.computeIfAbsent(emitterType, key -> new ConcurrentHashMap<>());
         map.put(name, emitter);
     }
 
     @Override
-    public synchronized List<Publisher<? extends Message<?>>> getPublishers(String name) {
+    public List<Publisher<? extends Message<?>>> getPublishers(String name) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         return publishers.getOrDefault(name, Collections.emptyList());
     }
 
     @Override
-    public synchronized Emitter<?> getEmitter(String name) {
+    public Emitter<?> getEmitter(String name) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         return getEmitter(name, Emitter.class);
     }
 
     @Override
-    public synchronized MutinyEmitter<?> getMutinyEmitter(String name) {
+    public MutinyEmitter<?> getMutinyEmitter(String name) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         return getEmitter(name, MutinyEmitter.class);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public synchronized <T> T getEmitter(String name, Class<? super T> emitterType) {
+    public <T> T getEmitter(String name, Class<? super T> emitterType) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         Map<String, Object> typedEmitters = emitters.get(emitterType);
         if (typedEmitters == null) {
@@ -98,28 +105,28 @@ public class InternalChannelRegistry implements ChannelRegistry {
     }
 
     @Override
-    public synchronized List<Subscriber<? extends Message<?>>> getSubscribers(String name) {
+    public List<Subscriber<? extends Message<?>>> getSubscribers(String name) {
         Objects.requireNonNull(name, msg.nameMustBeSet());
         return subscribers.getOrDefault(name, Collections.emptyList());
     }
 
     private <T> void register(Map<String, List<T>> multimap, String name, T item) {
-        List<T> list = multimap.computeIfAbsent(name, key -> new ArrayList<>());
+        List<T> list = multimap.computeIfAbsent(name, key -> new CopyOnWriteArrayList<>());
         list.add(item);
     }
 
     @Override
-    public synchronized Set<String> getIncomingNames() {
-        return new HashSet<>(publishers.keySet());
+    public Set<String> getIncomingNames() {
+        return publishers.keySet();
     }
 
     @Override
-    public synchronized Set<String> getOutgoingNames() {
-        return new HashSet<>(subscribers.keySet());
+    public Set<String> getOutgoingNames() {
+        return subscribers.keySet();
     }
 
     @Override
-    public synchronized Set<String> getEmitterNames() {
+    public Set<String> getEmitterNames() {
         return emitters.values().stream().flatMap(m -> m.keySet().stream()).collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
Switched to CHM and CopyOnWriteArrayList instead of synchronized methods.

Based on this initial commit:
https://github.com/whitingjr/smallrye-reactive-messaging/commit/f9c5def7b71401d177b8b6d7d7c78b1d63245487