### PR TITLE
Support blocking methods returning Uni and CompletionStage

### DIFF
--- a/documentation/src/main/docs/concepts/blocking.md
+++ b/documentation/src/main/docs/concepts/blocking.md
@@ -51,15 +51,17 @@ following configuration property to be defined:
 `@Blocking` does not support every signature. The following table lists
 the supported ones.
 
-| Shape      | Signature                                                             | Comment                                                                                                               |
-|------------|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| Publisher  | `@Outgoing("in") @Blocking O generator()`                             | Invokes the generator from a worker thread. If `ordered` is set to `false`, the generator can be called concurrently. |
-| Publisher  | `@Outgoing("in")  @Blocking  Message<O> generator()`                  | Invokes the generator from a worker thread. If `ordered` is set to `false`, the generator can be called concurrently. |
-| Processor  | `@Incoming("in") @Outgoing("bar") @Blocking O process(I in)`          | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
-| Processor  | `@Incoming("in") @Outgoing("bar") @Blocking Message<O> process(I in)` | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
-| Subscriber | `@Incoming("in") @Blocking void consume(I in)`                        | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
-| Subscriber | `@Incoming("in") @Blocking Uni<Void> consume(I in)`                   | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
-| Subscriber | `@Incoming("in") @Blocking CompletionStage<Void> consume(I in)`       | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
+| Shape      | Signature                                                                 | Comment                                                                                                               |
+|------------|---------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| Publisher  | `@Outgoing("in") @Blocking O generator()`                                 | Invokes the generator from a worker thread. If `ordered` is set to `false`, the generator can be called concurrently. |
+| Publisher  | `@Outgoing("in")  @Blocking  Message<O> generator()`                      | Invokes the generator from a worker thread. If `ordered` is set to `false`, the generator can be called concurrently. |
+| Processor  | `@Incoming("in") @Outgoing("bar") @Blocking O process(I in)`              | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
+| Processor  | `@Incoming("in") @Outgoing("bar") @Blocking Message<O> process(I in)`     | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
+| Subscriber | `@Incoming("in") @Blocking void consume(I in)`                            | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
+| Subscriber | `@Incoming("in") @Blocking Uni<Void> consume(I in)`                       | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
+| Subscriber | `@Incoming("in") @Blocking Uni<Void> consume(Message<I> msg)`             | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
+| Subscriber | `@Incoming("in") @Blocking CompletionStage<Void> consume(I in)`           | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
+| Subscriber | `@Incoming("in") @Blocking CompletionStage<Void> consume(Message<I> msg)` | Invokes the method on a worker thread. If `ordered` is set to `false`, the method can be called concurrently.         |
 
 When a method can be called concurrently, the max concurrency depends on
 the number of threads from the worker thread pool.

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/BlockingSubscriberTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/BlockingSubscriberTest.java
@@ -154,6 +154,7 @@ class BlockingSubscriberTest extends WeldTestBaseWithoutTails {
 
         await().until(() -> bean.list().size() == 6);
         assertThat(bean.list()).contains("a", "b", "c", "d", "e", "f");
+        assertThat(bean.completedReturns()).contains("a", "b", "c", "d", "e", "f");
 
         List<String> threadNames = bean.threads().stream().distinct().collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
@@ -173,6 +174,7 @@ class BlockingSubscriberTest extends WeldTestBaseWithoutTails {
 
         await().until(() -> bean.list().size() == 6);
         assertThat(bean.list()).contains("a", "b", "c", "d", "e", "f");
+        assertThat(bean.completedReturns()).contains("a", "b", "c", "d", "e", "f");
 
         List<String> threadNames = bean.threads().stream().distinct().collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
@@ -192,6 +194,7 @@ class BlockingSubscriberTest extends WeldTestBaseWithoutTails {
 
         await().until(() -> bean.list().size() == 6);
         assertThat(bean.list()).contains("a", "b", "c", "d", "e", "f");
+        assertThat(bean.completedReturns()).contains("a", "b", "c", "d", "e", "f");
 
         List<String> threadNames = bean.threads().stream().distinct().collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();
@@ -211,6 +214,7 @@ class BlockingSubscriberTest extends WeldTestBaseWithoutTails {
 
         await().until(() -> bean.list().size() == 6);
         assertThat(bean.list()).contains("a", "b", "c", "d", "e", "f");
+        assertThat(bean.completedReturns()).contains("a", "b", "c", "d", "e", "f");
 
         List<String> threadNames = bean.threads().stream().distinct().collect(Collectors.toList());
         assertThat(threadNames.contains(Thread.currentThread().getName())).isFalse();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/beans/IncomingCompletionStageMessageBlockingBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/beans/IncomingCompletionStageMessageBlockingBean.java
@@ -1,7 +1,6 @@
 package io.smallrye.reactive.messaging.blocking.beans;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -16,13 +15,15 @@ import io.smallrye.reactive.messaging.annotations.Blocking;
 public class IncomingCompletionStageMessageBlockingBean {
     private List<String> list = new CopyOnWriteArrayList<>();
     private List<String> threads = new CopyOnWriteArrayList<>();
+    private List<String> completedReturns = new CopyOnWriteArrayList<>();
 
     @Incoming("in")
     @Blocking
     public CompletionStage<Void> consume(Message<String> m) {
         threads.add(Thread.currentThread().getName());
         list.add(m.getPayload());
-        return CompletableFuture.completedFuture(null);
+        return m.ack()
+                .thenAccept(x -> completedReturns.add(m.getPayload()));
     }
 
     public List<String> list() {
@@ -31,5 +32,9 @@ public class IncomingCompletionStageMessageBlockingBean {
 
     public List<String> threads() {
         return threads;
+    }
+
+    public List<String> completedReturns() {
+        return completedReturns;
     }
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/beans/IncomingCompletionStagePayloadBlockingBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/beans/IncomingCompletionStagePayloadBlockingBean.java
@@ -15,13 +15,15 @@ import io.smallrye.reactive.messaging.annotations.Blocking;
 public class IncomingCompletionStagePayloadBlockingBean {
     private List<String> list = new CopyOnWriteArrayList<>();
     private List<String> threads = new CopyOnWriteArrayList<>();
+    private List<String> completedReturns = new CopyOnWriteArrayList<>();
 
     @Incoming("in")
     @Blocking
     public CompletionStage<Void> consume(String s) {
         threads.add(Thread.currentThread().getName());
         list.add(s);
-        return CompletableFuture.completedFuture(null);
+        return CompletableFuture.completedFuture(null)
+                .thenAccept(x -> completedReturns.add(s));
     }
 
     public List<String> list() {
@@ -30,5 +32,9 @@ public class IncomingCompletionStagePayloadBlockingBean {
 
     public List<String> threads() {
         return threads;
+    }
+
+    public List<String> completedReturns() {
+        return completedReturns;
     }
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/beans/IncomingUniMessageBlockingBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/beans/IncomingUniMessageBlockingBean.java
@@ -15,13 +15,15 @@ import io.smallrye.reactive.messaging.annotations.Blocking;
 public class IncomingUniMessageBlockingBean {
     private List<String> list = new CopyOnWriteArrayList<>();
     private List<String> threads = new CopyOnWriteArrayList<>();
+    private List<String> completedReturns = new CopyOnWriteArrayList<>();
 
     @Incoming("in")
     @Blocking
     public Uni<Void> consume(Message<String> m) {
         threads.add(Thread.currentThread().getName());
         list.add(m.getPayload());
-        return Uni.createFrom().voidItem();
+        return Uni.createFrom().completionStage(m::ack)
+                .invoke(() -> completedReturns.add(m.getPayload()));
     }
 
     public List<String> list() {
@@ -30,5 +32,9 @@ public class IncomingUniMessageBlockingBean {
 
     public List<String> threads() {
         return threads;
+    }
+
+    public List<String> completedReturns() {
+        return completedReturns;
     }
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/beans/IncomingUniPayloadBlockingBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/blocking/beans/IncomingUniPayloadBlockingBean.java
@@ -14,13 +14,15 @@ import io.smallrye.reactive.messaging.annotations.Blocking;
 public class IncomingUniPayloadBlockingBean {
     private List<String> list = new CopyOnWriteArrayList<>();
     private List<String> threads = new CopyOnWriteArrayList<>();
+    private List<String> completedReturns = new CopyOnWriteArrayList<>();
 
     @Incoming("in")
     @Blocking
     public Uni<Void> consume(String s) {
         threads.add(Thread.currentThread().getName());
         list.add(s);
-        return Uni.createFrom().voidItem();
+        return Uni.createFrom().voidItem()
+                .invoke(() -> completedReturns.add(s));
     }
 
     public List<String> list() {
@@ -29,5 +31,9 @@ public class IncomingUniPayloadBlockingBean {
 
     public List<String> threads() {
         return threads;
+    }
+
+    public List<String> completedReturns() {
+        return completedReturns;
     }
 }


### PR DESCRIPTION
Current support did not complete the returned `Uni` and `CompletionStage`. This change handles the completion and therefore allows handling messages consuming `Message<Payload>` :
- `Uni<Void> consume(Message<Payload> msg)`
- `CompletionStage<Void> consume(Message<Payload> msg)`

