### PR TITLE
RabbitMQ requeue with additional nack metadata

### DIFF
--- a/documentation/src/main/docs/rabbitmq/receiving-messages-from-rabbitmq.md
+++ b/documentation/src/main/docs/rabbitmq/receiving-messages-from-rabbitmq.md
@@ -173,12 +173,31 @@ controlled by the `failure-strategy` channel setting:
 -   `reject` - this strategy marks the RabbitMQ message as rejected
     (default). The processing continues with the next message.
 
+-   `requeue` - this strategy marks the RabbitMQ message as rejected
+    with requeue flag to true. The processing continues with the next message,
+    but the requeued message will be redelivered to the consumer.
+
+When using `dead-letter-queue`, it is also possible to change some
+metadata of the record that is sent to the dead letter topic. To do
+that, use the `Message.nack(Throwable, Metadata)` method:
+
+The RabbitMQ reject `requeue` flag can be controlled on different failure strategies
+using the {{ javadoc('io.smallrye.reactive.messaging.rabbitmq.RabbitMQRejectMetadata') }}.
+To do that, use the `Message.nack(Throwable, Metadata)` method by including the
+`RabbitMQRejectMetadata` metadata with `requeue` to `true`.
+
+``` java
+{{ insert('rabbitmq/inbound/RabbitMQRejectMetadataExample.java', 'code') }}
+```
+
 !!!warning "Experimental"
     `RabbitMQFailureHandler` is experimental and APIs are subject to change in the future
 
-In addition, you can also provide your own failure strategy. To provide a failure strategy implement a bean exposing the interface
-{{ javadoc('io.smallrye.reactive.messaging.rabbitmq.fault.RabbitMQFailureHandler') }}, qualified with a `@Identifier`. Set the name of the bean
-as the `failure-strategy` channel setting.
+In addition, you can also provide your own failure strategy.
+To provide a failure strategy implement a bean exposing the interface
+{{ javadoc('io.smallrye.reactive.messaging.rabbitmq.fault.RabbitMQFailureHandler') }},
+qualified with a `@Identifier`.
+Set the name of the bean as the `failure-strategy` channel setting.
 
 
 ## Configuration Reference

--- a/documentation/src/main/java/rabbitmq/inbound/RabbitMQRejectMetadataExample.java
+++ b/documentation/src/main/java/rabbitmq/inbound/RabbitMQRejectMetadataExample.java
@@ -1,0 +1,24 @@
+package rabbitmq.inbound;
+
+import java.util.concurrent.CompletionStage;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
+import io.smallrye.reactive.messaging.rabbitmq.RabbitMQRejectMetadata;
+
+@ApplicationScoped
+public class RabbitMQRejectMetadataExample {
+
+    // <code>
+    @Incoming("in")
+    public CompletionStage<Void> consume(Message<String> message) {
+        return message.nack(new Exception("Failed!"), Metadata.of(
+                new RabbitMQRejectMetadata(true)));
+    }
+    // </code>
+
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ConnectionHolder.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ConnectionHolder.java
@@ -91,8 +91,8 @@ public class ConnectionHolder {
         return client.basicAck(deliveryTag, false);
     }
 
-    public Function<Throwable, CompletionStage<Void>> getNack(final long deliveryTag, final boolean requeue) {
-        return t -> client.basicNack(deliveryTag, false, requeue).subscribeAsCompletionStage();
+    public Function<Throwable, Uni<Void>> getNack(final long deliveryTag, final boolean requeue) {
+        return t -> client.basicNack(deliveryTag, false, requeue);
     }
 
     public Vertx getVertx() {

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessage.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessage.java
@@ -44,7 +44,7 @@ public class IncomingRabbitMQMessage<T> implements ContextAwareMessage<T>, Metad
         }
 
         @Override
-        public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Context context, Throwable reason) {
+        public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Metadata metadata, Context context, Throwable reason) {
             return CompletableFuture.completedFuture(null);
         }
     }
