### PR TITLE
Multiple outgoings support

### DIFF
--- a/api/revapi.json
+++ b/api/revapi.json
@@ -29,20 +29,29 @@
     "minCriticality" : "documented",
     "differences" : [
         {
-            "ignore": true,
+            "code": "java.class.kindChanged",
+            "old": "class io.smallrye.reactive.messaging.Messages",
+            "new": "interface io.smallrye.reactive.messaging.Messages",
+            "justification": "Messages moved to interface with factory method"
+        },
+        {
+            "code": "java.class.nowAbstract",
+            "old": "class io.smallrye.reactive.messaging.Messages",
+            "new": "interface io.smallrye.reactive.messaging.Messages",
+            "justification": "Messages moved to interface with factory method"
+        },
+        {
             "code": "java.field.enumConstantOrderChanged",
             "old": "field io.smallrye.reactive.messaging.MediatorConfiguration.Production.NONE",
             "new": "field io.smallrye.reactive.messaging.MediatorConfiguration.Production.NONE",
             "justification": "Repeatable @Outgoing annotation"
         },
         {
-            "ignore": true,
             "code": "java.method.addedToInterface",
             "new": "method java.util.List<java.lang.String> io.smallrye.reactive.messaging.MediatorConfiguration::getOutgoings()",
             "justification": "Repeatable @Outgoing annotation"
         },
         {
-            "ignore": true,
             "code": "java.annotation.added",
             "old": "@interface org.eclipse.microprofile.reactive.messaging.Outgoing",
             "new": "@interface org.eclipse.microprofile.reactive.messaging.Outgoing",
@@ -50,11 +59,15 @@
             "justification": "Repeatable @Outgoing annotation"
         },
         {
-            "ignore": true,
             "code": "java.annotation.added",
             "old": "@interface org.eclipse.microprofile.reactive.messaging.Outgoing",
             "new": "@interface org.eclipse.microprofile.reactive.messaging.Outgoing",
             "annotation": "@java.lang.annotation.Repeatable(io.smallrye.reactive.messaging.annotations.Outgoings.class)",
+            "justification": "Repeatable @Outgoing annotation"
+        },
+        {
+            "code": "java.method.addedToInterface",
+            "new": "method boolean io.smallrye.reactive.messaging.MediatorConfiguration::hasTargetedOutput()",
             "justification": "Repeatable @Outgoing annotation"
         }
     ]