@@ -112,7 +112,7 @@ public class IncomingRabbitMQMessage<T> implements ContextAwareMessage<T>, Metad
             // We must switch to the context having created the message.
             // This context is passed when this instance of message is created.
             // It's more a Vert.x RabbitMQ client issue which should ensure calling `not accepted` on the right context.
-            return onNack.handle(this, context, reason);
+            return onNack.handle(this, metadata, context, reason);
         } finally {
             // Ensure ack/nack are only called once
             onAck = AlreadyAcknowledgedHandler.INSTANCE;
@@ -128,13 +128,22 @@ public class IncomingRabbitMQMessage<T> implements ContextAwareMessage<T>, Metad
     }
 
     /**
-     * Rejects the message by nack'ing with requeue=false; this will either discard the message for good or
-     * (if a DLQ has been set up) send it to the DLQ.
+     * Rejects the message by nack'ing it.
+     * <p>
+     * This will either discard the message for good, requeue (if {@link RabbitMQRejectMetadata#isRequeue()} is set)
+     * or (if a DLQ has been set up) send it to the DLQ.
+     * <p>
+     * Please note that requeue is potentially dangerous as it can lead to
+     * very high load if all consumers reject and requeue a message repeatedly.
      *
      * @param reason the cause of the rejection, which must not be null
+     * @param metadata additional nack metadata, may be {@code null}
      */
-    public void rejectMessage(Throwable reason) {
-        holder.getNack(this.deliveryTag, false).apply(reason);
+    public void rejectMessage(Throwable reason, Metadata metadata) {
+        Optional<RabbitMQRejectMetadata> rejectMetadata =
+                Optional.ofNullable(metadata).flatMap(md -> md.get(RabbitMQRejectMetadata.class));
+        boolean requeue = rejectMetadata.map(RabbitMQRejectMetadata::isRequeue).orElse(false);
+        holder.getNack(this.deliveryTag, requeue).apply(reason);
     }
 
     @Override

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -128,7 +128,7 @@ import io.vertx.rabbitmq.RabbitMQPublisherOptions;
 @ConnectorAttribute(name = "dead-letter-dlx-routing-key", direction = INCOMING, description = "If specified, a dead letter routing key to assign to the DLQ. Relevant only if auto-bind-dlq is true", type = "string")
 
 // Message consumer
-@ConnectorAttribute(name = "failure-strategy", direction = INCOMING, description = "The failure strategy to apply when a RabbitMQ message is nacked. Accepted values are `fail`, `accept`, `reject` (default) or name of a bean", type = "string", defaultValue = "reject")
+@ConnectorAttribute(name = "failure-strategy", direction = INCOMING, description = "The failure strategy to apply when a RabbitMQ message is nacked. Accepted values are `fail`, `accept`, `reject` (default), `requeue` or name of a bean", type = "string", defaultValue = "reject")
 @ConnectorAttribute(name = "broadcast", direction = INCOMING, description = "Whether the received RabbitMQ messages must be dispatched to multiple _subscribers_", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "auto-acknowledgement", direction = INCOMING, description = "Whether the received RabbitMQ messages must be acknowledged when received; if true then delivery constitutes acknowledgement", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "keep-most-recent", direction = INCOMING, description = "Whether to discard old messages instead of recent ones", type = "boolean", defaultValue = "false")

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQRejectMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQRejectMetadata.java
@@ -1,0 +1,32 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
+/**
+ * Additional nack metadata that specifies flags for the 'basic.reject' operation.
+ *
+ * @see {@link IncomingRabbitMQMessage#nack(Throwable, Metadata)}
+ */
+public class RabbitMQRejectMetadata {
+
+    private final boolean requeue;
+
+    /**
+     * Constructor.
+     *
+     * @param requeue requeue the message
+     */
+    public RabbitMQRejectMetadata(boolean requeue) {
+        this.requeue = requeue;
+    }
+
+    /**
+     * If requeue is true, the server will attempt to requeue the message.
+     * If requeue is false or the requeue attempt fails the messages are discarded or dead-lettered.
+     *
+     * @return requeue the message
+     */
+    public boolean isRequeue() {
+        return requeue;
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQAccept.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQAccept.java
@@ -6,13 +6,14 @@ import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.rabbitmq.ConnectionHolder;
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorIncomingConfiguration;
 import io.vertx.mutiny.core.Context;
-import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 /**
  * A {@link RabbitMQFailureHandler} that in effect treats the nack as an ack.
@@ -40,7 +41,8 @@ public class RabbitMQAccept implements RabbitMQFailureHandler {
     }
 
     @Override
-    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Metadata metadata, Context context, Throwable reason) {
+    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Metadata metadata, Context context,
+            Throwable reason) {
         // We mark the message as rejected and fail.
         log.nackedAcceptMessage(channel);
         log.fullIgnoredFailure(reason);

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQAccept.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQAccept.java
@@ -12,6 +12,7 @@ import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorIncomingConfiguration;
 import io.vertx.mutiny.core.Context;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 /**
  * A {@link RabbitMQFailureHandler} that in effect treats the nack as an ack.
@@ -39,7 +40,7 @@ public class RabbitMQAccept implements RabbitMQFailureHandler {
     }
 
     @Override
-    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Context context, Throwable reason) {
+    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Metadata metadata, Context context, Throwable reason) {
         // We mark the message as rejected and fail.
         log.nackedAcceptMessage(channel);
         log.fullIgnoredFailure(reason);

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailStop.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailStop.java
@@ -4,14 +4,12 @@ import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 
 import java.util.concurrent.CompletionStage;
 
+import io.smallrye.reactive.messaging.rabbitmq.*;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.smallrye.common.annotation.Identifier;
-import io.smallrye.reactive.messaging.rabbitmq.ConnectionHolder;
-import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
-import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
-import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorIncomingConfiguration;
 import io.vertx.mutiny.core.Context;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 /**
  * A {@link RabbitMQFailureHandler} that rejects the message and reports a failure.
@@ -41,10 +39,10 @@ public class RabbitMQFailStop implements RabbitMQFailureHandler {
     }
 
     @Override
-    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Context context, Throwable reason) {
+    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Metadata metadata, Context context, Throwable reason) {
         // We mark the message as rejected and fail.
         log.nackedFailMessage(channel);
         connector.reportIncomingFailure(channel, reason);
-        return ConnectionHolder.runOnContextAndReportFailure(context, reason, msg, (m) -> m.rejectMessage(reason));
+        return ConnectionHolder.runOnContextAndReportFailure(context, reason, msg, (m) -> m.rejectMessage(reason, metadata));
     }
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailureHandler.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailureHandler.java
@@ -7,6 +7,7 @@ import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorIncomingConfiguration;
 import io.vertx.mutiny.core.Context;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 /**
  * Implemented to provide message failure strategies.
@@ -37,11 +38,12 @@ public interface RabbitMQFailureHandler {
      * Handle message failure.
      *
      * @param message the failed message
+     * @param metadata additional nack metadata, may be {@code null}
      * @param context the {@link Context} in which the handling should be done
      * @param reason the reason for the failure
      * @param <V> message body type
      * @return a {@link CompletionStage}
      */
-    <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Context context, Throwable reason);
+    <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Metadata metadata, Context context, Throwable reason);
 
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailureHandler.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQFailureHandler.java
@@ -2,12 +2,13 @@ package io.smallrye.reactive.messaging.rabbitmq.fault;
 
 import java.util.concurrent.CompletionStage;
 
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
 import io.smallrye.common.annotation.Experimental;
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorIncomingConfiguration;
 import io.vertx.mutiny.core.Context;
-import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 /**
  * Implemented to provide message failure strategies.
@@ -21,8 +22,8 @@ public interface RabbitMQFailureHandler {
     interface Strategy {
         String FAIL = "fail";
         String ACCEPT = "accept";
-        String RELEASE = "release";
         String REJECT = "reject";
+        String REQUEUE = "requeue";
     }
 
     /**

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQReject.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQReject.java
@@ -2,14 +2,16 @@ package io.smallrye.reactive.messaging.rabbitmq.fault;
 
 import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
-import io.smallrye.reactive.messaging.rabbitmq.*;
 import jakarta.enterprise.context.ApplicationScoped;
 
-import io.smallrye.common.annotation.Identifier;
-import io.vertx.mutiny.core.Context;
 import org.eclipse.microprofile.reactive.messaging.Metadata;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.reactive.messaging.rabbitmq.*;
+import io.vertx.mutiny.core.Context;
 
 public class RabbitMQReject implements RabbitMQFailureHandler {
     private final String channel;
@@ -34,10 +36,14 @@ public class RabbitMQReject implements RabbitMQFailureHandler {
     }
 
     @Override
-    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Metadata metadata, Context context, Throwable reason) {
+    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Metadata metadata, Context context,
+            Throwable reason) {
         // We mark the message as rejected and fail.
         log.nackedIgnoreMessage(channel);
         log.fullIgnoredFailure(reason);
-        return ConnectionHolder.runOnContext(context, msg, m -> m.rejectMessage(reason, metadata));
+        boolean requeue = Optional.ofNullable(metadata)
+                .flatMap(md -> md.get(RabbitMQRejectMetadata.class))
+                .map(RabbitMQRejectMetadata::isRequeue).orElse(false);
+        return ConnectionHolder.runOnContext(context, msg, m -> m.rejectMessage(reason, requeue));
     }
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQReject.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQReject.java
@@ -4,14 +4,12 @@ import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 
 import java.util.concurrent.CompletionStage;
 
+import io.smallrye.reactive.messaging.rabbitmq.*;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import io.smallrye.common.annotation.Identifier;
-import io.smallrye.reactive.messaging.rabbitmq.ConnectionHolder;
-import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
-import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
-import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorIncomingConfiguration;
 import io.vertx.mutiny.core.Context;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 public class RabbitMQReject implements RabbitMQFailureHandler {
     private final String channel;
@@ -36,10 +34,10 @@ public class RabbitMQReject implements RabbitMQFailureHandler {
     }
 
     @Override
-    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Context context, Throwable reason) {
+    public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Metadata metadata, Context context, Throwable reason) {
         // We mark the message as rejected and fail.
         log.nackedIgnoreMessage(channel);
         log.fullIgnoredFailure(reason);
-        return ConnectionHolder.runOnContext(context, msg, m -> m.rejectMessage(reason));
+        return ConnectionHolder.runOnContext(context, msg, m -> m.rejectMessage(reason, metadata));
     }
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQRequeue.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/fault/RabbitMQRequeue.java
@@ -10,23 +10,23 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 import io.smallrye.common.annotation.Identifier;
-import io.smallrye.reactive.messaging.rabbitmq.*;
+import io.smallrye.reactive.messaging.rabbitmq.ConnectionHolder;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
+import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
+import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorIncomingConfiguration;
+import io.smallrye.reactive.messaging.rabbitmq.RabbitMQRejectMetadata;
 import io.vertx.mutiny.core.Context;
 
-/**
- * A {@link RabbitMQFailureHandler} that rejects the message and reports a failure.
- */
-public class RabbitMQFailStop implements RabbitMQFailureHandler {
+public class RabbitMQRequeue implements RabbitMQFailureHandler {
     private final String channel;
-    private final RabbitMQConnector connector;
 
     @ApplicationScoped
-    @Identifier(Strategy.FAIL)
+    @Identifier(Strategy.REQUEUE)
     public static class Factory implements RabbitMQFailureHandler.Factory {
 
         @Override
         public RabbitMQFailureHandler create(RabbitMQConnectorIncomingConfiguration config, RabbitMQConnector connector) {
-            return new RabbitMQFailStop(connector, config.getChannel());
+            return new RabbitMQRequeue(config.getChannel());
         }
     }
 
@@ -35,20 +35,19 @@ public class RabbitMQFailStop implements RabbitMQFailureHandler {
      *
      * @param channel the channel
      */
-    public RabbitMQFailStop(RabbitMQConnector connector, String channel) {
-        this.connector = connector;
+    public RabbitMQRequeue(String channel) {
         this.channel = channel;
     }
 
     @Override
     public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> msg, Metadata metadata, Context context,
             Throwable reason) {
-        // We mark the message as rejected and fail.
-        log.nackedFailMessage(channel);
-        connector.reportIncomingFailure(channel, reason);
+        // We mark the message as requeued and fail.
+        log.nackedIgnoreMessage(channel);
+        log.fullIgnoredFailure(reason);
         boolean requeue = Optional.ofNullable(metadata)
                 .flatMap(md -> md.get(RabbitMQRejectMetadata.class))
-                .map(RabbitMQRejectMetadata::isRequeue).orElse(false);
-        return ConnectionHolder.runOnContextAndReportFailure(context, reason, msg, (m) -> m.rejectMessage(reason, requeue));
+                .map(RabbitMQRejectMetadata::isRequeue).orElse(true);
+        return ConnectionHolder.runOnContext(context, msg, m -> m.rejectMessage(reason, requeue));
     }
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessageTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessageTest.java
@@ -33,7 +33,8 @@ public class IncomingRabbitMQMessageTest {
 
     RabbitMQFailureHandler doNothingNack = new RabbitMQFailureHandler() {
         @Override
-        public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Metadata metadata, Context context, Throwable reason) {
+        public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Metadata metadata, Context context,
+                Throwable reason) {
             return CompletableFuture.completedFuture(null);
         }
     };

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessageTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessageTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
 import org.junit.jupiter.api.Test;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
@@ -32,7 +33,7 @@ public class IncomingRabbitMQMessageTest {
 
     RabbitMQFailureHandler doNothingNack = new RabbitMQFailureHandler() {
         @Override
-        public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Context context, Throwable reason) {
+        public <V> CompletionStage<Void> handle(IncomingRabbitMQMessage<V> message, Metadata metadata, Context context, Throwable reason) {
             return CompletableFuture.completedFuture(null);
         }
     };

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import io.smallrye.reactive.messaging.rabbitmq.fault.RabbitMQFailureHandler;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
 import org.jboss.weld.environment.se.Weld;
@@ -620,4 +621,65 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
         assertThat(bean.getTypeCasts()).isEqualTo(0);
         assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
+
+    /**
+     * Verifies that messages can be requeued by RabbitMQ.
+     */
+    @Test
+    void testNackWithRejectAndRequeue() {
+        final String exchangeName = "exchg6";
+        final String queueName = "q6";
+        final String dlxName = "dlx6";
+        final String dlqName = "dlq6";
+        final String routingKey = "xyzzy";
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.data.exchange.name", exchangeName)
+                .put("mp.messaging.incoming.data.exchange.durable", false)
+                .put("mp.messaging.incoming.data.queue.name", queueName)
+                .put("mp.messaging.incoming.data.queue.durable", false)
+                .put("mp.messaging.incoming.data.queue.routing-keys", routingKey)
+                .put("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data.host", host)
+                .put("mp.messaging.incoming.data.port", port)
+                .put("mp.messaging.incoming.data.tracing-enabled", false)
+                .put("mp.messaging.incoming.data.failure-strategy", RabbitMQFailureHandler.Strategy.REJECT)
+                .put("mp.messaging.incoming.data.auto-bind-dlq", true)
+                .put("mp.messaging.incoming.data.dead-letter-exchange", dlxName)
+                .put("mp.messaging.incoming.data.dead-letter-queue-name", dlqName)
+                .put("mp.messaging.incoming.data.dlx.declare", true)
+                .put("mp.messaging.incoming.data-dlq.exchange.name", dlxName)
+                .put("mp.messaging.incoming.data-dlq.exchange.type", "direct")
+                .put("mp.messaging.incoming.data-dlq.queue.name", dlqName)
+                .put("mp.messaging.incoming.data-dlq.queue.routing-keys", routingKey)
+                .put("mp.messaging.incoming.data-dlq.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data-dlq.host", host)
+                .put("mp.messaging.incoming.data-dlq.port", port)
+                .put("mp.messaging.incoming.data-dlq.tracing-enabled", false)
+                .put("rabbitmq-username", username)
+                .put("rabbitmq-password", password)
+                .put("rabbitmq-reconnect-attempts", 0)
+                .write();
+
+        weld.addBeanClass(RequeueFirstDeliveryBean.class);
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAvailable(container));
+        RequeueFirstDeliveryBean bean = container.getBeanManager().createInstance().select(RequeueFirstDeliveryBean.class).get();
+
+        await().until(() -> isRabbitMQConnectorAvailable(container));
+
+        List<Integer> list = bean.getResults();
+        assertThat(list).isEmpty();
+
+        List<Integer> dlqList = bean.getDlqResults();
+        assertThat(dlqList).isEmpty();
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers(exchangeName, queueName, routingKey, counter::getAndIncrement);
+
+        await().atMost(1, TimeUnit.MINUTES).until(() -> list.size() >= 10);
+        assertThat(list).containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertThat(dlqList).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RequeueFirstDeliveryBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RequeueFirstDeliveryBean.java
@@ -1,0 +1,75 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.reactive.messaging.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A bean that can be registered to test rejecting and requeuing the
+ * first delivery attempt. Redeliveries will be nack'ed without requeue,
+ * so they should end up in the DLQ.
+ */
+@ApplicationScoped
+public class RequeueFirstDeliveryBean {
+    private final List<Integer> list = new ArrayList<>();
+    private final List<Integer> dlqList = new ArrayList<>();
+
+    private final AtomicInteger typeCastCounter = new AtomicInteger();
+
+    @Incoming("data")
+    @Outgoing("sink")
+    @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+    public Message<Integer> process(Message<String> input) {
+        int value = -1;
+        try {
+            value = Integer.parseInt(input.getPayload());
+        } catch (ClassCastException e) {
+            typeCastCounter.incrementAndGet();
+        }
+
+        return Message.of(value + 1, () -> {
+            boolean isRedeliver = input.getMetadata(IncomingRabbitMQMetadata.class)
+                    .map(IncomingRabbitMQMetadata::isRedeliver)
+                    .orElse(false);
+
+            if (isRedeliver) {
+                return input.nack(new RuntimeException("reject"));
+            } else {
+                return input.nack(new RuntimeException("requeue"), Metadata.of(new RabbitMQRejectMetadata(true)));
+            }
+        });
+    }
+
+    @Incoming("sink")
+    public void sink(int val) {
+        list.add(val);
+    }
+
+    @Incoming("data-dlq")
+    @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+    public CompletionStage<Void> dlq(Message<String> msg) {
+        try {
+            dlqList.add(Integer.parseInt(msg.getPayload()));
+        } catch (ClassCastException cce) {
+            typeCastCounter.incrementAndGet();
+        }
+
+        return msg.ack();
+    }
+
+    public List<Integer> getResults() {
+        return list;
+    }
+
+    public List<Integer> getDlqResults() {
+        return dlqList;
+    }
+
+    public int getTypeCasts() {
+        return typeCastCounter.get();
+    }
+}


### PR DESCRIPTION
Supports specifying the 'requeue' flag using additional nack metadata. Should fix #2200 .