--- a/api/revapi.json
+++ b/api/revapi.json
@@ -27,7 +27,37 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+        {
+            "ignore": true,
+            "code": "java.field.enumConstantOrderChanged",
+            "old": "field io.smallrye.reactive.messaging.MediatorConfiguration.Production.NONE",
+            "new": "field io.smallrye.reactive.messaging.MediatorConfiguration.Production.NONE",
+            "justification": "Repeatable @Outgoing annotation"
+        },
+        {
+            "ignore": true,
+            "code": "java.method.addedToInterface",
+            "new": "method java.util.List<java.lang.String> io.smallrye.reactive.messaging.MediatorConfiguration::getOutgoings()",
+            "justification": "Repeatable @Outgoing annotation"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.added",
+            "old": "@interface org.eclipse.microprofile.reactive.messaging.Outgoing",
+            "new": "@interface org.eclipse.microprofile.reactive.messaging.Outgoing",
+            "annotation": "@io.smallrye.common.annotation.Experimental(\"The repeatability is a SmallRye-specific feature\")",
+            "justification": "Repeatable @Outgoing annotation"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.added",
+            "old": "@interface org.eclipse.microprofile.reactive.messaging.Outgoing",
+            "new": "@interface org.eclipse.microprofile.reactive.messaging.Outgoing",
+            "annotation": "@java.lang.annotation.Repeatable(io.smallrye.reactive.messaging.annotations.Outgoings.class)",
+            "justification": "Repeatable @Outgoing annotation"
+        }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
@@ -15,7 +15,10 @@ public interface MediatorConfiguration {
 
     Shape shape();
 
+    @Deprecated(since = "4.8.0")
     String getOutgoing();
+
+    List<String> getOutgoings();
 
     List<String> getIncoming();
 
@@ -86,6 +89,8 @@ public interface MediatorConfiguration {
         COMPLETION_STAGE_OF_MESSAGE,
         UNI_OF_PAYLOAD,
         UNI_OF_MESSAGE,
+        SPLIT_MULTI_OF_PAYLOAD,
+        SPLIT_MULTI_OF_MESSAGE,
 
         NONE
     }

--- a/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/MediatorConfiguration.java
@@ -79,6 +79,8 @@ public interface MediatorConfiguration {
 
     MethodParameterDescriptor getParameterDescriptor();
 
+    boolean hasTargetedOutput();
+
     enum Production {
         STREAM_OF_MESSAGE,
         STREAM_OF_PAYLOAD,
@@ -92,7 +94,15 @@ public interface MediatorConfiguration {
         SPLIT_MULTI_OF_PAYLOAD,
         SPLIT_MULTI_OF_MESSAGE,
 
-        NONE
+        NONE;
+
+        public boolean isMessageType() {
+            return this == STREAM_OF_MESSAGE ||
+                    this == INDIVIDUAL_MESSAGE ||
+                    this == COMPLETION_STAGE_OF_MESSAGE ||
+                    this == UNI_OF_MESSAGE ||
+                    this == SPLIT_MULTI_OF_MESSAGE;
+        }
     }
 
     enum Consumption {
@@ -103,6 +113,12 @@ public interface MediatorConfiguration {
         MESSAGE,
         PAYLOAD,
 
-        NONE
+        NONE;
+
+        public boolean isMessageType() {
+            return this == STREAM_OF_MESSAGE ||
+                    this == KEYED_MULTI_MESSAGE ||
+                    this == MESSAGE;
+        }
     }
 }

--- a/api/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging;
 
+import java.util.List;
+
 import jakarta.enterprise.inject.spi.Prioritized;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -33,6 +35,19 @@ public interface PublisherDecorator extends Prioritized {
      */
     Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, String channelName,
             boolean isConnector);
+
+    /**
+     * Decorate a Multi
+     *
+     * @param publisher the multi to decorate
+     * @param @param channelName the list of channel names from which this publisher publishes
+     * @param isConnector {@code true} if decorated channel is connector
+     * @return the extended multi
+     */
+    default Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, List<String> channelName,
+            boolean isConnector) {
+        return decorate(publisher, channelName.isEmpty() ? null : channelName.get(0), isConnector);
+    }
 
     @Override
     default int getPriority() {

--- a/api/src/main/java/io/smallrye/reactive/messaging/Targeted.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/Targeted.java
@@ -1,0 +1,91 @@
+package io.smallrye.reactive.messaging;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Container of payloads to send multiple messages to different channels
+ * <p>
+ * The {@link TargetedMessages.Default} implementation holds channel-payload mappings in an unmodifiable {@link Map}.
+ */
+public interface Targeted extends Iterable<Map.Entry<String, Object>> {
+
+    static Targeted from(Map<String, Object> entries) {
+        return new Default(entries);
+    }
+
+    static Targeted of(String channel, Object payload) {
+        return from(Map.of(channel, payload));
+    }
+
+    static Targeted of(String c1, Object p1, String c2, Object p2) {
+        return from(Map.of(c1, p1, c2, p2));
+    }
+
+    static Targeted of(String c1, Object p1, String c2, Object p2, String c3, Object p3) {
+        return from(Map.of(c1, p1, c2, p2, c3, p3));
+    }
+
+    static Targeted of(String c1, Object p1, String c2, Object p2, String c3, Object p3, String c4, Object p4) {
+        return from(Map.of(c1, p1, c2, p2, c3, p3, c4, p4));
+    }
+
+    static Targeted of(String c1, Object p1, String c2, Object p2, String c3, Object p3, String c4, Object p4,
+            String c5, Object p5) {
+        return from(Map.of(c1, p1, c2, p2, c3, p3, c4, p4, c5, p5));
+    }
+
+    static Targeted of(String c1, Object p1, String c2, Object p2, String c3, Object p3, String c4, Object p4,
+            String c5, Object p5, String c6, Object p6) {
+        return from(Map.of(c1, p1, c2, p2, c3, p3, c4, p4, c5, p5, c6, p6));
+    }
+
+    /**
+     * Return the payload associated with the given channel
+     *
+     * @param channel the channel name
+     * @return the payload associated with the channel. Returns {@code null} if this mapping does not contain the given channel.
+     */
+    Object get(String channel);
+
+    /**
+     * Add the given channel-payload mapping to this target mapping by returning a new one.
+     * It returns a new {@link Targeted} instance.
+     *
+     * @param channel the channel to add
+     * @param payload the payload to add
+     * @return a new instance of {@link Targeted}
+     */
+    Targeted with(String channel, Object payload);
+
+    /**
+     * Default {@link Targeted} implementation
+     */
+    class Default implements Targeted {
+
+        private final Map<String, Object> backend;
+
+        public Default(Map<String, Object> map) {
+            this.backend = Map.copyOf(map);
+        }
+
+        @Override
+        public Object get(String channel) {
+            return backend.get(channel);
+        }
+
+        @Override
+        public Targeted with(String channel, Object payload) {
+            Map<String, Object> copy = new HashMap<>(backend);
+            copy.put(channel, payload);
+            return new Default(copy);
+        }
+
+        @Override
+        public Iterator<Map.Entry<String, Object>> iterator() {
+            return backend.entrySet().iterator();
+        }
+    }
+
+}

--- a/api/src/main/java/io/smallrye/reactive/messaging/TargetedMessages.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/TargetedMessages.java
@@ -1,0 +1,127 @@
+package io.smallrye.reactive.messaging;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * Container of {@link Message}s to send multiple messages to different channels
+ * <p>
+ * The {@link Default} implementation holds channel-message mappings in an unmodifiable {@link Map}.
+ * This implementation returns the inner map from the {@link Message#getPayload()}
+ */
+public interface TargetedMessages extends Message<Map<String, Message<?>>> {
+
+    /**
+     *
+     * @param payloads
+     * @return
+     */
+    static TargetedMessages from(Targeted payloads) {
+        Map<String, Message<?>> map = new HashMap<>();
+        for (Map.Entry<String, Object> entry : payloads) {
+            map.put(entry.getKey(), Message.of(entry.getValue()));
+        }
+        return from(map);
+    }
+
+    static TargetedMessages from(Map<String, Message<?>> entries) {
+        return new Default(entries);
+    }
+
+    static TargetedMessages of(String channel, Message<?> message) {
+        return from(Map.of(channel, message));
+    }
+
+    static TargetedMessages of(String c1, Message<?> m1, String c2, Message<?> m2) {
+        return from(Map.of(c1, m1, c2, m2));
+    }
+
+    static TargetedMessages of(String c1, Message<?> m1, String c2, Message<?> m2, String c3, Message<?> m3) {
+        return from(Map.of(c1, m1, c2, m2, c3, m3));
+    }
+
+    static TargetedMessages of(String c1, Message<?> m1, String c2, Message<?> m2, String c3, Message<?> m3,
+            String c4, Message<?> m4) {
+        return from(Map.of(c1, m1, c2, m2, c3, m3, c4, m4));
+    }
+
+    static TargetedMessages of(String c1, Message<?> m1, String c2, Message<?> m2, String c3, Message<?> m3,
+            String c4, Message<?> m4, String c5, Message<?> m5) {
+        return from(Map.of(c1, m1, c2, m2, c3, m3, c4, m4, c5, m5));
+    }
+
+    static TargetedMessages of(String c1, Message<?> m1, String c2, Message<?> m2, String c3, Message<?> m3,
+            String c4, Message<?> m4, String c5, Message<?> m5, String c6, Message<?> m6) {
+        return from(Map.of(c1, m1, c2, m2, c3, m3, c4, m4, c5, m5, c6, m6));
+    }
+
+    /**
+     * Return the message associated with the given channel
+     *
+     * @param channel the channel name
+     * @return the {@link Message} associated with the channel. Returns {@code null} if this mapping does not contain the given
+     *         channel.
+     */
+    Message<?> get(String channel);
+
+    /**
+     * Add a new mapping to this target mapping.
+     * It returns a new {@link TargetedMessages} instance.
+     *
+     * @param channel the channel to add
+     * @param message the message to add
+     * @return a new instance of {@link TargetedMessages}
+     */
+    TargetedMessages withMessage(String channel, Message<?> message);
+
+    /**
+     * Add a new mapping to this target mapping.
+     * If the given object is not an instance of {@link Message}, it'll be wrapped as a message
+     *
+     * @param channel the channel to add
+     * @param payloadOrMessage the payload or message to add
+     * @return a new instance of {@link Targeted}
+     */
+    TargetedMessages with(String channel, Object payloadOrMessage);
+
+    /**
+     * Default {@link TargetedMessages} implementation
+     */
+    class Default implements TargetedMessages {
+
+        private final Map<String, Message<?>> backend;
+
+        public Default(Map<String, Message<?>> map) {
+            this.backend = Map.copyOf(map);
+        }
+
+        @Override
+        public Message<?> get(String channel) {
+            return backend.get(channel);
+        }
+
+        @Override
+        public TargetedMessages withMessage(String channel, Message<?> message) {
+            Map<String, Message<?>> map = new HashMap<>(backend);
+            map.put(channel, message);
+            return new Default(map);
+        }
+
+        @Override
+        public TargetedMessages with(String channel, Object payload) {
+            if (payload instanceof Message) {
+                return withMessage(channel, (Message<?>) payload);
+            }
+            return withMessage(channel, Message.of(payload));
+        }
+
+        @Override
+        public Map<String, Message<?>> getPayload() {
+            return backend;
+        }
+
+    }
+
+}

--- a/api/src/main/java/io/smallrye/reactive/messaging/annotations/Outgoings.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/annotations/Outgoings.java
@@ -1,0 +1,47 @@
+package io.smallrye.reactive.messaging.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+/**
+ * This class is used to allow multiple {@link Outgoing} declarations.
+ * You can either use:
+ *
+ * <pre>
+ * <code>
+ * &#64;Outgoing("a")
+ * &#64;Outgoing("b")
+ * public void consume(T t);
+ * </code>
+ * </pre>
+ *
+ * Or use the {@link Outgoings} annotation as container:
+ *
+ * <pre>
+ * <code>
+ * &#64;Outgoings({
+ *    &#64;Outgoing("a")
+ *    &#64;Outgoing("b")
+ * })
+ * public void consume(T t);
+ * </code>
+ *
+ * </pre>
+ *
+ * <strong>NOTE:</strong> <em>Experimental</em>, not part of the specification.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Outgoings {
+
+    /**
+     * @return the array of {@link Outgoing}, must not contain {@code null}. All the included {@link Outgoing} must be
+     *         value (have a non-blank and non-null channel name).
+     */
+    Outgoing[] value();
+
+}

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Outgoing.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Outgoing.java
@@ -19,12 +19,16 @@
 package org.eclipse.microprofile.reactive.messaging;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.eclipse.microprofile.reactive.streams.operators.ProcessorBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.reactive.messaging.annotations.Outgoings;
 
 /**
  * Used to signify a publisher of outgoing messages.
@@ -66,6 +70,8 @@ import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(Outgoings.class)
+@Experimental("The repeatability is a SmallRye-specific feature")
 public @interface Outgoing {
 
     /**

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
             - 'Broadcast' : concepts/broadcast.md
             - 'Merge channels' : concepts/merge.md
             - '@Incomings' : concepts/incomings.md
+            - '@Outgoings' : concepts/outgoings.md
             - 'Testing' : concepts/testing.md
             - 'Logging' : concepts/logging.md
             - 'Advanced Configuration' : concepts/advanced-config.md

--- a/documentation/src/main/docs/concepts/outgoings.md
+++ b/documentation/src/main/docs/concepts/outgoings.md
@@ -43,18 +43,21 @@ which is a `Message` type:
 Note that in this case coordinated acknowledgements is handled explicitly
 using {{ javadoc('io.smallrye.reactive.messaging.Messages') }} utility.
 
-## Branching outgoing channels with `SplitterMulti`
+## Branching outgoing channels with `MultiSplitter`
 
 In stream transformer processors it can be useful to branch out an incoming
 stream into different sub-streams, based on some conditions.
 
-When consuming `Multi`, returning a `SplitterMulti` allows to do that:
-
-// TODO link to usage of `Multi.split` operation.
+When consuming a `Multi`, you can use the `Multi.split`
+(see [Mutiny documentation](https://smallrye.io/smallrye-mutiny/latest/guides/multi-split/))
+operation to define multiple branches.
+The stream transformer method with multiple outgoings must return a
+{{ javadoc('io.smallrye.mutiny.operators.multi.split.MultiSplitter', False, 'io.smallrye.reactive/mutiny') }}.
 
 ``` java
 {{ insert('outgoings/SplitterMultiExample.java', 'code') }}
 ```
 
 In this case the number of outgoing channels must match the number of branches given to `split` operation.
-
+Outgoing channels will be tried to be matched to branch identifier enum `toString` ignoring case.
+If not all branches are matched, it will fall back to one-by-one matching depending on the order of outgoing channel declarations and enum ordinals.

--- a/documentation/src/main/docs/concepts/outgoings.md
+++ b/documentation/src/main/docs/concepts/outgoings.md
@@ -1,0 +1,60 @@
+# Multiple Outgoing Channels
+
+!!!warning "Experimental"
+    Multiple `@Outgoings` is an experimental feature.
+
+The `@Outgoing` annotation is repeatable. It means that the method
+dispatches outgoing messages to multiple listed channels:
+
+``` java
+{{ insert('outgoings/OutgoingsExample.java', 'code') }}
+```
+
+The default behaviour is same as the [@Broadcast annotation](broadcast.md),
+meaning that outbound messages are dispatched to all listed outgoing channels.
+
+However, different dispatching mechanism can be employed:
+
+## Selectively dispatching messages using `Targeted` messages
+
+You can selectively dispatch messages to multiple outgoings by returning
+{{ javadoc('io.smallrye.reactive.messaging.Targeted') }} :
+
+``` java
+{{ insert('outgoings/TargetedExample.java', 'code') }}
+```
+
+In this example, three outgoing channels are declared on the `process` method
+but in some condition channel `out3` does not receive any messages.
+
+!!!important "Coordinated acknowledgements"
+    `Targeted` return types coordinate acknowledgements between outgoing messages
+    and the incoming message, therefore the incoming message will be ack'ed only
+    when all outgoing messages are ack'ed.
+
+In cases where you need to consume `Message` and handle metadata propagation
+more finely you can use {{ javadoc('io.smallrye.reactive.messaging.TargetedMessages') }}
+which is a `Message` type:
+
+``` java
+{{ insert('outgoings/TargetedExample.java', 'targeted-messages') }}
+```
+
+Note that in this case coordinated acknowledgements is handled explicitly
+using {{ javadoc('io.smallrye.reactive.messaging.Messages') }} utility.
+
+## Branching outgoing channels with `SplitterMulti`
+
+In stream transformer processors it can be useful to branch out an incoming
+stream into different sub-streams, based on some conditions.
+
+When consuming `Multi`, returning a `SplitterMulti` allows to do that:
+
+// TODO link to usage of `Multi.split` operation.
+
+``` java
+{{ insert('outgoings/SplitterMultiExample.java', 'code') }}
+```
+
+In this case the number of outgoing channels must match the number of branches given to `split` operation.
+

--- a/documentation/src/main/java/outgoings/OutgoingsExample.java
+++ b/documentation/src/main/java/outgoings/OutgoingsExample.java
@@ -1,0 +1,18 @@
+package outgoings;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+public class OutgoingsExample {
+
+    //<code>
+    @Incoming("in")
+    @Outgoing("out1")
+    @Outgoing("out2")
+    public String process(String s) {
+        // send messages from channel-in to both channel-out1 and channel-out2
+        return s.toUpperCase();
+    }
+    //</code>
+
+}

--- a/documentation/src/main/java/outgoings/SplitterMultiExample.java
+++ b/documentation/src/main/java/outgoings/SplitterMultiExample.java
@@ -1,0 +1,37 @@
+package outgoings;
+
+import java.util.Objects;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.split.MultiSplitter;
+
+public class SplitterMultiExample {
+
+    // <code>
+    enum Caps {
+        ALL_CAPS,
+        ALL_LOW,
+        MIXED
+    }
+
+    @Incoming("in")
+    @Outgoing("sink1")
+    @Outgoing("sink2")
+    @Outgoing("sink3")
+    public MultiSplitter<String, Caps> reshape(Multi<String> in) {
+        return in.split(Caps.class, s -> {
+            if (Objects.equals(s, s.toLowerCase())) {
+                return Caps.ALL_LOW;
+            } else if (Objects.equals(s, s.toUpperCase())) {
+                return Caps.ALL_CAPS;
+            } else {
+                return Caps.MIXED;
+            }
+        });
+    }
+    // </code>
+
+}

--- a/documentation/src/main/java/outgoings/TargetedExample.java
+++ b/documentation/src/main/java/outgoings/TargetedExample.java
@@ -1,0 +1,44 @@
+package outgoings;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.reactive.messaging.Messages;
+import io.smallrye.reactive.messaging.Targeted;
+import io.smallrye.reactive.messaging.TargetedMessages;
+
+public class TargetedExample {
+
+    //<code>
+    @Incoming("in")
+    @Outgoing("out1")
+    @Outgoing("out2")
+    @Outgoing("out3")
+    public Targeted process(double price) {
+        // send messages from channel-in to both channel-out1 and channel-out2
+        Targeted targeted = Targeted.of("out1", "Price: " + price,
+                "out2", "Quote: " + price);
+        if (price > 90.0) {
+            return targeted.with("out3", price);
+        }
+        return targeted;
+    }
+    //</code>
+
+    //<targeted-messages>
+    @Incoming("channel-in")
+    @Outgoing("channel-out1")
+    @Outgoing("channel-out2")
+    @Outgoing("channel-out3")
+    public TargetedMessages processMessage(Message<String> msg) {
+        // send messages from channel-in to both channel-out1 and channel-out2
+        return Messages.chain(msg)
+                .with(Map.of("channel-out1", msg.withPayload(msg.getPayload().toUpperCase()),
+                        "channel-out2", msg.withPayload(msg.getPayload().toLowerCase())));
+    }
+    //</targeted-messages>
+
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/split/MultiSplitterTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/split/MultiSplitterTest.java
@@ -1,0 +1,84 @@
+package io.smallrye.reactive.messaging.kafka.split;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.split.MultiSplitter;
+import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
+import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
+import io.smallrye.reactive.messaging.kafka.companion.ConsumerTask;
+
+class MultiSplitterTest extends KafkaCompanionTestBase {
+
+    @Test
+    public void sink() {
+        String sinkTopic = topic + "-sink";
+        KafkaMapBasedConfig config = kafkaConfig("mp.messaging.outgoing.sink")
+                .with("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+                .with("topic", sinkTopic)
+                .withPrefix("mp.messaging.outgoing.sink2")
+                .with("topic", sinkTopic + 2)
+                .with("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+        addBeans(Source.class);
+        runApplication(config, MySplitProcessorBean.class);
+
+        ConsumerTask<String, String> records = companion.consumeStrings()
+                .fromTopics(sinkTopic, 1500)
+                .awaitCompletion();
+        assertThat(records)
+                .extracting(ConsumerRecord::value)
+                .containsSequence(IntStream.range(1, 1500).map(i -> i * 2).mapToObj(String::valueOf)
+                        .collect(Collectors.toList()));
+
+        companion.consumeStrings()
+                .fromTopics(sinkTopic + 2, 1500)
+                .awaitCompletion();
+    }
+
+    @ApplicationScoped
+    public static class MySplitProcessorBean {
+
+        private final List<String> records = new CopyOnWriteArrayList<>();
+
+        enum OddEven {
+            EVEN,
+            ODD
+        }
+
+        @Incoming("data")
+        @Outgoing("sink")
+        @Outgoing("sink2")
+        public MultiSplitter<String, OddEven> process(Multi<String> recordMulti) {
+            return recordMulti
+                    .onItem().invoke(records::add)
+                    .split(OddEven.class, s -> (Integer.parseInt(s) % 2 == 0) ? OddEven.EVEN : OddEven.ODD);
+        }
+
+        public List<String> list() {
+            return records;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class Source {
+        @Outgoing("data")
+        Multi<String> produce() {
+            return Multi.createFrom().range(1, 3001).map(String::valueOf);
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
@@ -202,6 +202,10 @@ public abstract class AbstractMediator {
         return null;
     }
 
+    public Multi<? extends Message<?>> getStream(String outgoing) {
+        return getStream();
+    }
+
     public MediatorConfiguration getConfiguration() {
         return configuration;
     }
@@ -233,13 +237,26 @@ public abstract class AbstractMediator {
         }
 
         for (PublisherDecorator decorator : getSortedInstances(decorators)) {
-            input = decorator.decorate(input, getConfiguration().getOutgoing(), false);
+            input = decorator.decorate(input, getConfiguration().getOutgoings(), false);
         }
 
-        if (configuration.getBroadcast()) {
-            return BroadcastHelper.broadcastPublisher(input, configuration.getNumberOfSubscriberBeforeConnecting());
+        if (getBroadcast()) {
+            return BroadcastHelper.broadcastPublisher(input, getNumberOfSubscriberBeforeConnecting());
         } else {
             return input;
+        }
+    }
+
+    boolean getBroadcast() {
+        return configuration.getBroadcast() || configuration.getOutgoings().size() > 1;
+    }
+
+    int getNumberOfSubscriberBeforeConnecting() {
+        int outgoings = configuration.getOutgoings().size();
+        if (outgoings > 1) {
+            return outgoings;
+        } else {
+            return configuration.getNumberOfSubscriberBeforeConnecting();
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/DefaultMediatorConfiguration.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/DefaultMediatorConfiguration.java
@@ -69,6 +69,8 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
 
     private boolean useReactiveStreams = false;
 
+    private boolean hasTargetedOutput = false;
+
     /**
      * The merge policy.
      */
@@ -243,6 +245,7 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
             this.acknowledgment = this.mediatorConfigurationSupport.processDefaultAcknowledgement(this.shape, this.consumption,
                     this.production);
         }
+        this.hasTargetedOutput = this.mediatorConfigurationSupport.processTargetedOutput();
         this.mergePolicy = this.mediatorConfigurationSupport.processMerge(incomings, () -> {
             Merge annotation = method.getAnnotation(Merge.class);
             return annotation != null ? annotation.value() : null;
@@ -314,6 +317,11 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
     @Override
     public MethodParameterDescriptor getParameterDescriptor() {
         return descriptor;
+    }
+
+    @Override
+    public boolean hasTargetedOutput() {
+        return hasTargetedOutput;
     }
 
     @Override

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/DefaultMediatorConfiguration.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/DefaultMediatorConfiguration.java
@@ -27,6 +27,7 @@ import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
 import io.smallrye.reactive.messaging.annotations.Incomings;
 import io.smallrye.reactive.messaging.annotations.Merge;
+import io.smallrye.reactive.messaging.annotations.Outgoings;
 import io.smallrye.reactive.messaging.keyed.KeyValueExtractor;
 import io.smallrye.reactive.messaging.keyed.Keyed;
 import io.smallrye.reactive.messaging.providers.helpers.TypeUtils;
@@ -46,7 +47,7 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
 
     private List<String> incomingValues = Collections.emptyList();
 
-    private String outgoingValue = null;
+    private List<String> outgoingValues = Collections.emptyList();
 
     private Acknowledgment.Strategy acknowledgment;
 
@@ -149,10 +150,50 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
         if (values.length == 0) {
             throw ex.illegalArgumentForAnnotationNonEmpty("@Incoming", methodAsString());
         }
-        compute(Arrays.asList(values), outgoing, blocking);
+        compute(Arrays.asList(values), Collections.singletonList(outgoing), blocking);
+    }
+
+    public void compute(Incomings incomings, Outgoings outgoings, Blocking blocking) {
+        Incoming[] ins = incomings.value();
+        if (ins.length == 0) {
+            throw ex.illegalArgumentForAnnotationNonEmpty("@Incoming", methodAsString());
+        }
+        Outgoing[] outs = outgoings.value();
+        if (outs.length == 0) {
+            throw ex.illegalArgumentForAnnotationNonEmpty("@Outgoing", methodAsString());
+        }
+        compute(Arrays.asList(ins), Arrays.asList(outs), blocking);
+    }
+
+    public void compute(Incomings incomings, List<Outgoing> outgoings, Blocking blocking) {
+        Incoming[] ins = incomings.value();
+        if (ins.length == 0) {
+            throw ex.illegalArgumentForAnnotationNonEmpty("@Incoming", methodAsString());
+        }
+        compute(Arrays.asList(ins), outgoings, blocking);
+    }
+
+    public void compute(Incoming incoming, Outgoings outgoings, Blocking blocking) {
+        Outgoing[] values = outgoings.value();
+        if (values.length == 0) {
+            throw ex.illegalArgumentForAnnotationNonEmpty("@Outgoing", methodAsString());
+        }
+        compute(Collections.singletonList(incoming), Arrays.asList(values), blocking);
     }
 
     public void compute(List<Incoming> incomings, Outgoing outgoing, Blocking blocking) {
+        compute(incomings, Collections.singletonList(outgoing), blocking);
+    }
+
+    public void compute(List<Incoming> incomings, Outgoings outgoings, Blocking blocking) {
+        Outgoing[] outs = outgoings.value();
+        if (outs.length == 0) {
+            throw ex.illegalArgumentForAnnotationNonEmpty("@Outgoing", methodAsString());
+        }
+        compute(incomings, Arrays.asList(outs), blocking);
+    }
+
+    public void compute(List<Incoming> incomings, List<Outgoing> outgoings, Blocking blocking) {
         if (incomings != null) {
             for (Incoming incoming : incomings) {
                 if (Validation.isBlank(incoming.value())) {
@@ -163,11 +204,15 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
             incomings = Collections.emptyList();
         }
 
-        if (outgoing != null && Validation.isBlank(outgoing.value())) {
-            throw ex.illegalArgumentForAnnotationNullOrBlank("@Outgoing", methodAsString());
+        if (outgoings != null) {
+            for (Outgoing outgoing : outgoings) {
+                if (Validation.isBlank(outgoing.value())) {
+                    throw ex.illegalArgumentForAnnotationNullOrBlank("@Outgoing", methodAsString());
+                }
+            }
         }
 
-        this.shape = this.mediatorConfigurationSupport.determineShape(incomings, outgoing);
+        this.shape = this.mediatorConfigurationSupport.determineShape(incomings, outgoings);
 
         this.acknowledgment = this.mediatorConfigurationSupport.processSuppliedAcknowledgement(incomings, () -> {
             Acknowledgment annotation = method.getAnnotation(Acknowledgment.class);
@@ -177,8 +222,8 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
         if (!incomings.isEmpty()) {
             this.incomingValues = incomings.stream().map(Incoming::value).collect(Collectors.toList());
         }
-        if (outgoing != null) {
-            this.outgoingValue = outgoing.value();
+        if (!outgoings.isEmpty()) {
+            this.outgoingValues = outgoings.stream().map(Outgoing::value).collect(Collectors.toList());
         }
         if (blocking != null) {
             this.isBlocking = true;
@@ -202,7 +247,7 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
             Merge annotation = method.getAnnotation(Merge.class);
             return annotation != null ? annotation.value() : null;
         });
-        this.broadcastValue = this.mediatorConfigurationSupport.processBroadcast(outgoing, () -> {
+        this.broadcastValue = this.mediatorConfigurationSupport.processBroadcast(outgoings, () -> {
             Broadcast annotation = method.getAnnotation(Broadcast.class);
             return annotation != null ? annotation.value() : null;
         });
@@ -223,7 +268,22 @@ public class DefaultMediatorConfiguration implements MediatorConfiguration {
 
     @Override
     public String getOutgoing() {
-        return outgoingValue;
+        // Backwards compatible
+        if (outgoingValues != null && !outgoingValues.isEmpty()) {
+            return outgoingValues.get(0);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public List<String> getOutgoings() {
+        // Backwards compatible
+        if (outgoingValues != null && !outgoingValues.isEmpty()) {
+            return outgoingValues;
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MediatorConfigurationSupport.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MediatorConfigurationSupport.java
@@ -23,6 +23,8 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.split.MultiSplitter;
 import io.smallrye.reactive.messaging.MediatorConfiguration;
 import io.smallrye.reactive.messaging.Shape;
+import io.smallrye.reactive.messaging.Targeted;
+import io.smallrye.reactive.messaging.TargetedMessages;
 import io.smallrye.reactive.messaging.annotations.Merge;
 import io.smallrye.reactive.messaging.keyed.KeyValueExtractor;
 import io.smallrye.reactive.messaging.keyed.KeyedMulti;
@@ -610,6 +612,13 @@ public class MediatorConfigurationSupport {
             throw ex.definitionBroadcastOnlyOutgoing("@Incoming", methodAsString);
         }
         return null;
+    }
+
+    public boolean processTargetedOutput() {
+        return Targeted.class.isAssignableFrom(returnType)
+                || returnTypeAssignable.check(Targeted.class, 0) == GenericTypeAssignable.Result.Assignable
+                || TargetedMessages.class.isAssignableFrom(returnType)
+                || returnTypeAssignable.check(TargetedMessages.class, 0) == GenericTypeAssignable.Result.Assignable;
     }
 
     public void validateBlocking(ValidationOutput validationOutput) {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MediatorConfigurationSupport.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MediatorConfigurationSupport.java
@@ -20,6 +20,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.split.MultiSplitter;
 import io.smallrye.reactive.messaging.MediatorConfiguration;
 import io.smallrye.reactive.messaging.Shape;
 import io.smallrye.reactive.messaging.annotations.Merge;
@@ -45,8 +46,8 @@ public class MediatorConfigurationSupport {
         this.firstMethodParamTypeAssignable = firstMethodParamTypeAssignable;
     }
 
-    public Shape determineShape(List<?> incomingValue, Object outgoingValue) {
-        if (!incomingValue.isEmpty() && outgoingValue != null) {
+    public Shape determineShape(List<?> incomingValue, List<?> outgoingValue) {
+        if (!incomingValue.isEmpty() && !outgoingValue.isEmpty()) {
             if (isPublisherOrReactiveStreamsPublisherOrPublisherBuilder(returnType)
                     && isConsumingAPublisherOrReactiveStreamsPublisherOrAPublisherBuilder(parameterTypes)) {
                 return Shape.STREAM_TRANSFORMER;
@@ -63,6 +64,7 @@ public class MediatorConfigurationSupport {
     private boolean isPublisherOrReactiveStreamsPublisherOrPublisherBuilder(Class<?> returnType) {
         return ClassUtils.isAssignable(returnType, Flow.Publisher.class)
                 || ClassUtils.isAssignable(returnType, Publisher.class)
+                || ClassUtils.isAssignable(returnType, MultiSplitter.class)
                 || ClassUtils.isAssignable(returnType, PublisherBuilder.class);
     }
 
@@ -461,10 +463,16 @@ public class MediatorConfigurationSupport {
         if (returnTypeGenericCheck == GenericTypeAssignable.Result.NotGeneric) {
             throw ex.definitionExpectedReturnedParam("@Outgoing", methodAsString, returnType.getSimpleName());
         }
-        production = returnTypeGenericCheck == GenericTypeAssignable.Result.Assignable
-                ? MediatorConfiguration.Production.STREAM_OF_MESSAGE
-                : MediatorConfiguration.Production.STREAM_OF_PAYLOAD;
-
+        if (ClassUtils.isAssignable(returnType, MultiSplitter.class)) {
+            GenericTypeAssignable.Result multiSplitter = returnTypeAssignable.check(Message.class, 0);
+            production = multiSplitter == GenericTypeAssignable.Result.Assignable
+                    ? MediatorConfiguration.Production.SPLIT_MULTI_OF_MESSAGE
+                    : MediatorConfiguration.Production.SPLIT_MULTI_OF_PAYLOAD;
+        } else {
+            production = returnTypeGenericCheck == GenericTypeAssignable.Result.Assignable
+                    ? MediatorConfiguration.Production.STREAM_OF_MESSAGE
+                    : MediatorConfiguration.Production.STREAM_OF_PAYLOAD;
+        }
         if (parameterTypes.length == 1 && parameterTypes[0].equals(KeyedMulti.class)) {
             // Check whether it's a KeyMulti receiving payloads or messages
             if (firstMethodParamTypeAssignable.getType(1) instanceof ParameterizedType &&

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/StreamTransformerMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/StreamTransformerMediator.java
@@ -5,6 +5,9 @@ import static io.smallrye.reactive.messaging.providers.helpers.KeyMultiUtils.con
 import static io.smallrye.reactive.messaging.providers.i18n.ProviderExceptions.ex;
 import static io.smallrye.reactive.messaging.providers.i18n.ProviderMessages.msg;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Flow;
@@ -16,6 +19,8 @@ import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.reactivestreams.Publisher;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.split.MultiSplitter;
 import io.smallrye.reactive.converters.ReactiveTypeConverter;
 import io.smallrye.reactive.converters.Registry;
 import io.smallrye.reactive.messaging.MediatorConfiguration;
@@ -29,6 +34,8 @@ public class StreamTransformerMediator extends AbstractMediator {
     Function<Multi<? extends Message<?>>, Multi<? extends Message<?>>> function;
 
     private Multi<? extends Message<?>> publisher;
+
+    private final Map<String, Multi<? extends Message<?>>> outgoingPublisherMap = new HashMap<>();
 
     public StreamTransformerMediator(MediatorConfiguration configuration) {
         super(configuration);
@@ -53,6 +60,26 @@ public class StreamTransformerMediator extends AbstractMediator {
                 && configuration.production() == MediatorConfiguration.Production.STREAM_OF_PAYLOAD) {
             throw ex.definitionProducePayloadStreamAndConsumeMessageStream(configuration.methodAsString());
         }
+
+        if (configuration.consumption() == MediatorConfiguration.Consumption.STREAM_OF_MESSAGE
+                && configuration.production() == MediatorConfiguration.Production.SPLIT_MULTI_OF_PAYLOAD) {
+            throw ex.definitionProducePayloadStreamAndConsumeMessageStream(configuration.methodAsString());
+        }
+
+        if (configuration.consumption() == MediatorConfiguration.Consumption.STREAM_OF_PAYLOAD
+                && configuration.production() == MediatorConfiguration.Production.SPLIT_MULTI_OF_MESSAGE) {
+            throw ex.definitionProduceMessageStreamAndConsumePayloadStream(configuration.methodAsString());
+        }
+
+        if (configuration.consumption() == MediatorConfiguration.Consumption.KEYED_MULTI
+                && configuration.production() == MediatorConfiguration.Production.SPLIT_MULTI_OF_MESSAGE) {
+            throw ex.definitionProduceMessageStreamAndConsumePayloadStream(configuration.methodAsString());
+        }
+
+        if (configuration.consumption() == MediatorConfiguration.Consumption.KEYED_MULTI_MESSAGE
+                && configuration.production() == MediatorConfiguration.Production.SPLIT_MULTI_OF_PAYLOAD) {
+            throw ex.definitionProducePayloadStreamAndConsumeMessageStream(configuration.methodAsString());
+        }
     }
 
     @Override
@@ -66,6 +93,11 @@ public class StreamTransformerMediator extends AbstractMediator {
     public Multi<? extends Message<?>> getStream() {
         Objects.requireNonNull(publisher);
         return publisher;
+    }
+
+    @Override
+    public Multi<? extends Message<?>> getStream(String outgoing) {
+        return outgoingPublisherMap.get(outgoing);
     }
 
     @Override
@@ -86,6 +118,8 @@ public class StreamTransformerMediator extends AbstractMediator {
                     processMethodConsumingAPublisherBuilderOfMessages();
                 } else if (configuration.usesReactiveStreams()) {
                     processMethodConsumingAReactiveStreamsPublisherOfMessages();
+                } else if (configuration.production() == MediatorConfiguration.Production.SPLIT_MULTI_OF_MESSAGE) {
+                    processMethodConsumingAPublisherOfPayloadAndProducingSplitMultiOfMessages();
                 } else {
                     processMethodConsumingAPublisherOfMessages();
                 }
@@ -96,6 +130,8 @@ public class StreamTransformerMediator extends AbstractMediator {
                     processMethodConsumingAPublisherBuilderOfPayload();
                 } else if (configuration.usesReactiveStreams()) {
                     processMethodConsumingAReactiveStreamsPublisherOfPayload();
+                } else if (configuration.production() == MediatorConfiguration.Production.SPLIT_MULTI_OF_PAYLOAD) {
+                    processMethodConsumingAPublisherOfPayloadAndProducingSplitMulti();
                 } else {
                     processMethodConsumingAPublisherOfPayload();
                 }
@@ -134,11 +170,38 @@ public class StreamTransformerMediator extends AbstractMediator {
         };
     }
 
-    private void processMethodConsumingAPublisherOfMessages() {
+    private void processMethodConsumingAPublisherOfPayloadAndProducingSplitMultiOfMessages() {
         function = upstream -> {
             Multi<? extends Message<?>> multi = MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration);
             Flow.Publisher<? extends Message<?>> argument = convertToDesiredPublisherType(multi);
-            Flow.Publisher<Message<?>> result = invoke(argument);
+            MultiSplitter<? extends Message<?>, ?> result = fillSplitsOfMessages(argument);
+            Objects.requireNonNull(result, msg.methodReturnedNull(configuration.methodAsString()));
+            return upstream;
+        };
+    }
+
+    private <T extends Message<?>, K extends Enum<K>> MultiSplitter<T, K> fillSplitsOfMessages(Flow.Publisher<T> argument) {
+        MultiSplitter<T, K> result = invoke(argument);
+        K[] enumConstants = result.keyType().getEnumConstants();
+        List<String> outgoings = configuration.getOutgoings();
+        if (outgoings.size() != enumConstants.length) {
+            throw ex.outgoingsDoesNotMatchMultiSplitterTarget(getMethodAsString(), outgoings.size(), enumConstants.length);
+        }
+        for (int i = 0; i < outgoings.size(); i++) {
+            String outgoing = outgoings.get(i);
+            K key = enumConstants[i];
+            Multi<? extends Message<?>> m = result.get(key)
+                    // concat map with prefetch handles the request starvation issue with SplitMulti and also syncs requests
+                    .onItem().transformToUni(u -> Uni.createFrom().item(u)).concatenate(true);
+            outgoingPublisherMap.put(outgoing, m);
+        }
+        return result;
+    }
+
+    private void processMethodConsumingAPublisherOfMessages() {
+        function = upstream -> {
+            Multi<? extends Message<?>> multi = MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration);
+            Flow.Publisher<Message<?>> result = invoke(multi);
             Objects.requireNonNull(result, msg.methodReturnedNull(configuration.methodAsString()));
             return MultiUtils.publisher(result);
         };
@@ -191,6 +254,34 @@ public class StreamTransformerMediator extends AbstractMediator {
             return Multi.createFrom().publisher(AdaptersToFlow.publisher(result))
                     .onItem().transform(Message::of);
         };
+    }
+
+    private void processMethodConsumingAPublisherOfPayloadAndProducingSplitMulti() {
+        function = upstream -> {
+            Multi<?> multi = MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
+                    .onItem().transform(Message::getPayload);
+            MultiSplitter<?, ?> result = fillSplitFunction(multi);
+            Objects.requireNonNull(result, msg.methodReturnedNull(configuration.methodAsString()));
+            return upstream;
+        };
+    }
+
+    private <T extends Enum<T>> MultiSplitter<?, T> fillSplitFunction(Flow.Publisher<?> argument) {
+        MultiSplitter<?, T> result = invoke(argument);
+        T[] enumConstants = result.keyType().getEnumConstants();
+        List<String> outgoings = configuration.getOutgoings();
+        if (outgoings.size() != enumConstants.length) {
+            throw ex.outgoingsDoesNotMatchMultiSplitterTarget(getMethodAsString(), outgoings.size(), enumConstants.length);
+        }
+        for (int i = 0; i < outgoings.size(); i++) {
+            String outgoing = outgoings.get(i);
+            T key = enumConstants[i];
+            Multi<? extends Message<?>> m = result.get(key).onItem().transform(Message::of)
+                    // concat map with prefetch handles the request starvation issue with SplitMulti and also syncs requests
+                    .onItem().transformToUni(u -> Uni.createFrom().item(u)).concatenate(true);
+            outgoingPublisherMap.put(outgoing, m);
+        }
+        return result;
     }
 
     private void processMethodConsumingAPublisherOfPayload() {

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/StreamTransformerMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/StreamTransformerMediator.java
@@ -97,7 +97,11 @@ public class StreamTransformerMediator extends AbstractMediator {
 
     @Override
     public Multi<? extends Message<?>> getStream(String outgoing) {
-        return outgoingPublisherMap.get(outgoing);
+        if (configuration.production() == MediatorConfiguration.Production.SPLIT_MULTI_OF_MESSAGE
+                || configuration.production() == MediatorConfiguration.Production.SPLIT_MULTI_OF_PAYLOAD) {
+            return outgoingPublisherMap.get(outgoing);
+        }
+        return super.getStream(outgoing);
     }
 
     @Override

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/CollectedMediatorMetadata.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/CollectedMediatorMetadata.java
@@ -14,6 +14,7 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import io.smallrye.reactive.messaging.MediatorConfiguration;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Incomings;
+import io.smallrye.reactive.messaging.annotations.Outgoings;
 import io.smallrye.reactive.messaging.providers.DefaultMediatorConfiguration;
 
 class CollectedMediatorMetadata {
@@ -37,15 +38,35 @@ class CollectedMediatorMetadata {
         }
 
         Incomings incomings = met.getAnnotation(Incomings.class);
+        Outgoings outgoings = met.getAnnotation(Outgoings.class);
         Incoming incoming = met.getAnnotation(Incoming.class);
         Outgoing outgoing = met.getAnnotation(Outgoing.class);
         Blocking blocking = met.getAnnotation(Blocking.class);
         if (incomings != null) {
-            configuration.compute(incomings, outgoing, blocking);
+            if (outgoings != null) {
+                configuration.compute(incomings, outgoings, blocking);
+            } else if (outgoing != null) {
+                configuration.compute(incomings, outgoing, blocking);
+            } else {
+                configuration.compute(incomings, Collections.emptyList(), blocking);
+            }
         } else if (incoming != null) {
-            configuration.compute(Collections.singletonList(incoming), outgoing, blocking);
+            if (outgoings != null) {
+                configuration.compute(Collections.singletonList(incoming), outgoings, blocking);
+            } else if (outgoing != null) {
+                configuration.compute(Collections.singletonList(incoming), Collections.singletonList(outgoing), blocking);
+            } else {
+                configuration.compute(Collections.singletonList(incoming), Collections.emptyList(), blocking);
+            }
         } else {
-            configuration.compute(Collections.emptyList(), outgoing, blocking);
+            if (outgoings != null) {
+                configuration.compute(Collections.emptyList(), outgoings, blocking);
+            } else if (outgoing != null) {
+                configuration.compute(Collections.emptyList(), Collections.singletonList(outgoing), blocking);
+            } else {
+                // should never happen
+                configuration.compute(Collections.emptyList(), Collections.emptyList(), blocking);
+            }
         }
         return configuration;
     }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/MediatorManager.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/MediatorManager.java
@@ -24,6 +24,7 @@ import io.smallrye.reactive.messaging.EmitterConfiguration;
 import io.smallrye.reactive.messaging.PublisherDecorator;
 import io.smallrye.reactive.messaging.SubscriberDecorator;
 import io.smallrye.reactive.messaging.annotations.Incomings;
+import io.smallrye.reactive.messaging.annotations.Outgoings;
 import io.smallrye.reactive.messaging.keyed.KeyValueExtractor;
 import io.smallrye.reactive.messaging.providers.AbstractMediator;
 import io.smallrye.reactive.messaging.providers.MediatorFactory;
@@ -183,12 +184,12 @@ public class MediatorManager {
 
     private <T> boolean hasMediatorAnnotations(AnnotatedMethod<? super T> method) {
         return method.isAnnotationPresent(Incomings.class) || method.isAnnotationPresent(Incoming.class)
-                || method.isAnnotationPresent(Outgoing.class);
+                || method.isAnnotationPresent(Outgoing.class) || method.isAnnotationPresent(Outgoings.class);
     }
 
     private boolean hasMediatorAnnotations(Method m) {
         return m.isAnnotationPresent(Incomings.class) || m.isAnnotationPresent(Incoming.class)
-                || m.isAnnotationPresent(Outgoing.class);
+                || m.isAnnotationPresent(Outgoing.class) || m.isAnnotationPresent(Outgoings.class);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ReactiveMessagingExtension.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ReactiveMessagingExtension.java
@@ -24,6 +24,7 @@ import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
 import io.smallrye.reactive.messaging.annotations.EmitterFactoryFor;
 import io.smallrye.reactive.messaging.annotations.Incomings;
+import io.smallrye.reactive.messaging.annotations.Outgoings;
 import io.smallrye.reactive.messaging.providers.DefaultEmitterConfiguration;
 import io.smallrye.reactive.messaging.providers.connectors.WorkerPoolRegistry;
 import io.smallrye.reactive.messaging.providers.i18n.ProviderExceptions;
@@ -44,7 +45,7 @@ public class ReactiveMessagingExtension implements Extension {
         if (annotatedType.getMethods()
                 .stream()
                 .anyMatch(m -> m.isAnnotationPresent(Incomings.class) || m.isAnnotationPresent(Incoming.class)
-                        || m.isAnnotationPresent(Outgoing.class))) {
+                        || m.isAnnotationPresent(Outgoings.class) || m.isAnnotationPresent(Outgoing.class))) {
             mediatorBeans.add(new MediatorBean<>(event.getBean(), event.getAnnotatedBeanClass()));
         }
     }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderExceptions.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderExceptions.java
@@ -287,4 +287,7 @@ public interface ProviderExceptions {
 
     @Message(id = 1003, value = "Unable to find a matching KeyValueExtractor for method %s. Did you expose a bean implementing the KeyValueExtractor interface and implemented the `canExtract` method correctly?")
     DeploymentException noMatchingKeyValueExtractor(String method);
+
+    @Message(id = 1004, value = "Multiple Outgoings count does not match the number of split branches in %s. %d, %d")
+    IllegalStateException outgoingsDoesNotMatchMultiSplitterTarget(String method, int outgoings, int splitTarget);
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
@@ -76,9 +76,9 @@ public class Wiring {
         this.strictMode = strictMode;
 
         for (MediatorConfiguration mediator : mediators) {
-            if (mediator.getOutgoing() != null && !mediator.getIncoming().isEmpty()) {
+            if (!mediator.getOutgoings().isEmpty() && !mediator.getIncoming().isEmpty()) {
                 components.add(new ProcessorMediatorComponent(manager, mediator));
-            } else if (mediator.getOutgoing() != null) {
+            } else if (!mediator.getOutgoings().isEmpty()) {
                 components.add(new PublisherMediatorComponent(manager, mediator));
             } else {
                 components.add(new SubscriberMediatorComponent(manager, mediator));
@@ -191,8 +191,7 @@ public class Wiring {
     private List<Component> getMatchesFor(String incoming, Set<? extends Component> candidates) {
         List<Component> matches = new ArrayList<>();
         for (Component component : candidates) {
-            Optional<String> outgoing = component.outgoing();
-            if (outgoing.isPresent() && outgoing.get().equalsIgnoreCase(incoming)) {
+            if (component.outgoings().stream().anyMatch(s -> s.equalsIgnoreCase(incoming))) {
                 matches.add(component);
             }
         }
@@ -209,6 +208,10 @@ public class Wiring {
 
         default Optional<String> outgoing() {
             return Optional.empty();
+        }
+
+        default List<String> outgoings() {
+            return Collections.emptyList();
         }
 
         default List<String> incomings() {
@@ -240,12 +243,12 @@ public class Wiring {
         int getRequiredNumberOfSubscribers();
 
         default String getOutgoingChannel() {
-            return outgoing().orElseThrow(() -> new IllegalStateException("Outgoing not configured for " + this));
+            return String.join(",", outgoings());
         }
 
         @Override
         default boolean isDownstreamResolved() {
-            return !downstreams().isEmpty();
+            return outgoings().stream().allMatch(o -> downstreams().stream().anyMatch(c -> c.incomings().contains(o)));
         }
 
         @Override
@@ -299,6 +302,11 @@ public class Wiring {
         }
 
         @Override
+        public List<String> outgoings() {
+            return Collections.singletonList(name);
+        }
+
+        @Override
         public Set<Component> downstreams() {
             return downstreams;
         }
@@ -325,7 +333,7 @@ public class Wiring {
 
         @Override
         public void validate() throws WiringException {
-            if (!broadcast && downstreams().size() > 1) {
+            if (!broadcast() && downstreams().size() > 1) {
                 throw new TooManyDownstreamCandidatesException(this);
             }
         }
@@ -463,6 +471,11 @@ public class Wiring {
         }
 
         @Override
+        public List<String> outgoings() {
+            return Collections.singletonList(configuration.name());
+        }
+
+        @Override
         public Set<Component> downstreams() {
             return downstreams;
         }
@@ -543,6 +556,11 @@ public class Wiring {
         }
 
         @Override
+        public List<String> outgoings() {
+            return configuration.getOutgoings();
+        }
+
+        @Override
         public Optional<String> outgoing() {
             return Optional.of(configuration.getOutgoing());
         }
@@ -557,12 +575,19 @@ public class Wiring {
             synchronized (this) {
                 mediator = manager.createMediator(configuration);
             }
-            registry.register(configuration.getOutgoing(), mediator.getStream(), broadcast());
+
+            if (outgoings().size() > 1) {
+                for (String outgoing : configuration.getOutgoings()) {
+                    registry.register(outgoing, mediator.getStream(outgoing), broadcast());
+                }
+            } else {
+                registry.register(getOutgoingChannel(), mediator.getStream(), broadcast());
+            }
         }
 
         @Override
         public boolean broadcast() {
-            return configuration.getBroadcast();
+            return configuration.getBroadcast() || outgoings().size() > 1;
         }
 
         @Override
@@ -667,7 +692,7 @@ public class Wiring {
             // A subscriber can have multiple incomings - all of them must be bound.
             for (String incoming : incomings()) {
                 // For each incoming, check that we have a match
-                if (upstreams().stream().noneMatch(c -> incoming.equals(c.outgoing().orElse(null)))) {
+                if (upstreams().stream().noneMatch(c -> c.outgoings().contains(incoming))) {
                     return false;
                 }
             }
@@ -685,7 +710,7 @@ public class Wiring {
             // Check that for each incoming we have a single upstream or a merge strategy
             for (String incoming : incomings()) {
                 List<Component> components = downstreams().stream()
-                        .filter(c -> incoming.equals(c.outgoing().orElse(null)))
+                        .filter(c -> c.outgoings().contains(incoming))
                         .collect(Collectors.toList());
                 if (components.size() > 1 && !merge()) {
                     throw new TooManyUpstreamCandidatesException(this, incoming, components);
@@ -737,25 +762,34 @@ public class Wiring {
         }
 
         @Override
+        public List<String> outgoings() {
+            return configuration.getOutgoings();
+        }
+
+        @Override
         public Set<Component> downstreams() {
             return downstreams;
         }
 
         @Override
         public boolean broadcast() {
-            return configuration.getBroadcast();
+            return configuration.getBroadcast() || outgoings().size() > 1;
         }
 
         @Override
         public int getRequiredNumberOfSubscribers() {
-            return configuration.getNumberOfSubscriberBeforeConnecting();
+            if (outgoings().size() > 1) {
+                return Math.max(configuration.getNumberOfSubscriberBeforeConnecting(), downstreams().size());
+            } else {
+                return configuration.getNumberOfSubscriberBeforeConnecting();
+            }
         }
 
         private boolean hasAllUpstreams() {
             // A subscriber can have multiple incomings - all of them must be bound.
             for (String incoming : incomings()) {
                 // For each incoming, check that we have a match
-                if (upstreams().stream().noneMatch(c -> incoming.equals(c.outgoing().orElse(null)))) {
+                if (upstreams().stream().noneMatch(c -> c.outgoings().contains(incoming))) {
                     return false;
                 }
             }
@@ -772,7 +806,7 @@ public class Wiring {
             return "ProcessingMethod{" +
                     "method:'" + configuration.methodAsString()
                     + "', incoming:'" + String.join(",", configuration.getIncoming())
-                    + "', outgoing:'" + getOutgoingChannel() + "'}";
+                    + "', outgoing:'" + String.join(",", configuration.getOutgoings()) + "'}";
         }
 
         @Override
@@ -802,8 +836,13 @@ public class Wiring {
             }
 
             mediator.connectToUpstream(aggregates);
-
-            registry.register(getOutgoingChannel(), mediator.getStream(), merge());
+            if (outgoings().size() > 1) {
+                for (String outgoing : configuration.getOutgoings()) {
+                    registry.register(outgoing, mediator.getStream(outgoing), broadcast());
+                }
+            } else {
+                registry.register(getOutgoingChannel(), mediator.getStream(), broadcast());
+            }
         }
 
         @Override
@@ -811,7 +850,7 @@ public class Wiring {
             // Check that for each incoming we have a single upstream or a merge strategy
             for (String incoming : incomings()) {
                 List<Component> components = downstreams().stream()
-                        .filter(c -> incoming.equals(c.outgoing().orElse(null)))
+                        .filter(c -> c.outgoings().contains(incoming))
                         .collect(Collectors.toList());
                 if (components.size() > 1 && !merge()) {
                     throw new TooManyUpstreamCandidatesException(this, incoming, components);

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
@@ -592,7 +592,11 @@ public class Wiring {
 
         @Override
         public int getRequiredNumberOfSubscribers() {
-            return configuration.getNumberOfSubscriberBeforeConnecting();
+            if (outgoings().size() > 1) {
+                return Math.max(configuration.getNumberOfSubscriberBeforeConnecting(), downstreams().size());
+            } else {
+                return configuration.getNumberOfSubscriberBeforeConnecting();
+            }
         }
 
         @Override

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MediatorConfigurationSupportTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/MediatorConfigurationSupportTest.java
@@ -407,30 +407,32 @@ public class MediatorConfigurationSupportTest {
     @Test
     void testDetermineShape() {
         assertThat(new MediatorConfigurationSupport("mymethod", String.class, new Class[] { String.class }, null, null)
-                .determineShape(Collections.singletonList("incoming"), "outgoing")).isEqualTo(Shape.PROCESSOR);
+                .determineShape(Collections.singletonList("incoming"), Collections.singletonList("outgoing")))
+                .isEqualTo(Shape.PROCESSOR);
 
         assertThat(
                 new MediatorConfigurationSupport("mymethod", Multi.class, new Class[] { Publisher.class }, null, null)
-                        .determineShape(Collections.singletonList("incoming"), "outgoing"))
+                        .determineShape(Collections.singletonList("incoming"), Collections.singletonList("outgoing")))
                 .isEqualTo(Shape.STREAM_TRANSFORMER);
 
         assertThat(
                 new MediatorConfigurationSupport("mymethod", PublisherBuilder.class, new Class[] { PublisherBuilder.class },
                         null, null)
-                        .determineShape(Collections.singletonList("incoming"), "outgoing"))
+                        .determineShape(Collections.singletonList("incoming"), Collections.singletonList("outgoing")))
                 .isEqualTo(Shape.STREAM_TRANSFORMER);
 
         assertThat(
                 new MediatorConfigurationSupport("mymethod", PublisherBuilder.class, new Class[] { String.class }, null,
                         null)
-                        .determineShape(Collections.singletonList("incoming"), "outgoing"))
+                        .determineShape(Collections.singletonList("incoming"), Collections.singletonList("outgoing")))
                 .isEqualTo(Shape.PROCESSOR);
 
         assertThat(new MediatorConfigurationSupport("mymethod", String.class, new Class[0], null, null)
-                .determineShape(Collections.emptyList(), "outgoing")).isEqualTo(Shape.PUBLISHER);
+                .determineShape(Collections.emptyList(), Collections.singletonList("outgoing")))
+                .isEqualTo(Shape.PUBLISHER);
 
         assertThat(new MediatorConfigurationSupport("mymethod", Void.class, new Class[] { String.class }, null, null)
-                .determineShape(Collections.singletonList("incoming"), null)).isEqualTo(Shape.SUBSCRIBER);
+                .determineShape(Collections.singletonList("incoming"), Collections.emptyList())).isEqualTo(Shape.SUBSCRIBER);
     }
 
     @Test

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/outgoings/MultiLevelOutgoingsTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/outgoings/MultiLevelOutgoingsTest.java
@@ -91,8 +91,8 @@ public class MultiLevelOutgoingsTest extends WeldTestBaseWithoutTails {
         }
 
         @Incoming("z")
-        @Outgoing("w")
         @Outgoing("v")
+        @Outgoing("w")
         public MultiSplitter<String, FLIPFLOP> process(Multi<String> multi) {
             return multi.split(FLIPFLOP.class, s -> i.incrementAndGet() % 2 == 0 ? FLIPFLOP.W : FLIPFLOP.V);
         }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/outgoings/MultiLevelOutgoingsTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/outgoings/MultiLevelOutgoingsTest.java
@@ -1,0 +1,180 @@
+package io.smallrye.reactive.messaging.outgoings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.split.MultiSplitter;
+import io.smallrye.reactive.messaging.Targeted;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class MultiLevelOutgoingsTest extends WeldTestBaseWithoutTails {
+
+    // source --> -- first processor -- a --> x
+    //                                  b
+    //                                  c --> -- second processor -- --> y
+    //                                                               --> z -- branch processor -- --> w
+    //                                                                                            --> v
+
+    @Test
+    public void test() {
+        addBeanClass(A.class, B.class, X.class, Y.class, W.class, V.class, FirstProcessor.class,
+                SecondProcessor.class, Source.class, SplitBranchProcessor.class);
+        initialize();
+        B b = container.select(B.class).get();
+        X x = container.select(X.class).get();
+        Y y = container.select(Y.class).get();
+        W w = container.select(W.class).get();
+        V v = container.select(V.class).get();
+        await().until(() -> b.list().size() == 6);
+        await().untilAsserted(() -> assertThat(b.list()).containsExactly("A", "B", "C", "D", "E", "F"));
+        await().until(() -> x.list().size() == 6);
+        await().untilAsserted(() -> assertThat(x.list()).containsExactly("_A", "_B", "_C", "_D", "_E", "_F"));
+        await().until(() -> y.list().size() == 3);
+        await().untilAsserted(() -> assertThat(y.list()).containsExactly("B", "D", "F"));
+        await().until(() -> w.list().size() == 1);
+        await().untilAsserted(() -> assertThat(w.list()).containsExactly("C"));
+        await().until(() -> v.list().size() == 2);
+        await().untilAsserted(() -> assertThat(v.list()).containsExactly("A", "E"));
+    }
+
+    @ApplicationScoped
+    public static class Source {
+        @Outgoing("source")
+        public Multi<String> produce() {
+            return Multi.createFrom().items("a", "b", "c", "d", "e", "f");
+        }
+    }
+
+    @ApplicationScoped
+    public static class FirstProcessor {
+        @Incoming("source")
+        @Outgoing("a")
+        @Outgoing("b")
+        @Outgoing("c")
+        public Message<String> process(Message<String> s) {
+            return Message.of(s.getPayload().toUpperCase());
+        }
+    }
+
+    @ApplicationScoped
+    public static class SecondProcessor {
+
+        AtomicInteger i = new AtomicInteger();
+
+        @Incoming("c")
+        @Outgoing("y")
+        @Outgoing("z")
+        public Multi<Targeted> process(Multi<String> multi) {
+            return multi.map(s -> i.incrementAndGet() % 2 == 0 ? Targeted.of("y", s) : Targeted.of("z", s));
+        }
+    }
+
+    public static class SplitBranchProcessor {
+
+        AtomicInteger i = new AtomicInteger();
+
+        public enum FLIPFLOP {
+            W,
+            V
+        }
+
+        @Incoming("z")
+        @Outgoing("w")
+        @Outgoing("v")
+        public MultiSplitter<String, FLIPFLOP> process(Multi<String> multi) {
+            return multi.split(FLIPFLOP.class, s -> i.incrementAndGet() % 2 == 0 ? FLIPFLOP.W : FLIPFLOP.V);
+        }
+    }
+
+    @ApplicationScoped
+    public static class A {
+        @Incoming("a")
+        @Outgoing("x")
+        public String process(String s) {
+            return "_" + s;
+        }
+    }
+
+    @ApplicationScoped
+    public static class B {
+        private List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("b")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class X {
+        private List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("x")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class Y {
+        private List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("y")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class W {
+        private List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("w")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class V {
+        private List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("v")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/outgoings/OutgoingsTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/outgoings/OutgoingsTest.java
@@ -1,0 +1,388 @@
+package io.smallrye.reactive.messaging.outgoings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.DeploymentException;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+import io.smallrye.reactive.messaging.annotations.Merge;
+import io.smallrye.reactive.messaging.annotations.Outgoings;
+import io.smallrye.reactive.messaging.providers.extension.MediatorManager;
+
+public class OutgoingsTest extends WeldTestBaseWithoutTails {
+
+    @AfterEach
+    public void cleanup() {
+        System.clearProperty(MediatorManager.STRICT_MODE_PROPERTY);
+    }
+
+    @Test
+    public void testInvalidOutgoings() {
+        addBeanClass(IncomingOnA.class);
+        addBeanClass(InvalidOutgoings.class);
+
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+
+    }
+
+    @Test
+    public void testEmptyOutgoings() {
+        addBeanClass(IncomingOnA.class);
+        addBeanClass(EmptyOutgoings.class);
+
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testInvalidBeanWithOutgoings() {
+        addBeanClass(IncomingOnA.class);
+        addBeanClass(InvalidBeanWithOutgoings.class);
+
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testOutgoingsWithThreeSources() {
+        addBeanClass(IncomingOnA.class, IncomingOnB.class, IncomingOnC.class);
+        addBeanClass(MultipleOutgoingsProducer.class);
+
+        initialize();
+        IncomingOnA inA = container.select(IncomingOnA.class).get();
+        IncomingOnB inB = container.select(IncomingOnB.class).get();
+        IncomingOnC inC = container.select(IncomingOnC.class).get();
+
+        await().until(() -> inA.list().size() == 6);
+        assertThat(inA.list()).contains("a", "b", "c", "d", "e", "f");
+        await().until(() -> inB.list().size() == 6);
+        assertThat(inB.list()).contains("a", "b", "c", "d", "e", "f");
+        await().until(() -> inC.list().size() == 6);
+        assertThat(inC.list()).contains("a", "b", "c", "d", "e", "f");
+    }
+
+    @Test
+    public void testOutgoings() {
+        addBeanClass(IncomingOnA.class, IncomingOnB.class);
+        addBeanClass(MyBeanUsingOutgoings.class);
+
+        initialize();
+        MyBeanUsingOutgoings bean = container.select(MyBeanUsingOutgoings.class).get();
+        IncomingOnA inA = container.select(IncomingOnA.class).get();
+        IncomingOnB inB = container.select(IncomingOnB.class).get();
+
+        await().until(() -> inA.list().size() == 6);
+        assertThat(inA.list()).contains("a", "b", "c", "d", "e", "f");
+        await().until(() -> inB.list().size() == 6);
+        assertThat(inB.list()).contains("a", "b", "c", "d", "e", "f");
+    }
+
+    @Test
+    public void testOutgoingsWithMissingDownstream() {
+        addBeanClass(IncomingOnC.class);
+        addBeanClass(MultipleOutgoingsProducer.class);
+        initialize();
+    }
+
+    @Test
+    public void testOutgoingsWithMissingDownstreamInStrictMode() {
+        System.setProperty(MediatorManager.STRICT_MODE_PROPERTY, "true");
+        addBeanClass(IncomingOnB.class);
+        addBeanClass(MultipleOutgoingsProducer.class);
+        assertThatThrownBy(this::initialize).isInstanceOf(DeploymentException.class);
+    }
+
+    @Test
+    public void testProcessorUsingMultipleOutgoings() {
+        addBeanClass(MySource.class);
+        addBeanClass(IncomingOnA.class);
+        addBeanClass(ProcessorUsingMultipleOutgoings.class);
+        addBeanClass(IncomingOnB.class);
+
+        initialize();
+        ProcessorUsingMultipleOutgoings bean = container.select(ProcessorUsingMultipleOutgoings.class).get();
+        IncomingOnA inA = container.select(IncomingOnA.class).get();
+        IncomingOnB inB = container.select(IncomingOnB.class).get();
+
+        await().until(() -> bean.list().size() == 6);
+        await().until(() -> inA.list().size() == 6);
+        await().until(() -> inB.list().size() == 6);
+        assertThat(bean.list()).contains("a", "b", "c", "d", "e", "f");
+        assertThat(inA.list()).contains("A", "B", "C", "D", "E", "F");
+        assertThat(inB.list()).contains("A", "B", "C", "D", "E", "F");
+    }
+
+    @Test
+    public void testCombiningOutgoingsAndBroadcastWithAProcessor() {
+        addBeanClass(MySource.class);
+        addBeanClass(IncomingOnA.class);
+        addBeanClass(ProcessorUsingMultipleOutgoingsAndBroadcast.class);
+        addBeanClass(IncomingOnB.class);
+
+        initialize();
+        ProcessorUsingMultipleOutgoingsAndBroadcast bean = container.select(ProcessorUsingMultipleOutgoingsAndBroadcast.class)
+                .get();
+        IncomingOnA inA = container.select(IncomingOnA.class).get();
+        IncomingOnB inB = container.select(IncomingOnB.class).get();
+
+        await().until(() -> bean.list().size() == 6);
+        await().until(() -> inA.list().size() == 6);
+        await().until(() -> inB.list().size() == 6);
+        assertThat(bean.list()).contains("a", "b", "c", "d", "e", "f");
+        assertThat(inA.list()).contains("A", "B", "C", "D", "E", "F");
+        assertThat(inB.list()).contains("A", "B", "C", "D", "E", "F");
+    }
+
+    @Test
+    public void testCombiningOutgoingsAndBroadcastWithASubscriber() {
+        addBeanClass(MySource.class);
+        addBeanClass(MySecondSource.class);
+        addBeanClass(IncomingOnA.class);
+        addBeanClass(MyBeanUsingMultipleIncomingsAndMergeAndMultipleOutgoings.class);
+        addBeanClass(IncomingOnB.class);
+
+        initialize();
+        MyBeanUsingMultipleIncomingsAndMergeAndMultipleOutgoings bean = container
+                .select(MyBeanUsingMultipleIncomingsAndMergeAndMultipleOutgoings.class).get();
+        IncomingOnA inA = container.select(IncomingOnA.class).get();
+        IncomingOnB inB = container.select(IncomingOnB.class).get();
+
+        await().until(() -> bean.list().size() == 8);
+        assertThat(bean.list()).contains("a", "b", "c", "d", "e", "f", "g", "h");
+        assertThat(inA.list()).contains("A", "B", "C", "D", "E", "F", "G", "H");
+        assertThat(inB.list()).contains("A", "B", "C", "D", "E", "F", "G", "H");
+    }
+
+    @ApplicationScoped
+    public static class IncomingOnA {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("a")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class IncomingOnB {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("b")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class IncomingOnC {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("c")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class SecondIncomingOnB {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("b")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MultipleOutgoingsProducer {
+
+        @Outgoing("a")
+        @Outgoing("b")
+        @Outgoing("c")
+        @Broadcast
+        public Publisher<String> produce() {
+            return Flowable.just("a", "b", "c", "d", "e", "f");
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyBeanUsingMultipleIncomings {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("a")
+        @Incoming("b")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyBeanUsingOutgoings {
+
+        @Outgoings({
+                @Outgoing("a"),
+                @Outgoing("b")
+        })
+        @Broadcast
+        public Publisher<String> produce() {
+            return Flowable.just("a", "b", "c", "d", "e", "f");
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyBeanUsingMultipleIncomingsAndMergeAndMultipleOutgoings {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Merge
+        @Incoming("in")
+        @Incoming("in2")
+        @Outgoing("a")
+        @Outgoing("b")
+        public String consume(String s) {
+            list.add(s);
+            return s.toUpperCase();
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class ProcessorUsingMultipleOutgoings {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("in")
+        @Outgoing("a")
+        @Outgoing("b")
+        public String consume(String s) {
+            list.add(s);
+            return s.toUpperCase();
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProcessorUsingMultipleOutgoingsAndBroadcast {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("in")
+        @Outgoing("a")
+        @Outgoing("b")
+        @Broadcast
+        public String consume(String s) {
+            list.add(s);
+            return s.toUpperCase();
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MySource {
+
+        @Outgoing("in")
+        public Multi<String> produce() {
+            return Multi.createFrom().items("a", "b", "c", "d", "e", "f");
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MySecondSource {
+
+        @Outgoing("in2")
+        public Multi<String> produce() {
+            return Multi.createFrom().items("g", "h");
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class InvalidBeanWithOutgoings {
+
+        @Outgoing("a")
+        @Outgoing("")
+        public Flow.Publisher<String> produce() {
+            return Multi.createFrom().items("a", "b", "c");
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class InvalidOutgoings {
+
+        @Outgoings({
+                @Outgoing("a"),
+                @Outgoing("")
+        })
+        public Flow.Publisher<String> produce() {
+            return Multi.createFrom().items("a", "b", "c");
+        }
+    }
+
+    @ApplicationScoped
+    public static class EmptyOutgoings {
+
+        @Outgoings({})
+        public Flow.Publisher<String> produce() {
+            return Multi.createFrom().items("a", "b", "c");
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/outgoings/TargetedMessagesTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/outgoings/TargetedMessagesTest.java
@@ -1,0 +1,177 @@
+package io.smallrye.reactive.messaging.outgoings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.Targeted;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.smallrye.reactive.messaging.providers.extension.MediatorManager;
+
+public class TargetedMessagesTest extends WeldTestBaseWithoutTails {
+
+    @AfterEach
+    public void cleanup() {
+        System.clearProperty(MediatorManager.STRICT_MODE_PROPERTY);
+    }
+
+    @Test
+    public void testOutgoingsWithThreeSources() {
+        addBeanClass(IncomingOnA.class, IncomingOnB.class, IncomingOnC.class);
+        addBeanClass(MultipleOutgoingsProducer.class);
+
+        initialize();
+        IncomingOnA inA = container.select(IncomingOnA.class).get();
+        IncomingOnB inB = container.select(IncomingOnB.class).get();
+        IncomingOnC inC = container.select(IncomingOnC.class).get();
+
+        await().until(() -> inA.list().size() == 3);
+        assertThat(inA.list()).contains("a-b", "a-c", "a-d");
+        await().until(() -> inB.list().size() == 3);
+        assertThat(inB.list()).contains("b-a", "b-c", "b-d");
+        await().until(() -> inC.list().size() == 3);
+        assertThat(inC.list()).contains("c-a", "c-b", "c-d");
+    }
+
+    @Test
+    public void testCombiningOutgoingsAndBroadcastWithAProcessor() {
+        addBeanClass(MySource.class);
+        addBeanClass(IncomingOnA.class);
+        addBeanClass(ProcessorUsingMultipleOutgoingsAndBroadcast.class);
+        addBeanClass(IncomingOnB.class);
+
+        initialize();
+        ProcessorUsingMultipleOutgoingsAndBroadcast bean = container
+                .select(ProcessorUsingMultipleOutgoingsAndBroadcast.class).get();
+        MySource source = container.select(MySource.class).get();
+        IncomingOnA inA = container.select(IncomingOnA.class).get();
+        IncomingOnB inB = container.select(IncomingOnB.class).get();
+
+        await().until(() -> bean.list().size() == 6);
+        await().until(() -> inA.list().size() == 6);
+        await().until(() -> inB.list().size() == 6);
+        assertThat(bean.list()).contains("a", "b", "c", "d", "e", "f");
+        assertThat(inA.list()).contains("a-A", "a-B", "a-C", "a-D", "a-E", "a-F");
+        assertThat(inB.list()).contains("b-A", "b-B", "b-C", "b-D", "b-E", "b-F");
+        assertThat(source.acked()).contains("a", "b", "c", "d", "e", "f");
+    }
+
+    @ApplicationScoped
+    public static class IncomingOnA {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("a")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class IncomingOnB {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("b")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class IncomingOnC {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("c")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MultipleOutgoingsProducer {
+
+        @Outgoing("a")
+        @Outgoing("b")
+        @Outgoing("c")
+        public Publisher<Targeted> produce() {
+            return Flowable.just(
+                    Targeted.of("b", "b-a", "c", "c-a"),
+                    Targeted.of("a", "a-b", "c", "c-b"),
+                    Targeted.of("a", "a-c", "b", "b-c"),
+                    Targeted.of("a", "a-d", "b", "b-d", "c", "c-d"));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class ProcessorUsingMultipleOutgoingsAndBroadcast {
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("in")
+        @Outgoing("a")
+        @Outgoing("b")
+        public Targeted consume(String s) {
+            list.add(s);
+            return Targeted.of("a", "a-" + s.toUpperCase(),
+                    "b", "b-" + s.toUpperCase());
+        }
+
+        public List<String> list() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MySource {
+
+        List<String> acked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("in")
+        public Multi<Message<String>> produce() {
+            return Multi.createFrom().items(
+                    Message.of("a", () -> CompletableFuture.completedFuture(null).thenAccept(x -> acked.add("a"))),
+                    Message.of("b", () -> CompletableFuture.completedFuture(null).thenAccept(x -> acked.add("b"))),
+                    Message.of("c", () -> CompletableFuture.completedFuture(null).thenAccept(x -> acked.add("c"))),
+                    Message.of("d", () -> CompletableFuture.completedFuture(null).thenAccept(x -> acked.add("d"))),
+                    Message.of("e", () -> CompletableFuture.completedFuture(null).thenAccept(x -> acked.add("e"))),
+                    Message.of("f", () -> CompletableFuture.completedFuture(null).thenAccept(x -> acked.add("f"))));
+        }
+
+        public List<String> acked() {
+            return acked;
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/wiring/WiringMergeTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/wiring/WiringMergeTest.java
@@ -31,7 +31,8 @@ public class WiringMergeTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("processWithMerge"), bean);
-        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")),
+                Collections.singletonList(OutgoingLiteral.of("b")), null);
 
         EmitterConfiguration ec = new DefaultEmitterConfiguration("a", EMITTER, null, null);
         ChannelConfiguration cc1 = new ChannelConfiguration("b");
@@ -54,7 +55,8 @@ public class WiringMergeTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
-        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")),
+                Collections.singletonList(OutgoingLiteral.of("b")), null);
 
         EmitterConfiguration ec = new DefaultEmitterConfiguration("a", EMITTER, null, null);
         ChannelConfiguration cc1 = new ChannelConfiguration("b");
@@ -76,7 +78,7 @@ public class WiringMergeTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
-        subscriber.compute(Collections.singletonList(IncomingLiteral.of("a")), null, null);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("a")), Collections.emptyList(), null);
 
         EmitterConfiguration ec = new DefaultEmitterConfiguration("a", EMITTER, null, null);
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/wiring/WiringTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/wiring/WiringTest.java
@@ -46,11 +46,12 @@ class WiringTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
-        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), Collections.emptyList(), null);
         DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
-        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        producer.compute(Collections.emptyList(), Collections.singletonList(OutgoingLiteral.of("a")), null);
         DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
-        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")),
+                Collections.singletonList(OutgoingLiteral.of("b")), null);
 
         Wiring wiring = new Wiring();
         wiring.prepare(false, registry, Collections.emptyList(), Collections.emptyList(),
@@ -77,11 +78,12 @@ class WiringTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
-        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), Collections.emptyList(), null);
         DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
-        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        producer.compute(Collections.emptyList(), Collections.singletonList(OutgoingLiteral.of("a")), null);
         DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
-        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")),
+                Collections.singletonList(OutgoingLiteral.of("b")), null);
 
         Wiring wiring = new Wiring();
         wiring.prepare(true, registry, Collections.emptyList(), Collections.emptyList(),
@@ -107,9 +109,10 @@ class WiringTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
-        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), Collections.emptyList(), null);
         DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
-        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")),
+                Collections.singletonList(OutgoingLiteral.of("b")), null);
 
         Wiring wiring = new Wiring();
         wiring.prepare(false, registry, Collections.emptyList(), Collections.emptyList(),
@@ -135,9 +138,9 @@ class WiringTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
-        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), Collections.emptyList(), null);
         DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
-        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        producer.compute(Collections.emptyList(), Collections.singletonList(OutgoingLiteral.of("a")), null);
 
         Wiring wiring = new Wiring();
         wiring.prepare(false, registry, Collections.emptyList(), Collections.emptyList(),
@@ -163,9 +166,10 @@ class WiringTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration producer = new DefaultMediatorConfiguration(getMethod("producer"), bean);
-        producer.compute(Collections.emptyList(), OutgoingLiteral.of("a"), null);
+        producer.compute(Collections.emptyList(), Collections.singletonList(OutgoingLiteral.of("a")), null);
         DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
-        processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
+        processor.compute(Collections.singletonList(IncomingLiteral.of("a")),
+                Collections.singletonList(OutgoingLiteral.of("b")), null);
 
         Wiring wiring = new Wiring();
         wiring.prepare(false, registry, Collections.emptyList(), Collections.emptyList(),
@@ -325,7 +329,7 @@ class WiringTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
-        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), Collections.emptyList(), null);
         DefaultMediatorConfiguration processor = new DefaultMediatorConfiguration(getMethod("process"), bean);
         processor.compute(Collections.singletonList(IncomingLiteral.of("a")), OutgoingLiteral.of("b"), null);
 
@@ -382,7 +386,7 @@ class WiringTest {
         when(bean.getBeanClass()).thenReturn(WiringTest.class);
 
         DefaultMediatorConfiguration subscriber = new DefaultMediatorConfiguration(getMethod("consume"), bean);
-        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), null, null);
+        subscriber.compute(Collections.singletonList(IncomingLiteral.of("b")), Collections.emptyList(), null);
 
         Wiring wiring = new Wiring();
         wiring.prepare(false,

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/split/MultiSplitterTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/split/MultiSplitterTest.java
@@ -1,0 +1,190 @@
+package io.smallrye.reactive.messaging.split;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.split.MultiSplitter;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+
+public class MultiSplitterTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    void testSplitOfPayloads() {
+        addBeanClass(Sink.class, PayloadSource.class, SplitterMulti.class);
+
+        // Failures are captured during the initialization because these tests are not async (the sources are immediate)
+
+        try {
+            initialize();
+        } catch (Exception e) {
+            Assertions.fail("Initialization not expected to fail", e);
+            return;
+        }
+
+        Sink sink = get(Sink.class);
+        await().until(() -> sink.listSink1().size() == 2
+                && sink.listSink2().size() == 2
+                && sink.listSink3().size() == 2);
+        assertThat(sink.listSink1()).contains("ABC", "DEF");
+        assertThat(sink.listSink2()).contains("abc", "def");
+    }
+
+    @Test
+    void testSplitOfMessages() {
+        addBeanClass(Sink.class, MessageSource.class, SplitterMultiOfMessages.class);
+
+        // Failures are captured during the initialization because these tests are not async (the sources are immediate)
+
+        try {
+            initialize();
+        } catch (Exception e) {
+            Assertions.fail("Initialization not expected to fail", e);
+            return;
+        }
+
+        Sink sink = get(Sink.class);
+        await().until(() -> sink.listSink1().size() == 4);
+        assertThat(sink.listSink1()).containsExactly("1", "2", "3", "4");
+        assertThat(sink.listSink2()).containsExactly("1", "2");
+        assertThat(sink.listSink3()).containsExactly("1", "2");
+    }
+
+    @ApplicationScoped
+    public static class PayloadSource {
+        @Outgoing("in")
+        Multi<String> source() {
+            return Multi.createFrom().items(
+                    "abc", "ABC", "AbC", "DEF", "DeF", "def");
+        }
+    }
+
+    public static class Key {
+        public final String key;
+
+        public Key(String key) {
+            this.key = key;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MessageSource {
+        @Outgoing("in")
+        Multi<Message<String>> source() {
+            return Multi.createFrom().items(
+                    Message.of("1").addMetadata(new Key("a")),
+                    Message.of("1").addMetadata(new Key("b")),
+                    Message.of("2").addMetadata(new Key("b")),
+                    Message.of("2").addMetadata(new Key("a")),
+                    Message.of("3").addMetadata(new Key("a")),
+                    Message.of("1").addMetadata(new Key("c")),
+                    Message.of("2").addMetadata(new Key("c")),
+                    Message.of("4").addMetadata(new Key("a")));
+        }
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+
+        private final List<String> listSink1 = new CopyOnWriteArrayList<>();
+        private final List<String> listSink2 = new CopyOnWriteArrayList<>();
+        private final List<String> listSink3 = new CopyOnWriteArrayList<>();
+
+        @Incoming("sink1")
+        void all_caps(String s) {
+            System.out.println("sink1 " + s);
+            listSink1.add(s);
+        }
+
+        @Incoming("sink2")
+        void all_low(String s) {
+            System.out.println("sink2 " + s);
+            listSink2.add(s);
+        }
+
+        @Incoming("sink3")
+        void mixed(String s) {
+            System.out.println("sink3 " + s);
+            listSink3.add(s);
+        }
+
+        public List<String> listSink1() {
+            return listSink1;
+        }
+
+        public List<String> listSink2() {
+            return listSink2;
+        }
+
+        public List<String> listSink3() {
+            return listSink3;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class SplitterMulti {
+
+        enum Caps {
+            ALL_CAPS,
+            ALL_LOW,
+            MIXED
+        }
+
+        @Incoming("in")
+        @Outgoing("sink1")
+        @Outgoing("sink2")
+        @Outgoing("sink3")
+        public MultiSplitter<String, Caps> reshape(Multi<String> in) {
+            return in.split(Caps.class, s -> {
+                if (Objects.equals(s, s.toLowerCase())) {
+                    return Caps.ALL_LOW;
+                } else if (Objects.equals(s, s.toUpperCase())) {
+                    return Caps.ALL_CAPS;
+                } else {
+                    return Caps.MIXED;
+                }
+            });
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class SplitterMultiOfMessages {
+
+        enum MetadataKey {
+            A,
+            B,
+            C;
+
+            static MetadataKey fromKey(String key) {
+                return MetadataKey.valueOf(key.toUpperCase());
+            }
+        }
+
+        @Incoming("in")
+        @Outgoing("sink1")
+        @Outgoing("sink2")
+        @Outgoing("sink3")
+        public MultiSplitter<Message<String>, MetadataKey> reshape(Multi<Message<String>> in) {
+            return in.split(MetadataKey.class, s -> {
+                return MetadataKey.fromKey(s.getMetadata(Key.class).map(k -> k.key).orElse(null));
+            });
+        }
+
+    }
+
+}


### PR DESCRIPTION
Added support repeatable `@Outgoing`
- By default, it considers the method as a broadcast to all downstream channels.
- `Targeted` and `TargetedMessages` are introduced as containers to selectively dispatch messages to multiple outgoing channels. 
- On the stream transformer case, if `SplitterMulti` is returned from the method it'll wire split branches to outgoing channels by the order of declaration and order of split enum ordinals. This depends on https://github.com/smallrye/smallrye-mutiny/issues/1278 released in [Mutiny 2.4.0](https://github.com/smallrye/smallrye-mutiny/milestone/64)
