### PR TITLE
Message metadata propagation with ack and nack

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -49,6 +49,31 @@
       </dependency>
     </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
+                  <artifactId>microprofile-reactive-messaging-api</artifactId>
+                </artifactItem>
+              </artifactItems>
+              <stripVersion>true</stripVersion>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
     <profiles>
         <profile>
             <id>coverage</id>

--- a/api/revapi.json
+++ b/api/revapi.json
@@ -27,7 +27,119 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+        {
+            "code": "java.annotation.removed",
+            "old": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> org.eclipse.microprofile.reactive.messaging.Message<T>::getNack()",
+            "new": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> org.eclipse.microprofile.reactive.messaging.Message<T>::getNack()",
+            "annotation": "@io.smallrye.common.annotation.Experimental(\"nack support is a SmallRye-only feature\")",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+
+        },
+        {
+            "code": "java.annotation.removed",
+            "old": "method java.util.concurrent.CompletionStage<java.lang.Void> org.eclipse.microprofile.reactive.messaging.Message<T>::nack(java.lang.Throwable)",
+            "new": "method java.util.concurrent.CompletionStage<java.lang.Void> org.eclipse.microprofile.reactive.messaging.Message<T>::nack(java.lang.Throwable)",
+            "annotation": "@io.smallrye.common.annotation.Experimental(\"nack support is a SmallRye-only feature\")",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "code": "java.annotation.attributeValueChanged",
+            "old": "method <T> org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::of(T, org.eclipse.microprofile.reactive.messaging.Metadata, java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>>, java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>)",
+            "new": "method <T> org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::of(T, org.eclipse.microprofile.reactive.messaging.Metadata, java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>>, java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>)",
+            "annotationType": "io.smallrye.common.annotation.Experimental",
+            "attribute": "value",
+            "oldValue": "\"nack support is a SmallRye-only feature\"",
+            "newValue": "\"metadata propagation is a SmallRye-specific feature\"",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "code": "java.annotation.attributeValueChanged",
+            "old": "method org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::withNack(java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>)",
+            "new": "method org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::withNack(java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>)",
+            "annotationType": "io.smallrye.common.annotation.Experimental",
+            "attribute": "value",
+            "oldValue": "\"nack support is a SmallRye-only feature\"",
+            "newValue": "\"metadata propagation is a SmallRye-specific feature\"",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.removed",
+            "old": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> org.eclipse.microprofile.reactive.messaging.Message<T>::getNack() @ io.smallrye.reactive.messaging.TargetedMessages.Default",
+            "new": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> org.eclipse.microprofile.reactive.messaging.Message<T>::getNack() @ io.smallrye.reactive.messaging.TargetedMessages.Default",
+            "annotation": "@io.smallrye.common.annotation.Experimental(\"nack support is a SmallRye-only feature\")",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.removed",
+            "old": "method java.util.concurrent.CompletionStage<java.lang.Void> org.eclipse.microprofile.reactive.messaging.Message<T>::nack(java.lang.Throwable) @ io.smallrye.reactive.messaging.TargetedMessages.Default",
+            "new": "method java.util.concurrent.CompletionStage<java.lang.Void> org.eclipse.microprofile.reactive.messaging.Message<T>::nack(java.lang.Throwable) @ io.smallrye.reactive.messaging.TargetedMessages.Default",
+            "annotation": "@io.smallrye.common.annotation.Experimental(\"nack support is a SmallRye-only feature\")",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.attributeValueChanged",
+            "old": "method <T> org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::of(T, org.eclipse.microprofile.reactive.messaging.Metadata, java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>>, java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>) @ io.smallrye.reactive.messaging.TargetedMessages.Default",
+            "new": "method <T> org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::of(T, org.eclipse.microprofile.reactive.messaging.Metadata, java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>>, java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>) @ io.smallrye.reactive.messaging.TargetedMessages.Default",
+            "annotationType": "io.smallrye.common.annotation.Experimental",
+            "attribute": "value",
+            "oldValue": "\"nack support is a SmallRye-only feature\"",
+            "newValue": "\"metadata propagation is a SmallRye-specific feature\"",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.attributeValueChanged",
+            "old": "method org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::withNack(java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>) @ io.smallrye.reactive.messaging.TargetedMessages.Default",
+            "new": "method org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::withNack(java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>) @ io.smallrye.reactive.messaging.TargetedMessages.Default",
+            "annotationType": "io.smallrye.common.annotation.Experimental",
+            "attribute": "value",
+            "oldValue": "\"nack support is a SmallRye-only feature\"",
+            "newValue": "\"metadata propagation is a SmallRye-specific feature\"",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.removed",
+            "old": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> org.eclipse.microprofile.reactive.messaging.Message<T>::getNack() @ io.smallrye.reactive.messaging.TargetedMessages",
+            "new": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> org.eclipse.microprofile.reactive.messaging.Message<T>::getNack() @ io.smallrye.reactive.messaging.TargetedMessages",
+            "annotation": "@io.smallrye.common.annotation.Experimental(\"nack support is a SmallRye-only feature\")",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.removed",
+            "old": "method java.util.concurrent.CompletionStage<java.lang.Void> org.eclipse.microprofile.reactive.messaging.Message<T>::nack(java.lang.Throwable) @ io.smallrye.reactive.messaging.TargetedMessages",
+            "new": "method java.util.concurrent.CompletionStage<java.lang.Void> org.eclipse.microprofile.reactive.messaging.Message<T>::nack(java.lang.Throwable) @ io.smallrye.reactive.messaging.TargetedMessages",
+            "annotation": "@io.smallrye.common.annotation.Experimental(\"nack support is a SmallRye-only feature\")",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.attributeValueChanged",
+            "old": "method <T> org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::of(T, org.eclipse.microprofile.reactive.messaging.Metadata, java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>>, java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>) @ io.smallrye.reactive.messaging.TargetedMessages",
+            "new": "method <T> org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::of(T, org.eclipse.microprofile.reactive.messaging.Metadata, java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>>, java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>) @ io.smallrye.reactive.messaging.TargetedMessages",
+            "annotationType": "io.smallrye.common.annotation.Experimental",
+            "attribute": "value",
+            "oldValue": "\"nack support is a SmallRye-only feature\"",
+            "newValue": "\"metadata propagation is a SmallRye-specific feature\"",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        },
+        {
+            "ignore": true,
+            "code": "java.annotation.attributeValueChanged",
+            "old": "method org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::withNack(java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>) @ io.smallrye.reactive.messaging.TargetedMessages",
+            "new": "method org.eclipse.microprofile.reactive.messaging.Message<T> org.eclipse.microprofile.reactive.messaging.Message<T>::withNack(java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>) @ io.smallrye.reactive.messaging.TargetedMessages",
+            "annotationType": "io.smallrye.common.annotation.Experimental",
+            "attribute": "value",
+            "oldValue": "\"nack support is a SmallRye-only feature\"",
+            "newValue": "\"metadata propagation is a SmallRye-specific feature\"",
+            "justification": "Added Message metadata propagation, nack support no longer a SmallRye-only feature"
+        }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/api/src/main/java/io/smallrye/reactive/messaging/IncomingInterceptor.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/IncomingInterceptor.java
@@ -1,0 +1,50 @@
+package io.smallrye.reactive.messaging;
+
+import jakarta.enterprise.inject.spi.Prioritized;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * Interceptor for incoming messages on connector channels.
+ * <p>
+ * To register an outgoing interceptor, expose a managed bean, implementing this interface,
+ * and qualified with {@code @Identifier} with the targeted channel name.
+ * <p>
+ * Only one interceptor is allowed to be bound for interception per incoming channel.
+ * When multiple interceptors are available, implementation should override the {@link #getPriority()} method.
+ */
+@Experimental("Smallrye-only feature")
+public interface IncomingInterceptor extends Prioritized {
+
+    @Override
+    default int getPriority() {
+        return -1;
+    }
+
+    /**
+     * Called after message received
+     *
+     * @param message received message
+     * @return the message to dispatch for consumer methods, possibly mutated
+     */
+    default Message<?> onMessage(Message<?> message) {
+        return message;
+    }
+
+    /**
+     * Called after message acknowledgment
+     *
+     * @param message acknowledged message
+     */
+    void onMessageAck(Message<?> message);
+
+    /**
+     * Called after message negative-acknowledgement
+     *
+     * @param message message to negative-acknowledge
+     * @param failure failure
+     */
+    void onMessageNack(Message<?> message, Throwable failure);
+}

--- a/api/src/main/java/io/smallrye/reactive/messaging/IncomingInterceptor.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/IncomingInterceptor.java
@@ -29,7 +29,7 @@ public interface IncomingInterceptor extends Prioritized {
      * @param message received message
      * @return the message to dispatch for consumer methods, possibly mutated
      */
-    default Message<?> onMessage(Message<?> message) {
+    default Message<?> afterMessageReceive(Message<?> message) {
         return message;
     }
 

--- a/api/src/main/java/io/smallrye/reactive/messaging/OutgoingInterceptor.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/OutgoingInterceptor.java
@@ -28,9 +28,21 @@ public interface OutgoingInterceptor extends Prioritized {
      *
      * @param message message to send
      * @return the message to send, possibly mutated
+     * @deprecated use {@link #beforeMessageSend(Message)}
      */
+    @Deprecated(since = "4.12.0")
     default Message<?> onMessage(Message<?> message) {
         return message;
+    }
+
+    /**
+     * Called before message transmission
+     *
+     * @param message message to send
+     * @return the message to send, possibly mutated
+     */
+    default Message<?> beforeMessageSend(Message<?> message) {
+        return onMessage(message);
     }
 
     /**

--- a/api/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
@@ -34,7 +34,7 @@ public interface PublisherDecorator extends Prioritized {
      * @return the extended multi
      * @deprecated replaced with {@link #decorate(Multi, List, boolean)}
      */
-    @Deprecated(since = "4.10.1")
+    @Deprecated(since = "4.12.0")
     default Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, String channelName,
             boolean isConnector) {
         return publisher;

--- a/api/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/PublisherDecorator.java
@@ -32,9 +32,13 @@ public interface PublisherDecorator extends Prioritized {
      * @param channelName the name of the channel to which this publisher publishes
      * @param isConnector {@code true} if decorated channel is connector
      * @return the extended multi
+     * @deprecated replaced with {@link #decorate(Multi, List, boolean)}
      */
-    Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, String channelName,
-            boolean isConnector);
+    @Deprecated(since = "4.10.1")
+    default Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, String channelName,
+            boolean isConnector) {
+        return publisher;
+    }
 
     /**
      * Decorate a Multi

--- a/api/src/main/java/io/smallrye/reactive/messaging/observation/DefaultMessageObservation.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/observation/DefaultMessageObservation.java
@@ -1,0 +1,77 @@
+package io.smallrye.reactive.messaging.observation;
+
+import java.time.Duration;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * The default implementation based on system nano time.
+ */
+public class DefaultMessageObservation implements MessageObservation {
+
+    // metadata
+    private final String channelName;
+
+    // time
+    private final long creation;
+    protected volatile long completion;
+
+    // status
+    protected volatile boolean done;
+    protected volatile Throwable nackReason;
+
+    public DefaultMessageObservation(String channelName) {
+        this(channelName, System.nanoTime());
+    }
+
+    public DefaultMessageObservation(String channelName, long creationTime) {
+        this.channelName = channelName;
+        this.creation = creationTime;
+    }
+
+    @Override
+    public String getChannel() {
+        return channelName;
+    }
+
+    @Override
+    public long getCreationTime() {
+        return creation;
+    }
+
+    @Override
+    public long getCompletionTime() {
+        return completion;
+    }
+
+    @Override
+    public boolean isDone() {
+        return done || nackReason != null;
+    }
+
+    @Override
+    public Throwable getReason() {
+        return nackReason;
+    }
+
+    @Override
+    public Duration getCompletionDuration() {
+        if (isDone()) {
+            return Duration.ofNanos(completion - creation);
+        }
+        return null;
+    }
+
+    @Override
+    public void onMessageAck(Message<?> message) {
+        completion = System.nanoTime();
+        done = true;
+    }
+
+    @Override
+    public void onMessageNack(Message<?> message, Throwable reason) {
+        completion = System.nanoTime();
+        nackReason = reason;
+    }
+
+}

--- a/api/src/main/java/io/smallrye/reactive/messaging/observation/MessageObservation.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/observation/MessageObservation.java
@@ -1,0 +1,56 @@
+package io.smallrye.reactive.messaging.observation;
+
+import java.time.Duration;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * The message observation contract
+ */
+public interface MessageObservation {
+
+    /**
+     * @return the channel name of the message
+     */
+    String getChannel();
+
+    /**
+     * @return the creation time of the message in system nanos
+     */
+    long getCreationTime();
+
+    /**
+     * @return the completion time of the message in system nanos
+     */
+    long getCompletionTime();
+
+    /**
+     *
+     * @return the duration between creation and the completion time, null if message processing is not completed
+     */
+    Duration getCompletionDuration();
+
+    /**
+     *
+     * @return {@code true} if the message processing is completed with acknowledgement or negative acknowledgement
+     */
+    boolean isDone();
+
+    /**
+     * @return the negative acknowledgement reason
+     */
+    Throwable getReason();
+
+    /**
+     * Notify the observation of acknowledgement event
+     *
+     */
+    void onMessageAck(Message<?> message);
+
+    /**
+     * Notify the observation of negative acknowledgement event
+     *
+     * @param reason the reason of the negative acknowledgement
+     */
+    void onMessageNack(Message<?> message, Throwable reason);
+}

--- a/api/src/main/java/io/smallrye/reactive/messaging/observation/MessageObservationCollector.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/observation/MessageObservationCollector.java
@@ -1,0 +1,44 @@
+package io.smallrye.reactive.messaging.observation;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+/**
+ * The observation collector is called with the new message and returns the message observation that will be used
+ * to observe messages from their creation until the ack or the nack event
+ * <p>
+ *
+ * <p>
+ * The implementation of this interface must be a CDI managed bean in order to be discovered
+ *
+ * @param <T> the type of the observation context
+ */
+public interface MessageObservationCollector<T extends ObservationContext> {
+
+    /**
+     * Initialize observation for the given channel
+     * If {@code null} is returned the observation for the given channel is disabled
+     *
+     * @param channel the channel of the message
+     * @param incoming whether the channel is incoming or outgoing
+     * @param emitter whether the channel is an emitter
+     * @return the observation context
+     */
+    default T initObservation(String channel, boolean incoming, boolean emitter) {
+        // enabled by default
+        return (T) ObservationContext.DEFAULT;
+    }
+
+    /**
+     * Returns a new {@link MessageObservation} object on which to collect the message processing events.
+     * If {@link #initObservation(String, boolean, boolean)} is implemented,
+     * the {@link ObservationContext} object returned from that method will be passed to this method.
+     * If not it is called with {@link ObservationContext#DEFAULT} and should be ignored.
+     *
+     * @param channel the channel of the message
+     * @param message the message
+     * @param observationContext the observation context
+     * @return the message observation
+     */
+    MessageObservation onNewMessage(String channel, Message<?> message, T observationContext);
+
+}

--- a/api/src/main/java/io/smallrye/reactive/messaging/observation/ObservationContext.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/observation/ObservationContext.java
@@ -1,0 +1,22 @@
+package io.smallrye.reactive.messaging.observation;
+
+/**
+ * The per-channel context of the Message observation.
+ * It is created at the observation initialization by-channel and included at each message observation calls.
+ */
+public interface ObservationContext {
+
+    /**
+     * Default no-op observation context
+     */
+    ObservationContext DEFAULT = observation -> {
+
+    };
+
+    /**
+     * Called after observation is completed.
+     *
+     * @param observation the completed message observation
+     */
+    void complete(MessageObservation observation);
+}

--- a/api/src/test/java/io/smallrye/reactive/messaging/MessagesWithMetadataTest.java
+++ b/api/src/test/java/io/smallrye/reactive/messaging/MessagesWithMetadataTest.java
@@ -1,0 +1,284 @@
+package io.smallrye.reactive.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.junit.jupiter.api.Test;
+
+public class MessagesWithMetadataTest {
+
+    @Test
+    public void testMergeOfTwoMessagesAndAckWithMetadata() {
+        AtomicBoolean ackM1 = new AtomicBoolean();
+        AtomicBoolean ackM2 = new AtomicBoolean();
+        Class<Integer> metaType = Integer.class;
+        Message<String> m1 = Message.of("A").withAckWithMetadata(metadata -> {
+            if (metadata.get(metaType).isPresent()) {
+                ackM1.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+        Message<Integer> m2 = Message.of(1).withAckWithMetadata(metadata -> {
+            if (metadata.get(metaType).isPresent()) {
+                ackM2.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        Message<String> merged = Messages.merge(List.of(m1, m2), l -> l.get(0) + "-" + l.get(1));
+
+        assertThat(merged.getPayload()).isEqualTo("A-1");
+
+        assertThat(merged.ack(Metadata.of(1))).isCompleted();
+        assertThat(ackM1).isTrue();
+        assertThat(ackM2).isTrue();
+    }
+
+    @Test
+    public void testMergeOfTwoMessagesOfSameTypeAndAckWithMetadata() {
+        AtomicBoolean ackM1 = new AtomicBoolean();
+        AtomicBoolean ackM2 = new AtomicBoolean();
+        Message<String> m1 = Message.of("A").withAckWithMetadata(metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                ackM1.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+        Message<String> m2 = Message.of("B").withAckWithMetadata(metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                ackM2.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        Message<String> merged = Messages.merge(List.of(m1, m2), l -> l.get(0) + "-" + l.get(1));
+
+        assertThat(merged.getPayload()).isEqualTo("A-B");
+
+        assertThat(merged.addMetadata(1).ack()).isCompleted();
+        assertThat(ackM1).isTrue();
+        assertThat(ackM2).isTrue();
+    }
+
+    @Test
+    public void testMergeOfTwoMessagesAndNackWithMetadata() {
+        AtomicBoolean nackM1 = new AtomicBoolean();
+        AtomicBoolean nackM2 = new AtomicBoolean();
+        Message<String> m1 = Message.of("A").withNackWithMetadata((throwable, metadata) -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                nackM1.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+        Message<Integer> m2 = Message.of(1).withNackWithMetadata((throwable, metadata) -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                nackM2.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        Message<String> merged = Messages.merge(List.of(m1, m2), l -> l.get(0) + "-" + l.get(1));
+
+        assertThat(merged.getPayload()).isEqualTo("A-1");
+
+        assertThat(merged.nack(new IOException("boom"), Metadata.of(1))).isCompleted();
+        assertThat(nackM1).isTrue();
+        assertThat(nackM2).isTrue();
+    }
+
+    @Test
+    void testMergeAsListWithMetadata() {
+        AtomicBoolean ackM1 = new AtomicBoolean();
+        AtomicBoolean ackM2 = new AtomicBoolean();
+        AtomicBoolean ackM3 = new AtomicBoolean();
+        Message<String> m1 = Message.of("A").withAckWithMetadata(metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                ackM1.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+        Message<String> m2 = Message.of("B").withAckWithMetadata(metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                ackM2.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+        Message<String> m3 = Message.of("C").withAckWithMetadata(metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                ackM3.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        Message<List<String>> result = Messages.merge(List.of(m1, m2, m3));
+        assertThat(result.getPayload()).containsExactly("A", "B", "C");
+
+        assertThat(result.ack(Metadata.of(1))).isCompleted();
+        assertThat(ackM1).isTrue();
+        assertThat(ackM2).isTrue();
+        assertThat(ackM3).isTrue();
+    }
+
+    @Test
+    void testMergeAsListAndNackWithMetadata() {
+        AtomicBoolean nackM1 = new AtomicBoolean();
+        AtomicBoolean nackM2 = new AtomicBoolean();
+        AtomicBoolean nackM3 = new AtomicBoolean();
+        Message<String> m1 = Message.of("A").withNackWithMetadata((throwable, metadata) -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                nackM1.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+        Message<String> m2 = Message.of("B").withNackWithMetadata((throwable, metadata) -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                nackM2.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+        Message<String> m3 = Message.of("C").withNackWithMetadata((throwable, metadata) -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                nackM3.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        Message<List<String>> result = Messages.merge(List.of(m1, m2, m3));
+        assertThat(result.getPayload()).containsExactly("A", "B", "C");
+
+        assertThat(result.nack(new IOException("boom"), Metadata.of(1))).isCompleted();
+        assertThat(nackM1).isTrue();
+        assertThat(nackM2).isTrue();
+        assertThat(nackM3).isTrue();
+    }
+
+    @Test
+    void checkSimpleChainAcknowledgementWithMetadata() {
+        AtomicBoolean o1Ack = new AtomicBoolean();
+        AtomicBoolean o2Ack = new AtomicBoolean();
+        AtomicInteger i1Ack = new AtomicInteger();
+        Message<String> o1 = Message.of("foo", metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                o1Ack.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+        Message<String> o2 = Message.of("bar", metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                o2Ack.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        Message<Integer> i = Message.of(1, metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                i1Ack.incrementAndGet();
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        List<Message<?>> outcomes = Messages.chain(i).with(o1, o2);
+        assertThat(i1Ack).hasValue(0);
+        assertThat(o1Ack).isFalse();
+        assertThat(o2Ack).isFalse();
+
+        outcomes.get(0).ack(Metadata.of(1));
+        assertThat(i1Ack).hasValue(0);
+        assertThat(o1Ack).isTrue();
+        assertThat(o2Ack).isFalse();
+
+        outcomes.get(1).ack(Metadata.of(1));
+        assertThat(i1Ack).hasValue(1);
+        assertThat(o1Ack).isTrue();
+        assertThat(o1Ack).isTrue();
+
+        outcomes.get(1).ack(Metadata.of(2));
+        outcomes.get(0).ack(Metadata.of(2));
+        assertThat(i1Ack).hasValue(1);
+
+        outcomes.get(1).nack(new Exception("boom"));
+        outcomes.get(0).nack(new Exception("boom"));
+        assertThat(i1Ack).hasValue(1);
+    }
+
+    @Test
+    void checkSimpleChainNegativeAcknowledgementWithMetadata() {
+        AtomicBoolean o1Ack = new AtomicBoolean();
+        AtomicBoolean o2Ack = new AtomicBoolean();
+        AtomicBoolean o1Nack = new AtomicBoolean();
+        AtomicBoolean o2Nack = new AtomicBoolean();
+        AtomicInteger i1Ack = new AtomicInteger();
+        AtomicInteger i1Nack = new AtomicInteger();
+        Message<String> o1 = Message.of("foo", metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                o1Ack.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        }, (throwable, metadata) -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                o1Nack.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+        Message<String> o2 = Message.of("bar", metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                o2Ack.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        }, (throwable, metadata) -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                o2Nack.set(true);
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        Message<Integer> i = Message.of(1, metadata -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                i1Ack.incrementAndGet();
+            }
+            return CompletableFuture.completedFuture(null);
+        }, (throwable, metadata) -> {
+            if (metadata.get(Integer.class).isPresent()) {
+                i1Nack.incrementAndGet();
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        List<Message<?>> outcomes = Messages.chain(i).with(o1, o2);
+        assertThat(i1Ack).hasValue(0);
+        assertThat(o1Ack).isFalse();
+        assertThat(o2Ack).isFalse();
+        assertThat(i1Nack).hasValue(0);
+        assertThat(o1Nack).isFalse();
+        assertThat(o2Nack).isFalse();
+
+        outcomes.get(0).ack(Metadata.of(1));
+        assertThat(i1Ack).hasValue(0);
+        assertThat(o1Ack).isTrue();
+        assertThat(o2Ack).isFalse();
+        assertThat(i1Nack).hasValue(0);
+        assertThat(o1Nack).isFalse();
+        assertThat(o2Nack).isFalse();
+
+        outcomes.get(0).nack(new Exception("boom"), Metadata.of(1));
+        assertThat(i1Ack).hasValue(0);
+        assertThat(i1Nack).hasValue(0);
+
+        outcomes.get(1).nack(new Exception("boom"), Metadata.of(1));
+        assertThat(i1Nack).hasValue(1);
+        assertThat(i1Ack).hasValue(0);
+        assertThat(o2Nack).isTrue();
+
+        outcomes.get(1).ack(Metadata.of(1));
+        assertThat(i1Nack).hasValue(1);
+        assertThat(i1Ack).hasValue(0);
+    }
+
+}

--- a/api/src/test/java/org/eclipse/microprofile/reactive/messaging/AckNackChainTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/reactive/messaging/AckNackChainTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +36,74 @@ public class AckNackChainTest {
     }
 
     @Test
+    public void testAckChainWithCustomMessageImplementingAck() {
+        AtomicInteger m1Ack = new AtomicInteger();
+        AtomicInteger m2Ack = new AtomicInteger();
+        AtomicInteger m3Ack = new AtomicInteger();
+        Message<String> m1 = new Message<>() {
+            @Override
+            public String getPayload() {
+                return "1";
+            }
+
+            @Override
+            public Supplier<CompletionStage<Void>> getAck() {
+                return this::ack;
+            }
+
+            @Override
+            public CompletionStage<Void> ack() {
+                m1Ack.incrementAndGet();
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        Message<String> m2 = Message.of("2", () -> m1.getAck().get().thenAccept(x -> m2Ack.incrementAndGet()));
+
+        Message<String> m3 = Message.of("3", () -> m2.ack().thenAccept(x -> m3Ack.incrementAndGet()));
+
+        CompletionStage<Void> acked = m3.ack();
+        acked.toCompletableFuture().join();
+
+        assertThat(m3Ack).hasValue(1);
+        assertThat(m2Ack).hasValue(1);
+        assertThat(m1Ack).hasValue(1);
+    }
+
+    @Test
+    public void testAckChainWithCustomMessageImplementingAckWithMetadata() {
+        AtomicInteger m1Ack = new AtomicInteger();
+        AtomicInteger m2Ack = new AtomicInteger();
+        AtomicInteger m3Ack = new AtomicInteger();
+        Message<String> m1 = new Message<>() {
+            @Override
+            public String getPayload() {
+                return "1";
+            }
+
+            @Override
+            public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
+                return metadata -> {
+                    m1Ack.incrementAndGet();
+                    return CompletableFuture.completedFuture(null);
+                };
+            }
+
+        };
+
+        Message<String> m2 = Message.of("2", () -> m1.getAck().get().thenAccept(x -> m2Ack.incrementAndGet()));
+
+        Message<String> m3 = Message.of("3", () -> m2.ack().thenAccept(x -> m3Ack.incrementAndGet()));
+
+        CompletionStage<Void> acked = m3.ack();
+        acked.toCompletableFuture().join();
+
+        assertThat(m3Ack).hasValue(1);
+        assertThat(m2Ack).hasValue(1);
+        assertThat(m1Ack).hasValue(1);
+    }
+
+    @Test
     public void testNackChain() {
         AtomicInteger m1Nack = new AtomicInteger();
         AtomicInteger m2Nack = new AtomicInteger();
@@ -44,6 +115,103 @@ public class AckNackChainTest {
                     m1Nack.incrementAndGet();
                     return CompletableFuture.completedFuture(null);
                 });
+
+        Message<String> m2 = Message.of("2", Metadata.empty(),
+                () -> CompletableFuture.completedFuture(null),
+                cause -> {
+                    assertThat(cause).isNotNull();
+                    return m1.getNack().apply(cause).thenAccept(x -> m2Nack.incrementAndGet());
+                });
+
+        Message<String> m3 = Message.of("3", Metadata.empty(),
+                () -> CompletableFuture.completedFuture(null),
+                cause -> {
+                    assertThat(cause).isNotNull();
+                    return m2.nack(cause).thenAccept(x -> m3Nack.incrementAndGet());
+                });
+
+        CompletionStage<Void> nacked = m3.nack(new Exception("boom"));
+        nacked.toCompletableFuture().join();
+
+        assertThat(m3Nack).hasValue(1);
+        assertThat(m2Nack).hasValue(1);
+        assertThat(m1Nack).hasValue(1);
+    }
+
+    @Test
+    public void testNackChainWithCustomMessage() {
+        AtomicInteger m1Nack = new AtomicInteger();
+        AtomicInteger m2Nack = new AtomicInteger();
+        AtomicInteger m3Nack = new AtomicInteger();
+
+        Message<String> m1 = new Message<>() {
+            @Override
+            public String getPayload() {
+                return "1";
+            }
+
+            @Override
+            public Supplier<CompletionStage<Void>> getAck() {
+                return () -> CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public Function<Throwable, CompletionStage<Void>> getNack() {
+                return cause -> {
+                    assertThat(cause).isNotNull();
+                    m1Nack.incrementAndGet();
+                    return CompletableFuture.completedFuture(null);
+                };
+            }
+        };
+
+        Message<String> m2 = Message.of("2", Metadata.empty(),
+                () -> CompletableFuture.completedFuture(null),
+                cause -> {
+                    assertThat(cause).isNotNull();
+                    return m1.getNack().apply(cause).thenAccept(x -> m2Nack.incrementAndGet());
+                });
+
+        Message<String> m3 = Message.of("3", Metadata.empty(),
+                () -> CompletableFuture.completedFuture(null),
+                cause -> {
+                    assertThat(cause).isNotNull();
+                    return m2.nack(cause).thenAccept(x -> m3Nack.incrementAndGet());
+                });
+
+        CompletionStage<Void> nacked = m3.nack(new Exception("boom"));
+        nacked.toCompletableFuture().join();
+
+        assertThat(m3Nack).hasValue(1);
+        assertThat(m2Nack).hasValue(1);
+        assertThat(m1Nack).hasValue(1);
+    }
+
+    @Test
+    public void testNackChainWithCustomMessageImplementingAckWithMetadata() {
+        AtomicInteger m1Nack = new AtomicInteger();
+        AtomicInteger m2Nack = new AtomicInteger();
+        AtomicInteger m3Nack = new AtomicInteger();
+        Message<String> m1 = new Message<>() {
+            @Override
+            public String getPayload() {
+                return "1";
+            }
+
+            @Override
+            public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
+                return metadata -> CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public BiFunction<Throwable, Metadata, CompletionStage<Void>> getNackWithMetadata() {
+                return (cause, metadata) -> {
+                    assertThat(cause).isNotNull();
+                    m1Nack.incrementAndGet();
+                    return CompletableFuture.completedFuture(null);
+                };
+            }
+        };
 
         Message<String> m2 = Message.of("2", Metadata.empty(),
                 () -> CompletableFuture.completedFuture(null),

--- a/api/src/test/java/org/eclipse/microprofile/reactive/messaging/CustomMessageTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/reactive/messaging/CustomMessageTest.java
@@ -4,20 +4,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
-public class MessageTest {
+public class CustomMessageTest {
 
     private final MyMetadata myMetadata = new MyMetadata("bar");
 
     @Test
     public void testCreationFromPayloadOnly() {
-        Message<String> message = Message.of("foo");
+        Message<String> message = () -> "foo";
         assertThat(message.getPayload()).isEqualTo("foo");
         assertThat(message.getMetadata()).isEmpty();
         assertThat(message.getAck()).isNotNull();
@@ -30,7 +32,17 @@ public class MessageTest {
     @Test
     public void testCreationFromPayloadAndMetadataOnly() {
 
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata));
+        Message<String> message = new Message<String>() {
+            @Override
+            public String getPayload() {
+                return "foo";
+            }
+
+            @Override
+            public Metadata getMetadata() {
+                return Metadata.of(myMetadata);
+            }
+        };
         assertThat(message.getPayload()).isEqualTo("foo");
         assertThat(message.getMetadata()).hasSize(1).containsExactly(myMetadata);
         assertThat(message.getAck()).isNotNull();
@@ -50,7 +62,17 @@ public class MessageTest {
     @Test
     public void testCreationFromPayloadAndMetadataAsIterable() {
         List<Object> metadata = Arrays.asList(myMetadata, new AtomicInteger(2));
-        Message<String> message = Message.of("foo", metadata);
+        Message<String> message = new Message<>() {
+            @Override
+            public String getPayload() {
+                return "foo";
+            }
+
+            @Override
+            public Metadata getMetadata() {
+                return Metadata.from(metadata);
+            }
+        };
         assertThat(message.getPayload()).isEqualTo("foo");
         assertThat(message.getMetadata()).hasSize(2);
         assertThat(message.getAck()).isNotNull();
@@ -65,10 +87,24 @@ public class MessageTest {
     @Test
     public void testCreationFromPayloadAndAck() {
         AtomicInteger count = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", () -> {
-            count.incrementAndGet();
-            return CompletableFuture.completedFuture(null);
-        });
+        Message<String> message = new Message<>() {
+            @Override
+            public String getPayload() {
+                return "foo";
+            }
+
+            @Override
+            public Supplier<CompletionStage<Void>> getAck() {
+                return this::ack;
+            }
+
+            @Override
+            public CompletionStage<Void> ack() {
+                count.incrementAndGet();
+                return CompletableFuture.completedFuture(null);
+            }
+
+        };
         assertThat(message.getPayload()).isEqualTo("foo");
         assertThat(message.getMetadata()).hasSize(0);
         assertThat(message.getAck()).isNotNull();
@@ -83,10 +119,29 @@ public class MessageTest {
     @Test
     public void testCreationFromPayloadMetadataAndAck() {
         AtomicInteger count = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata), () -> {
-            count.incrementAndGet();
-            return CompletableFuture.completedFuture(null);
-        });
+        Message<String> message = new Message<>() {
+            @Override
+            public String getPayload() {
+                return "foo";
+            }
+
+            @Override
+            public Metadata getMetadata() {
+                return Metadata.of(myMetadata);
+            }
+
+            @Override
+            public Supplier<CompletionStage<Void>> getAck() {
+                return this::ack;
+            }
+
+            @Override
+            public CompletionStage<Void> ack() {
+                count.incrementAndGet();
+                return CompletableFuture.completedFuture(null);
+            }
+
+        };
         assertThat(message.getPayload()).isEqualTo("foo");
         assertThat(message.getMetadata()).hasSize(1).containsExactly(myMetadata);
         assertThat(message.getAck()).isNotNull();
@@ -104,10 +159,30 @@ public class MessageTest {
     public void testCreationFromPayloadMetadataAsIterableAndAck() {
         List<Object> metadata = Arrays.asList(myMetadata, new AtomicInteger(2));
         AtomicInteger count = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", metadata, () -> {
-            count.incrementAndGet();
-            return CompletableFuture.completedFuture(null);
-        });
+        Message<String> message = new Message<>() {
+            @Override
+            public String getPayload() {
+                return "foo";
+            }
+
+            @Override
+            public Metadata getMetadata() {
+                return Metadata.from(metadata);
+            }
+
+            @Override
+            public Supplier<CompletionStage<Void>> getAck() {
+                return this::ack;
+            }
+
+            @Override
+            public CompletionStage<Void> ack() {
+                count.incrementAndGet();
+                return CompletableFuture.completedFuture(null);
+            }
+
+        };
+
         assertThat(message.getPayload()).isEqualTo("foo");
         assertThat(message.getMetadata()).hasSize(2).contains(myMetadata);
         assertThat(message.getAck()).isNotNull();
@@ -122,48 +197,11 @@ public class MessageTest {
     }
 
     @Test
-    public void testCreationFromPayloadMetadataAsIterableAckAndNack() {
-        AtomicInteger ack = new AtomicInteger(0);
-        AtomicInteger nack = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Collections.singleton(myMetadata),
-                () -> {
-                    ack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                },
-                t -> {
-                    assertThat(t).hasMessage("cause");
-                    nack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                }
-
-        );
-        assertThat(message.getPayload()).isEqualTo("foo");
-        assertThat(message.getMetadata()).hasSize(1).containsExactly(myMetadata);
-        assertThat(message.getAck()).isNotNull();
-        assertThat(message.getNack()).isNotNull();
-
-        assertThat(message.ack().toCompletableFuture().join()).isNull();
-        assertThat(message.nack(new Exception("cause")).toCompletableFuture().join()).isNull();
-        assertThat(ack).hasValue(1);
-        assertThat(nack).hasValue(1);
-    }
-
-    @Test
     public void testCreationFromPayloadMetadataAckAndNack() {
         AtomicInteger ack = new AtomicInteger(0);
         AtomicInteger nack = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata),
-                () -> {
-                    ack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                },
-                t -> {
-                    assertThat(t).hasMessage("cause");
-                    nack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                }
+        Message<String> message = new CustomMessage<>("foo", Metadata.of(myMetadata), ack, nack);
 
-        );
         assertThat(message.getPayload()).isEqualTo("foo");
         assertThat(message.getMetadata()).hasSize(1).containsExactly(myMetadata);
         assertThat(message.getAck()).isNotNull();
@@ -179,18 +217,7 @@ public class MessageTest {
     public void testWithPayload() {
         AtomicInteger ack = new AtomicInteger(0);
         AtomicInteger nack = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata),
-                () -> {
-                    ack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                },
-                t -> {
-                    assertThat(t).hasMessage("cause");
-                    nack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                }
-
-        );
+        Message<String> message = new CustomMessage<>("foo", Metadata.of(myMetadata), ack, nack);
 
         Message<String> created = message.withPayload("bar");
         assertThat(created.getPayload()).isEqualTo("bar");
@@ -209,52 +236,9 @@ public class MessageTest {
     public void testWithMetadata() {
         AtomicInteger ack = new AtomicInteger(0);
         AtomicInteger nack = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata),
-                () -> {
-                    ack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                },
-                t -> {
-                    assertThat(t).hasMessage("cause");
-                    nack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                }
-
-        );
-
+        Message<String> message = new CustomMessage<>("foo", Metadata.of(myMetadata), ack, nack);
         MyMetadata mm = new MyMetadata("hello");
         Message<String> created = message.withMetadata(Metadata.of(mm));
-        assertThat(created.getPayload()).isEqualTo("foo");
-        assertThat(created.getMetadata()).hasSize(1).containsExactly(mm);
-        assertThat(created.getAck()).isNotNull();
-        assertThat(created.getNack()).isNotNull();
-
-        assertThat(created.ack().toCompletableFuture().join()).isNull();
-        assertThat(created.nack(new Exception("cause")).toCompletableFuture().join()).isNull();
-        assertThat(ack).hasValue(1);
-        assertThat(nack).hasValue(1);
-
-    }
-
-    @Test
-    public void testWithMetadataAsIterable() {
-        AtomicInteger ack = new AtomicInteger(0);
-        AtomicInteger nack = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata),
-                () -> {
-                    ack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                },
-                t -> {
-                    assertThat(t).hasMessage("cause");
-                    nack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                }
-
-        );
-
-        MyMetadata mm = new MyMetadata("hello");
-        Message<String> created = message.withMetadata(Collections.singletonList(mm));
         assertThat(created.getPayload()).isEqualTo("foo");
         assertThat(created.getMetadata()).hasSize(1).containsExactly(mm);
         assertThat(created.getAck()).isNotNull();
@@ -272,19 +256,7 @@ public class MessageTest {
         AtomicInteger ack = new AtomicInteger(0);
         AtomicInteger ack2 = new AtomicInteger(0);
         AtomicInteger nack = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata),
-                () -> {
-                    ack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                },
-                t -> {
-                    assertThat(t).hasMessage("cause");
-                    nack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                }
-
-        );
-
+        Message<String> message = new CustomMessage<>("foo", Metadata.of(myMetadata), ack, nack);
         Message<String> created = message.withAck(() -> {
             ack2.incrementAndGet();
             return CompletableFuture.completedFuture(null);
@@ -307,18 +279,7 @@ public class MessageTest {
         AtomicInteger ack = new AtomicInteger(0);
         AtomicInteger nack = new AtomicInteger(0);
         AtomicInteger nack2 = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata),
-                () -> {
-                    ack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                },
-                t -> {
-                    assertThat(t).hasMessage("cause");
-                    nack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                }
-
-        );
+        Message<String> message = new CustomMessage<>("foo", Metadata.of(myMetadata), ack, nack);
 
         Message<String> created = message.withNack(t -> {
             assertThat(t).hasMessage("cause");
@@ -341,19 +302,7 @@ public class MessageTest {
     public void testAddMetadata() {
         AtomicInteger ack = new AtomicInteger(0);
         AtomicInteger nack = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata),
-                () -> {
-                    ack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                },
-                t -> {
-                    assertThat(t).hasMessage("cause");
-                    nack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                }
-
-        );
-
+        Message<String> message = new CustomMessage<>("foo", Metadata.of(myMetadata), ack, nack);
         Message<String> created = message.addMetadata(new AtomicInteger(2));
         assertThat(created.getPayload()).isEqualTo("foo");
         assertThat(created.getMetadata()).hasSize(2).contains(myMetadata);
@@ -370,19 +319,7 @@ public class MessageTest {
     public void testAckAndNackNull() {
         AtomicInteger ack = new AtomicInteger(0);
         AtomicInteger nack = new AtomicInteger(0);
-        Message<String> message = Message.of("foo", Metadata.of(myMetadata),
-                () -> {
-                    ack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                },
-                t -> {
-                    assertThat(t).hasMessage("cause");
-                    nack.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                }
-
-        );
-
+        Message<String> message = new CustomMessage<>("foo", Metadata.of(myMetadata), ack, nack);
         Message<String> created = message.withAck(null).withNack(null);
         assertThat(created.getPayload()).isEqualTo("foo");
         assertThat(created.getMetadata()).hasSize(1).contains(myMetadata);
@@ -414,6 +351,54 @@ public class MessageTest {
 
         public String getValue() {
             return value;
+        }
+    }
+
+    private static class CustomMessage<T> implements Message<T> {
+
+        T payload;
+        Metadata metadata;
+        AtomicInteger ack;
+        AtomicInteger nack;
+
+        public CustomMessage(T payload, Metadata metadata, AtomicInteger ack, AtomicInteger nack) {
+            this.payload = payload;
+            this.metadata = metadata;
+            this.ack = ack;
+            this.nack = nack;
+        }
+
+        @Override
+        public T getPayload() {
+            return payload;
+        }
+
+        @Override
+        public Metadata getMetadata() {
+            return metadata;
+        }
+
+        @Override
+        public Supplier<CompletionStage<Void>> getAck() {
+            return this::ack;
+        }
+
+        @Override
+        public Function<Throwable, CompletionStage<Void>> getNack() {
+            return this::nack;
+        }
+
+        @Override
+        public CompletionStage<Void> ack() {
+            ack.incrementAndGet();
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Void> nack(Throwable reason, Metadata metadata) {
+            assertThat(reason).hasMessage("cause");
+            nack.incrementAndGet();
+            return CompletableFuture.completedFuture(null);
         }
     }
 }

--- a/api/src/test/java/org/eclipse/microprofile/reactive/messaging/MessageSpecCompatibilityTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/reactive/messaging/MessageSpecCompatibilityTest.java
@@ -1,0 +1,53 @@
+package org.eclipse.microprofile.reactive.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+public class MessageSpecCompatibilityTest {
+
+    public static Class<?> getClassesFromJarFile(File jarFile) throws IOException, ClassNotFoundException {
+        // URL classloader without parent
+        try (URLClassLoader cl = URLClassLoader.newInstance(
+                new URL[] { new URL("jar:file:" + jarFile + "!/") }, null)) {
+            return cl.loadClass(Message.class.getName());
+        }
+    }
+
+    @Test
+    void loadClassFromJar() throws IOException, ClassNotFoundException {
+        File jarFile = new File("./target/lib/microprofile-reactive-messaging-api.jar");
+        Class<?> clazz = getClassesFromJarFile(jarFile);
+
+        List<String> specMethods = Arrays.stream(clazz.getDeclaredMethods())
+                .filter(m -> Modifier.isPublic(m.getModifiers()))
+                .map(Method::toGenericString)
+                .collect(Collectors.toList());
+
+        List<String> rmMethods = Arrays.stream(Message.class.getDeclaredMethods())
+                .filter(m -> Modifier.isPublic(m.getModifiers()))
+                .map(Method::toGenericString)
+                .collect(Collectors.toList());
+
+        System.out.println(Message.class.getName() + " public methods from MicroProfile specification:");
+        for (String signature : specMethods) {
+            System.out.println(signature);
+        }
+        assertThat(rmMethods).containsAll(specMethods);
+        rmMethods.removeAll(specMethods);
+        System.out.println("Remaining methods in Smallrye implementation:");
+        for (String signature : rmMethods) {
+            System.out.println(signature);
+        }
+    }
+}

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -21,7 +21,7 @@ nav:
             - 'Skipping Messages': concepts/skipping.md
             - 'Message Converters': concepts/converters.md
             - 'Keyed Streams': concepts/keyed-multi.md
-            - 'Channel Decorators': concepts/decorators.md
+            - 'Channel Decorators and Interceptors': concepts/decorators.md
             - 'Broadcast' : concepts/broadcast.md
             - 'Merge channels' : concepts/merge.md
             - 'Incoming Channel Concurrency' : concepts/incoming-concurrency.md

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
             - '@Outgoings' : concepts/outgoings.md
             - 'Testing' : concepts/testing.md
             - 'Logging' : concepts/logging.md
+            - 'Observability API' : concepts/observability.md
             - 'Advanced Configuration' : concepts/advanced-config.md
             - 'Message Context' : concepts/message-context.md
             - 'Metadata Injection': concepts/incoming-metadata-injection.md

--- a/documentation/src/main/docs/concepts/decorators.md
+++ b/documentation/src/main/docs/concepts/decorators.md
@@ -32,18 +32,42 @@ obtained using the `jakarta.enterprise.inject.spi.Prioritized#getPriority` metho
     The `SubscriberDecorator` receive a list of channel names because `@Incoming` annotation is repeatable
     and consuming methods can be linked to multiple channels.
 
-## Intercepting Outgoing Messages
+## Intercepting Incoming and Outgoing Messages
 
-Decorators can be used to intercept and alter messages, both on incoming and outgoing channels.
-Smallrye Reactive Messaging provides a `SubscriberDecorator` by default to allow intercepting outgoing messages for a specific channel.
+Decorators (`PublisherDecorator` and `SubscriberDecorator`) can be used to intercept and alter messages, both on incoming and outgoing channels.
 
-To provide an outgoing interceptor implement a bean exposing the interface {{ javadoc('io.smallrye.reactive.messaging.OutgoingInterceptor') }}, qualified with a `@Identifier` with the channel name to intercept.
+Smallrye Reactive Messaging allows defining intercepting incoming and outgoing messages for a specific channel, using
+`IncomingInterceptor` and `OutgoingInterceptor` respectively.
+
 Only one interceptor is allowed to be bound for interception per outgoing channel.
 If no interceptors are found with a `@Identifier` but a `@Default` one is available, it is used.
 When multiple interceptors are available, the bean with the highest priority is used.
 
+### `IncomingInterceptor`
+
+To provide an incoming interceptor implement a bean exposing the interface {{ javadoc('io.smallrye.reactive.messaging.IncomingInterceptor') }}, qualified with a `@Identifier` with the channel name to intercept.
+
 ``` java
-{{ insert('interceptors/MyInterceptor.java') }}
+{{ insert('interceptors/MyIncomingInterceptor.java') }}
+```
+
+An `IncomingInterceptor` can implement these three methods:
+
+- `Message<?> onMessage(Message<?> message)` : Called after receiving the message from an incoming connector.
+  The message can be altered by returning a new message from this method. The modified message will be consumed in incoming channels.
+- `void onMessageAck(Message<?> message)` : Called after message acknowledgment.
+- `void onMessageNack(Message<?> message, Throwable failure)` : Called after message negative-acknowledgment.
+
+!!!Note
+    If you are willing to adapt an incoming message payload to fit a consuming method receiving type,
+    you can use [`MessageConverter`](./converters)s.
+
+### `OutgoingInterceptor`
+
+To provide an outgoing interceptor implement a bean exposing the interface {{ javadoc('io.smallrye.reactive.messaging.OutgoingInterceptor') }}, qualified with a `@Identifier` with the channel name to intercept.
+
+``` java
+{{ insert('interceptors/MyOutgoingInterceptor.java') }}
 ```
 
 An `OutgoingInterceptor` can implement these three methods:
@@ -52,8 +76,4 @@ An `OutgoingInterceptor` can implement these three methods:
 The message can be altered by returning a new message from this method.
 - `void onMessageAck(Message<?> message)` : Called after message acknowledgment.
 This callback can access `OutgoingMessageMetadata` which will hold the result of the message transmission to the broker, if supported by the connector. This is only supported by MQTT and Kafka connectors.
-- `void onMessageNack(Message<?> message, Throwable failure)` : Called before message negative-acknowledgment.
-
-!!!Note
-    If you are willing to adapt an incoming message payload to fit a consuming method receiving type,
-    you can use `MessageConverter`s.
+- `void onMessageNack(Message<?> message, Throwable failure)` : Called after message negative-acknowledgment.

--- a/documentation/src/main/docs/concepts/decorators.md
+++ b/documentation/src/main/docs/concepts/decorators.md
@@ -53,7 +53,7 @@ To provide an incoming interceptor implement a bean exposing the interface {{ ja
 
 An `IncomingInterceptor` can implement these three methods:
 
-- `Message<?> onMessage(Message<?> message)` : Called after receiving the message from an incoming connector.
+- `Message<?> afterMessageReceive(Message<?> message)` : Called after receiving the message from an incoming connector.
   The message can be altered by returning a new message from this method. The modified message will be consumed in incoming channels.
 - `void onMessageAck(Message<?> message)` : Called after message acknowledgment.
 - `void onMessageNack(Message<?> message, Throwable failure)` : Called after message negative-acknowledgment.
@@ -72,7 +72,7 @@ To provide an outgoing interceptor implement a bean exposing the interface {{ ja
 
 An `OutgoingInterceptor` can implement these three methods:
 
-- `Message<?> onMessage(Message<?> message)` : Called before passing the message to the outgoing connector for transmission.
+- `Message<?> beforeMessageSend(Message<?> message)` : Called before passing the message to the outgoing connector for transmission.
 The message can be altered by returning a new message from this method.
 - `void onMessageAck(Message<?> message)` : Called after message acknowledgment.
 This callback can access `OutgoingMessageMetadata` which will hold the result of the message transmission to the broker, if supported by the connector. This is only supported by MQTT and Kafka connectors.

--- a/documentation/src/main/docs/concepts/observability.md
+++ b/documentation/src/main/docs/concepts/observability.md
@@ -1,0 +1,30 @@
+# Observability API
+
+!!!important
+    Observability API is experimental and SmallRye only feature.
+
+Smallrye Reactive Messaging proposes an observability API that allows to observe messages received and send through inbound and outbound channels.
+
+For any observation to happen, you need to provide an implementation of the `MessageObservationCollector`, discovered as a CDI-managed bean.
+
+At wiring time the discovered `MessageObservationCollector` implementation `initObservation` method is called once per channel to initialize the `ObservationContext`.
+The default `initObservation` implementation returns a default `ObservationContext` object,
+but the collector implementation can provide a custom per-channel `ObservationContext` object that'll hold information necessary for the observation.
+The `ObservationContext#complete` method is called each time a message observation is completed – message being acked or nacked.
+The collector implementation can decide at initialization time to disable the observation per channel by returning a `null` observation context.
+
+For each new message, the collector is on `onNewMessage` method with the channel name, the `Message` and the `ObservationContext` object initialized beforehand.
+This method can react to the creation of a new message but also is responsible for instantiating and returning a `MessageObservation`.
+While custom implementations can augment the observability capability, SmallRye Reactive Messaging provides a default implementation `DefaultMessageObservation`.
+
+So a simple observability collector can be implemented as such:
+
+``` java
+{{ insert('observability/SimpleMessageObservationCollector.java', ) }}
+```
+
+A collector with a custom `ObservationContext` can be implemented as such :
+
+``` java
+{{ insert('observability/ContextMessageObservationCollector.java', ) }}
+```

--- a/documentation/src/main/java/interceptors/MyIncomingInterceptor.java
+++ b/documentation/src/main/java/interceptors/MyIncomingInterceptor.java
@@ -1,16 +1,18 @@
 package interceptors;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.reactive.messaging.IncomingInterceptor;
-import jakarta.enterprise.context.ApplicationScoped;
-import org.eclipse.microprofile.reactive.messaging.Message;
 
 @Identifier("channel-a")
 @ApplicationScoped
 public class MyIncomingInterceptor implements IncomingInterceptor {
 
     @Override
-    public Message<?> onMessage(Message<?> message) {
+    public Message<?> afterMessageReceive(Message<?> message) {
         return message.withPayload("changed " + message.getPayload());
     }
 

--- a/documentation/src/main/java/interceptors/MyIncomingInterceptor.java
+++ b/documentation/src/main/java/interceptors/MyIncomingInterceptor.java
@@ -1,16 +1,13 @@
 package interceptors;
 
-import jakarta.enterprise.context.ApplicationScoped;
-
-import org.eclipse.microprofile.reactive.messaging.Message;
-
 import io.smallrye.common.annotation.Identifier;
-import io.smallrye.reactive.messaging.OutgoingInterceptor;
-import io.smallrye.reactive.messaging.OutgoingMessageMetadata;
+import io.smallrye.reactive.messaging.IncomingInterceptor;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.reactive.messaging.Message;
 
 @Identifier("channel-a")
 @ApplicationScoped
-public class MyInterceptor implements OutgoingInterceptor {
+public class MyIncomingInterceptor implements IncomingInterceptor {
 
     @Override
     public Message<?> onMessage(Message<?> message) {
@@ -19,12 +16,11 @@ public class MyInterceptor implements OutgoingInterceptor {
 
     @Override
     public void onMessageAck(Message<?> message) {
-        message.getMetadata(OutgoingMessageMetadata.class)
-                .ifPresent(m -> m.getResult());
+        // Called after message ack
     }
 
     @Override
     public void onMessageNack(Message<?> message, Throwable failure) {
-
+        // Called after message nack
     }
 }

--- a/documentation/src/main/java/interceptors/MyOutgoingInterceptor.java
+++ b/documentation/src/main/java/interceptors/MyOutgoingInterceptor.java
@@ -1,0 +1,30 @@
+package interceptors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.reactive.messaging.OutgoingInterceptor;
+import io.smallrye.reactive.messaging.OutgoingMessageMetadata;
+
+@Identifier("channel-a")
+@ApplicationScoped
+public class MyOutgoingInterceptor implements OutgoingInterceptor {
+
+    @Override
+    public Message<?> onMessage(Message<?> message) {
+        return message.withPayload("changed " + message.getPayload());
+    }
+
+    @Override
+    public void onMessageAck(Message<?> message) {
+        message.getMetadata(OutgoingMessageMetadata.class)
+                .ifPresent(m -> m.getResult());
+    }
+
+    @Override
+    public void onMessageNack(Message<?> message, Throwable failure) {
+
+    }
+}

--- a/documentation/src/main/java/observability/ContextMessageObservationCollector.java
+++ b/documentation/src/main/java/observability/ContextMessageObservationCollector.java
@@ -1,0 +1,57 @@
+package observability;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.reactive.messaging.observation.DefaultMessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservationCollector;
+import io.smallrye.reactive.messaging.observation.ObservationContext;
+
+@ApplicationScoped
+public class ContextMessageObservationCollector
+        implements MessageObservationCollector<ContextMessageObservationCollector.MyContext> {
+
+    @Override
+    public MyContext initObservation(String channel, boolean incoming, boolean emitter) {
+        // Called on observation setup, per channel
+        // if returned null the observation for that channel is disabled
+        return new MyContext(channel, incoming, emitter);
+    }
+
+    @Override
+    public MessageObservation onNewMessage(String channel, Message<?> message, MyContext ctx) {
+        // Called after message has been created
+        return new DefaultMessageObservation(channel);
+    }
+
+    public static class MyContext implements ObservationContext {
+
+        private final String channel;
+        private final boolean incoming;
+        private final boolean emitter;
+
+        public MyContext(String channel, boolean incoming, boolean emitter) {
+            this.channel = channel;
+            this.incoming = incoming;
+            this.emitter = emitter;
+        }
+
+        @Override
+        public void complete(MessageObservation observation) {
+            // called after message processing has completed and observation is done
+            // register duration
+            Duration duration = observation.getCompletionDuration();
+            Throwable reason = observation.getReason();
+            if (reason != null) {
+                // message was nacked
+            } else {
+                // message was acked successfully
+            }
+        }
+    }
+
+}

--- a/documentation/src/main/java/observability/SimpleMessageObservationCollector.java
+++ b/documentation/src/main/java/observability/SimpleMessageObservationCollector.java
@@ -1,0 +1,21 @@
+package observability;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.reactive.messaging.observation.DefaultMessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservationCollector;
+import io.smallrye.reactive.messaging.observation.ObservationContext;
+
+@ApplicationScoped
+public class SimpleMessageObservationCollector implements MessageObservationCollector<ObservationContext> {
+
+    @Override
+    public MessageObservation onNewMessage(String channel, Message<?> message, ObservationContext ctx) {
+        // Called after message has been created
+        return new DefaultMessageObservation(channel);
+    }
+
+}

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/AmqpMessage.java
@@ -4,8 +4,8 @@ import static io.smallrye.reactive.messaging.providers.locals.ContextAwareMessag
 
 import java.util.ArrayList;
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.AmqpSequence;
@@ -96,7 +96,7 @@ public class AmqpMessage<T> implements ContextAwareMessage<T>, MetadataInjectabl
     }
 
     @Override
-    public CompletionStage<Void> ack() {
+    public CompletionStage<Void> ack(Metadata metadata) {
         // We must switch to the context having created the message.
         // This context is passed when this instance of message is created.
         // It's more a Vert.x AMQP client issue which should ensure calling `accepted` on the right context.
@@ -229,12 +229,12 @@ public class AmqpMessage<T> implements ContextAwareMessage<T>, MetadataInjectabl
     }
 
     @Override
-    public Supplier<CompletionStage<Void>> getAck() {
+    public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
         return this::ack;
     }
 
     @Override
-    public Function<Throwable, CompletionStage<Void>> getNack() {
+    public BiFunction<Throwable, Metadata, CompletionStage<Void>> getNackWithMetadata() {
         return this::nack;
     }
 

--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/OutgoingAmqpMessage.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/OutgoingAmqpMessage.java
@@ -2,8 +2,8 @@ package io.smallrye.reactive.messaging.amqp;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.eclipse.microprofile.reactive.messaging.Metadata;
 
@@ -95,7 +95,7 @@ public class OutgoingAmqpMessage<T> extends AmqpMessage<T>
     }
 
     @Override
-    public CompletionStage<Void> ack() {
+    public CompletionStage<Void> ack(Metadata metadata) {
         return CompletableFuture.completedFuture(null);
     }
 
@@ -105,12 +105,12 @@ public class OutgoingAmqpMessage<T> extends AmqpMessage<T>
     }
 
     @Override
-    public Supplier<CompletionStage<Void>> getAck() {
+    public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
         return this::ack;
     }
 
     @Override
-    public Function<Throwable, CompletionStage<Void>> getNack() {
+    public BiFunction<Throwable, Metadata, CompletionStage<Void>> getNackWithMetadata() {
         return this::nack;
     }
 

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ConcurrentProcessorTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ConcurrentProcessorTest.java
@@ -214,7 +214,7 @@ public class ConcurrentProcessorTest extends AmqpBrokerTestBase {
             int value = input.getPayload();
             int next = value + 1;
             perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-            return Uni.createFrom().item(Message.of(next, input::ack))
+            return Uni.createFrom().item(input.withPayload(next))
                     .onItem().delayIt().by(Duration.ofMillis(100));
         }
 
@@ -246,7 +246,7 @@ public class ConcurrentProcessorTest extends AmqpBrokerTestBase {
                         int value = input.getPayload();
                         int next = value + 1;
                         perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-                        return Uni.createFrom().item(Message.of(next, input::ack))
+                        return Uni.createFrom().item(input.withPayload(next))
                                 .onItem().delayIt().by(Duration.ofMillis(100));
                     });
         }

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ConsumptionBean.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ConsumptionBean.java
@@ -20,7 +20,7 @@ public class ConsumptionBean {
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(AmqpMessage<Integer> input) {
         int value = input.getPayload();
-        return Message.of(value + 1, input::ack);
+        return input.withPayload(value + 1);
     }
 
     @Incoming("sink")

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/NullProducingBean.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/NullProducingBean.java
@@ -18,7 +18,7 @@ public class NullProducingBean {
     @Outgoing("sink")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(Message<Integer> input) {
-        return Message.of(null, input::ack);
+        return input.withPayload(null);
     }
 
     @Outgoing("data")

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBean.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBean.java
@@ -18,7 +18,7 @@ public class ProducingBean {
     @Outgoing("sink")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(Message<Integer> input) {
-        return Message.of(input.getPayload() + 1, input::ack);
+        return input.withPayload(input.getPayload() + 1);
     }
 
     @Outgoing("data")

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBeanUsingOutboundMetadata.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/ProducingBeanUsingOutboundMetadata.java
@@ -23,7 +23,7 @@ public class ProducingBeanUsingOutboundMetadata {
                 .withAddress("metadata-address")
                 .build();
 
-        return Message.of(input.getPayload() + 1, input::ack).addMetadata(metadata);
+        return input.withPayload(input.getPayload() + 1).addMetadata(metadata);
     }
 
     @Outgoing("data")

--- a/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/CamelMessage.java
+++ b/smallrye-reactive-messaging-camel/src/main/java/io/smallrye/reactive/messaging/camel/CamelMessage.java
@@ -1,7 +1,7 @@
 package io.smallrye.reactive.messaging.camel;
 
 import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import org.apache.camel.Exchange;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -43,7 +43,7 @@ public class CamelMessage<T> implements Message<T> {
     }
 
     @Override
-    public Function<Throwable, CompletionStage<Void>> getNack() {
+    public BiFunction<Throwable, Metadata, CompletionStage<Void>> getNackWithMetadata() {
         return this::nack;
     }
 }

--- a/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubMessage.java
+++ b/smallrye-reactive-messaging-gcp-pubsub/src/main/java/io/smallrye/reactive/messaging/gcp/pubsub/PubSubMessage.java
@@ -5,9 +5,10 @@ import static io.smallrye.reactive.messaging.gcp.pubsub.i18n.PubSubMessages.msg;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.pubsub.v1.PubsubMessage;
@@ -38,7 +39,7 @@ public class PubSubMessage implements Message<String> {
     }
 
     @Override
-    public CompletionStage<Void> ack() {
+    public CompletionStage<Void> ack(Metadata metadata) {
         if (ackReplyConsumer != null) {
             ackReplyConsumer.ack();
         }
@@ -46,7 +47,7 @@ public class PubSubMessage implements Message<String> {
     }
 
     @Override
-    public Supplier<CompletionStage<Void>> getAck() {
+    public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
         return this::ack;
     }
 

--- a/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/IncomingJmsMessage.java
+++ b/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/IncomingJmsMessage.java
@@ -4,7 +4,7 @@ import static io.smallrye.reactive.messaging.jms.i18n.JmsExceptions.ex;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
@@ -104,12 +104,12 @@ public class IncomingJmsMessage<T> implements org.eclipse.microprofile.reactive.
     }
 
     @Override
-    public Supplier<CompletionStage<Void>> getAck() {
+    public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
         return this::ack;
     }
 
     @Override
-    public CompletionStage<Void> ack() {
+    public CompletionStage<Void> ack(Metadata metadata) {
         return Uni.createFrom().voidItem()
                 .onItem().invoke(m -> {
                     try {

--- a/smallrye-reactive-messaging-kafka/revapi.json
+++ b/smallrye-reactive-messaging-kafka/revapi.json
@@ -36,7 +36,86 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+        {
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method java.util.concurrent.CompletionStage<java.lang.Void> io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord<K, T>::ack()",
+        "new": "method java.util.concurrent.CompletionStage<java.lang.Void> io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord<K, T>::ack(org.eclipse.microprofile.reactive.messaging.Metadata)",
+        "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.removed",
+            "old": "method java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>> io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord<K, T>::getAck()",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.removed",
+            "old": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord<K, T>::getNack()",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.numberOfParametersChanged",
+            "old": "method java.util.concurrent.CompletionStage<java.lang.Void> io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordBatch<K, T>::ack()",
+            "new": "method java.util.concurrent.CompletionStage<java.lang.Void> io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordBatch<K, T>::ack(org.eclipse.microprofile.reactive.messaging.Metadata)",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.removed",
+            "old": "method java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>> io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordBatch<K, T>::getAck()",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.removed",
+            "old": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> io.smallrye.reactive.messaging.kafka.IncomingKafkaRecordBatch<K, T>::getNack()",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.addedToInterface",
+            "new": "method io.smallrye.mutiny.Uni<java.util.Map<java.lang.String, java.util.List<org.apache.kafka.common.PartitionInfo>>> io.smallrye.reactive.messaging.kafka.KafkaConsumer<K, V>::lisTopics()",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.addedToInterface",
+            "new": "method io.smallrye.mutiny.Uni<java.util.Map<java.lang.String, java.util.List<org.apache.kafka.common.PartitionInfo>>> io.smallrye.reactive.messaging.kafka.KafkaConsumer<K, V>::lisTopics(java.time.Duration)",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.addedToInterface",
+            "new": "method io.smallrye.mutiny.Uni<java.util.List<org.apache.kafka.common.PartitionInfo>> io.smallrye.reactive.messaging.kafka.KafkaConsumer<K, V>::partitionsFor(java.lang.String)",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.parameterTypeChanged",
+            "old": "parameter void io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecord<K, T>::<init>(java.lang.String, K, T, java.time.Instant, int, org.apache.kafka.common.header.Headers, ===java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>>===, java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>, org.eclipse.microprofile.reactive.messaging.Metadata)",
+            "new": "parameter void io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecord<K, T>::<init>(java.lang.String, K, T, java.time.Instant, int, org.apache.kafka.common.header.Headers, ===java.util.function.Function<org.eclipse.microprofile.reactive.messaging.Metadata, java.util.concurrent.CompletionStage<java.lang.Void>>===, java.util.function.BiFunction<java.lang.Throwable, org.eclipse.microprofile.reactive.messaging.Metadata, java.util.concurrent.CompletionStage<java.lang.Void>>, org.eclipse.microprofile.reactive.messaging.Metadata)",
+            "parameterIndex": "6",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.parameterTypeChanged",
+            "old": "parameter void io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecord<K, T>::<init>(java.lang.String, K, T, java.time.Instant, int, org.apache.kafka.common.header.Headers, java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>>, ===java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>>===, org.eclipse.microprofile.reactive.messaging.Metadata)",
+            "new": "parameter void io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecord<K, T>::<init>(java.lang.String, K, T, java.time.Instant, int, org.apache.kafka.common.header.Headers, java.util.function.Function<org.eclipse.microprofile.reactive.messaging.Metadata, java.util.concurrent.CompletionStage<java.lang.Void>>, ===java.util.function.BiFunction<java.lang.Throwable, org.eclipse.microprofile.reactive.messaging.Metadata, java.util.concurrent.CompletionStage<java.lang.Void>>===, org.eclipse.microprofile.reactive.messaging.Metadata)",
+            "parameterIndex": "7",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.numberOfParametersChanged",
+            "old": "method java.util.concurrent.CompletionStage<java.lang.Void> io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecord<K, T>::ack()",
+            "new": "method java.util.concurrent.CompletionStage<java.lang.Void> io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecord<K, T>::ack(org.eclipse.microprofile.reactive.messaging.Metadata)",
+            "justification": "Added Message metadata propagation"
+
+        },
+        {
+            "code": "java.method.removed",
+            "old": "method java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>> io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecord<K, T>::getAck()",
+            "justification": "Added Message metadata propagation"
+        },
+        {
+            "code": "java.method.removed",
+            "old": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecord<K, T>::getNack()",
+            "justification": "Added Message metadata propagation"
+        }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecord.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/IncomingKafkaRecord.java
@@ -3,8 +3,8 @@ package io.smallrye.reactive.messaging.kafka;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
@@ -113,17 +113,17 @@ public class IncomingKafkaRecord<K, T> implements KafkaRecord<K, T>, MetadataInj
     }
 
     @Override
-    public Supplier<CompletionStage<Void>> getAck() {
+    public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
         return this::ack;
     }
 
     @Override
-    public Function<Throwable, CompletionStage<Void>> getNack() {
+    public BiFunction<Throwable, Metadata, CompletionStage<Void>> getNackWithMetadata() {
         return this::nack;
     }
 
     @Override
-    public CompletionStage<Void> ack() {
+    public CompletionStage<Void> ack(Metadata metadata) {
         return commitHandler.handle(this).subscribeAsCompletionStage();
     }
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumer.java
@@ -1,6 +1,8 @@
 package io.smallrye.reactive.messaging.kafka;
 
+import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -8,6 +10,7 @@ import java.util.function.Function;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
 import io.smallrye.common.annotation.CheckReturnValue;
@@ -209,4 +212,12 @@ public interface KafkaConsumer<K, V> {
     @CheckReturnValue
     Uni<Void> resetToLastCommittedPositions();
 
+    @CheckReturnValue
+    Uni<Map<String, List<PartitionInfo>>> lisTopics();
+
+    @CheckReturnValue
+    Uni<Map<String, List<PartitionInfo>>> lisTopics(Duration timeout);
+
+    @CheckReturnValue
+    Uni<List<PartitionInfo>> partitionsFor(String topic);
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.literal.NamedLiteral;
 
 import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -507,6 +508,30 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     public Uni<Void> seekToEnd(Collection<TopicPartition> partitions) {
         return runOnPollingThread(c -> {
             c.seekToEnd(partitions);
+        });
+    }
+
+    @Override
+    @CheckReturnValue
+    public Uni<Map<String, List<PartitionInfo>>> lisTopics() {
+        return runOnPollingThread(consumer -> {
+            return consumer.listTopics();
+        });
+    }
+
+    @Override
+    @CheckReturnValue
+    public Uni<Map<String, List<PartitionInfo>>> lisTopics(Duration timeout) {
+        return runOnPollingThread(consumer -> {
+            return consumer.listTopics(timeout);
+        });
+    }
+
+    @Override
+    @CheckReturnValue
+    public Uni<List<PartitionInfo>> partitionsFor(String topic) {
+        return runOnPollingThread(consumer -> {
+            return consumer.partitionsFor(topic);
         });
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConcurrentProcessorTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConcurrentProcessorTest.java
@@ -157,7 +157,7 @@ public class ConcurrentProcessorTest extends KafkaCompanionTestBase {
             int value = input.getPayload();
             int next = value + 1;
             perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-            return Uni.createFrom().item(Message.of(next, input::ack))
+            return Uni.createFrom().item(input.withPayload(next))
                     .onItem().delayIt().by(Duration.ofMillis(100));
         }
 
@@ -189,7 +189,7 @@ public class ConcurrentProcessorTest extends KafkaCompanionTestBase {
                         int value = input.getPayload();
                         int next = value + 1;
                         perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-                        return Uni.createFrom().item(Message.of(next, input::ack))
+                        return Uni.createFrom().item(input.withPayload(next))
                                 .onItem().delayIt().by(Duration.ofMillis(100));
                     });
         }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionBeanUsingRawMessage.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ConsumptionBeanUsingRawMessage.java
@@ -21,7 +21,7 @@ public class ConsumptionBeanUsingRawMessage {
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(Message<Integer> input) {
         kafka.add(input);
-        return Message.of(input.getPayload() + 1, input::ack);
+        return input.withPayload(input.getPayload() + 1);
     }
 
     @Incoming("sink")

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingBean.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingBean.java
@@ -18,7 +18,7 @@ public class ProducingBean {
     @Outgoing("output")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(Message<Integer> input) {
-        return Message.of(input.getPayload() + 1, input::ack);
+        return input.withPayload(input.getPayload() + 1);
     }
 
     @Outgoing("data")

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingMessageWithHeaderBean.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/ProducingMessageWithHeaderBean.java
@@ -30,7 +30,7 @@ public class ProducingMessageWithHeaderBean {
                 Metadata.of(
                         OutgoingKafkaRecordMetadata.builder().withKey(Integer.toString(input.getPayload()))
                                 .withHeaders(list).build()),
-                input::ack);
+                m -> input.ack(m));
     }
 
     @Outgoing("data")

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
@@ -36,6 +36,8 @@ import io.smallrye.reactive.messaging.providers.extension.HealthCenter;
 import io.smallrye.reactive.messaging.providers.extension.LegacyEmitterFactoryImpl;
 import io.smallrye.reactive.messaging.providers.extension.MediatorManager;
 import io.smallrye.reactive.messaging.providers.extension.MutinyEmitterFactoryImpl;
+import io.smallrye.reactive.messaging.providers.extension.ObservationDecorator;
+import io.smallrye.reactive.messaging.providers.extension.OutgoingObservationDecorator;
 import io.smallrye.reactive.messaging.providers.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.providers.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.providers.impl.ConnectorFactories;
@@ -102,6 +104,8 @@ public class WeldTestBase {
         weld.addBeanClass(MetricDecorator.class);
         weld.addBeanClass(MicrometerDecorator.class);
         weld.addBeanClass(ContextDecorator.class);
+        weld.addBeanClass(ObservationDecorator.class);
+        weld.addBeanClass(OutgoingObservationDecorator.class);
         weld.disableDiscovery();
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/health/SinkHealthCheckTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/health/SinkHealthCheckTest.java
@@ -181,7 +181,7 @@ public class SinkHealthCheckTest extends KafkaCompanionTestBase {
         @Outgoing("output")
         @Acknowledgment(Acknowledgment.Strategy.MANUAL)
         public Message<Integer> process(Message<Integer> input) {
-            return Message.of(input.getPayload() + 1, input::ack)
+            return input.withPayload(input.getPayload() + 1)
                     .addMetadata(OutgoingKafkaRecordMetadata.builder().withTopic(topic).build());
         }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/metrics/ObservationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/metrics/ObservationTest.java
@@ -1,0 +1,251 @@
+package io.smallrye.reactive.messaging.kafka.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
+import io.smallrye.reactive.messaging.kafka.metrics.ObservationTest.MyReactiveMessagingMessageObservationCollector.KafkaMessageObservation;
+import io.smallrye.reactive.messaging.observation.DefaultMessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservationCollector;
+import io.smallrye.reactive.messaging.observation.ObservationContext;
+
+public class ObservationTest extends KafkaCompanionTestBase {
+
+    @Test
+    void testConsumeIndividualMessages() {
+        addBeans(MyReactiveMessagingMessageObservationCollector.class);
+        addBeans(MyConsumingApp.class);
+
+        runApplication(kafkaConfig("mp.messaging.incoming.kafka", false)
+                .with("topic", topic)
+                .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName())
+                .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()));
+
+        companion.produceStrings()
+                .fromMulti(Multi.createFrom().range(0, 5).map(i -> new ProducerRecord<>(topic, null, Integer.toString(i))));
+
+        MyReactiveMessagingMessageObservationCollector reporter = get(MyReactiveMessagingMessageObservationCollector.class);
+        await().untilAsserted(() -> {
+            assertThat(reporter.getObservations()).hasSize(5);
+            assertThat(reporter.getObservations()).allSatisfy(obs -> {
+                assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+                assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+                assertThat(obs.getReason()).isNull();
+            });
+        });
+    }
+
+    @Test
+    void testConsumeBatchMessages() {
+        addBeans(MyReactiveMessagingMessageObservationCollector.class);
+        addBeans(MyBatchConsumingApp.class);
+
+        runApplication(kafkaConfig("mp.messaging.incoming.kafka", false)
+                .with("topic", topic)
+                .with("batch", true)
+                .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName())
+                .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()));
+
+        companion.produceStrings()
+                .fromMulti(Multi.createFrom().range(0, 1000).map(i -> new ProducerRecord<>(topic, null, Integer.toString(i))));
+
+        MyReactiveMessagingMessageObservationCollector reporter = get(MyReactiveMessagingMessageObservationCollector.class);
+        MyBatchConsumingApp batches = get(MyBatchConsumingApp.class);
+        await().untilAsserted(() -> {
+            assertThat(batches.count()).isEqualTo(1000);
+            assertThat(reporter.getObservations()).allSatisfy(obs -> {
+                assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+                assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+                assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+                assertThat(obs.getReason()).isNull();
+            });
+        });
+    }
+
+    @Test
+    void testProducer() {
+        addBeans(MyReactiveMessagingMessageObservationCollector.class);
+        addBeans(MyProducerApp.class);
+
+        runApplication(kafkaConfig("mp.messaging.outgoing.kafka", false)
+                .with("topic", topic)
+                .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+                .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+
+        MyReactiveMessagingMessageObservationCollector reporter = get(MyReactiveMessagingMessageObservationCollector.class);
+        MyProducerApp producer = get(MyProducerApp.class);
+        await().untilAsserted(() -> {
+            assertThat(producer.count()).isEqualTo(5);
+            assertThat(reporter.getObservations()).hasSize(5);
+            assertThat(reporter.getObservations()).allSatisfy(obs -> {
+                assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+                assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+                assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+                assertThat(obs.getReason()).isNull();
+            });
+        });
+    }
+
+    @Test
+    void testEmitterProducer() {
+        addBeans(MyReactiveMessagingMessageObservationCollector.class);
+        addBeans(MyEmitterProducerApp.class);
+
+        runApplication(kafkaConfig("mp.messaging.outgoing.kafka", false)
+                .with("topic", topic)
+                .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+                .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+
+        MyReactiveMessagingMessageObservationCollector reporter = get(MyReactiveMessagingMessageObservationCollector.class);
+        MyEmitterProducerApp producer = get(MyEmitterProducerApp.class);
+        producer.produce();
+        await().untilAsserted(() -> {
+            assertThat(producer.count()).isEqualTo(5);
+            assertThat(reporter.getObservations()).hasSize(5);
+            assertThat(reporter.getObservations()).allSatisfy(obs -> {
+                assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+                assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+                assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+                assertThat(obs.getReason()).isNull();
+            });
+        });
+    }
+
+    @ApplicationScoped
+    public static class MyConsumingApp {
+        @Incoming("kafka")
+        public void consume(String ignored, KafkaMessageObservation metadata) {
+            assertThat(metadata).isNotNull();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyBatchConsumingApp {
+
+        AtomicInteger count = new AtomicInteger();
+
+        @Incoming("kafka")
+        public void consume(List<String> s, KafkaMessageObservation metadata) {
+            assertThat(metadata).isNotNull();
+            count.addAndGet(s.size());
+        }
+
+        public int count() {
+            return count.get();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyProducerApp {
+
+        AtomicInteger acked = new AtomicInteger();
+
+        @Outgoing("kafka")
+        public Multi<Message<String>> produce() {
+            return Multi.createFrom().items("1", "2", "3", "4", "5")
+                    .map(s -> Message.of(s, () -> {
+                        acked.incrementAndGet();
+                        return CompletableFuture.completedFuture(null);
+                    }));
+        }
+
+        public int count() {
+            return acked.get();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyEmitterProducerApp {
+        AtomicInteger acked = new AtomicInteger();
+
+        @Inject
+        @Channel("kafka")
+        Emitter<String> emitter;
+
+        public void produce() {
+            for (int i = 0; i < 5; i++) {
+                emitter.send(Message.of(String.valueOf(i + 1), () -> {
+                    acked.incrementAndGet();
+                    return CompletableFuture.completedFuture(null);
+                }));
+            }
+        }
+
+        public int count() {
+            return acked.get();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyReactiveMessagingMessageObservationCollector
+            implements MessageObservationCollector<ObservationContext> {
+
+        private final List<MessageObservation> observations = new CopyOnWriteArrayList<>();
+
+        @Override
+        public MessageObservation onNewMessage(String channel, Message<?> message, ObservationContext ctx) {
+            KafkaMessageObservation observation = new KafkaMessageObservation(channel, message);
+            observations.add(observation);
+            return observation;
+        }
+
+        public List<MessageObservation> getObservations() {
+            return observations;
+        }
+
+        public static class KafkaMessageObservation extends DefaultMessageObservation {
+            final long recordTs;
+            final long createdMs;
+            volatile long completedMs;
+
+            public KafkaMessageObservation(String channel, Message<?> message) {
+                super(channel);
+                this.createdMs = System.currentTimeMillis();
+                Optional<IncomingKafkaRecordMetadata> metadata = message.getMetadata(IncomingKafkaRecordMetadata.class);
+                if (metadata.isPresent()) {
+                    Instant inst = metadata.get().getTimestamp();
+                    recordTs = inst.toEpochMilli();
+                    System.out.println("record " + recordTs);
+                } else {
+                    recordTs = 0L;
+                }
+            }
+
+            @Override
+            public void onMessageAck(Message<?> message) {
+                super.onMessageAck(message);
+                completedMs = System.currentTimeMillis();
+                System.out.println("completed in " + completedMs);
+                done = true;
+            }
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-mqtt/revapi.json
+++ b/smallrye-reactive-messaging-mqtt/revapi.json
@@ -21,7 +21,11 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [ {
+        "code": "java.method.removed",
+        "old": "method java.util.function.Function<java.lang.Throwable, java.util.concurrent.CompletionStage<java.lang.Void>> io.smallrye.reactive.messaging.mqtt.ReceivingMqttMessage::getNack()",
+        "justification": "Added Message metadata propagation"
+    }]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/ReceivingMqttMessage.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/ReceivingMqttMessage.java
@@ -3,7 +3,7 @@ package io.smallrye.reactive.messaging.mqtt;
 import static io.smallrye.reactive.messaging.providers.locals.ContextAwareMessage.captureContextMetadata;
 
 import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import org.eclipse.microprofile.reactive.messaging.Metadata;
 
@@ -64,7 +64,7 @@ public class ReceivingMqttMessage implements MqttMessage<byte[]> {
     }
 
     @Override
-    public Function<Throwable, CompletionStage<Void>> getNack() {
+    public BiFunction<Throwable, Metadata, CompletionStage<Void>> getNackWithMetadata() {
         return this::nack;
     }
 }

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessage.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/SendingMqttMessage.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.mqtt;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.reactive.messaging.Metadata;
@@ -32,7 +33,7 @@ public final class SendingMqttMessage<T> implements MqttMessage<T> {
     }
 
     @Override
-    public CompletionStage<Void> ack() {
+    public CompletionStage<Void> ack(Metadata metadata) {
         if (ack != null) {
             return ack.get();
         }
@@ -40,7 +41,7 @@ public final class SendingMqttMessage<T> implements MqttMessage<T> {
     }
 
     @Override
-    public Supplier<CompletionStage<Void>> getAck() {
+    public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
         return this::ack;
     }
 

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ConcurrentProcessorTest.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ConcurrentProcessorTest.java
@@ -197,7 +197,7 @@ public class ConcurrentProcessorTest extends MqttTestBase {
             int value = Integer.parseInt(input.getPayload());
             int next = value + 1;
             perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-            return Uni.createFrom().item(Message.of(next, input::ack))
+            return Uni.createFrom().item(input.withPayload(next))
                     .onItem().delayIt().by(Duration.ofMillis(100));
         }
 
@@ -229,7 +229,7 @@ public class ConcurrentProcessorTest extends MqttTestBase {
                         int value = Integer.parseInt(input.getPayload());
                         int next = value + 1;
                         perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-                        return Uni.createFrom().item(Message.of(next, input::ack))
+                        return Uni.createFrom().item(input.withPayload(next))
                                 .onItem().delayIt().by(Duration.ofMillis(100));
                     });
         }

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/NullProducingBean.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/NullProducingBean.java
@@ -18,7 +18,7 @@ public class NullProducingBean {
     @Outgoing("sink")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(Message<Integer> input) {
-        return Message.of(null, input::ack);
+        return input.withPayload(null);
     }
 
     @Outgoing("data")

--- a/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ProducingBean.java
+++ b/smallrye-reactive-messaging-mqtt/src/test/java/io/smallrye/reactive/messaging/mqtt/ProducingBean.java
@@ -18,7 +18,7 @@ public class ProducingBean {
     @Outgoing("sink")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(Message<Integer> input) {
-        return Message.of(input.getPayload() + 1, input::ack);
+        return input.withPayload(input.getPayload() + 1);
     }
 
     @Outgoing("data")

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/IncomingInterceptorDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/IncomingInterceptorDecorator.java
@@ -1,0 +1,61 @@
+package io.smallrye.reactive.messaging.providers;
+
+import static io.smallrye.reactive.messaging.providers.helpers.CDIUtils.getInstanceById;
+import static io.smallrye.reactive.messaging.providers.helpers.CDIUtils.getSortedInstances;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.unchecked.Unchecked;
+import io.smallrye.reactive.messaging.IncomingInterceptor;
+import io.smallrye.reactive.messaging.PublisherDecorator;
+
+/**
+ * Decorator to support {@link IncomingInterceptor}s.
+ * High priority value to be called after other decorators.
+ */
+@ApplicationScoped
+public class IncomingInterceptorDecorator implements PublisherDecorator {
+
+    @Any
+    @Inject
+    Instance<IncomingInterceptor> interceptors;
+
+    @Override
+    public int getPriority() {
+        return 500;
+    }
+
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> publisher, String channelName,
+            boolean isConnector) {
+        Multi<? extends Message<?>> multi = publisher;
+        if (isConnector) {
+            Instance<IncomingInterceptor> instances = getInstanceById(interceptors, channelName);
+            if (instances.isUnsatisfied()) {
+                instances = interceptors.select().select(Default.Literal.INSTANCE);
+            }
+            List<IncomingInterceptor> matching = getSortedInstances(instances);
+            if (!matching.isEmpty()) {
+                IncomingInterceptor interceptor = matching.get(0);
+                multi = multi.map(m -> {
+                    Message<?> before = interceptor.onMessage(m);
+                    Message<?> withAck = before.withAck(() -> before.ack()
+                            .thenAccept(Unchecked.consumer(x -> interceptor.onMessageAck(before))));
+                    return withAck.withNack(t -> withAck.nack(t)
+                            .thenAccept(Unchecked.consumer(x -> interceptor.onMessageNack(withAck, t))));
+                });
+            }
+        }
+        return multi;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/IncomingInterceptorDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/IncomingInterceptorDecorator.java
@@ -47,11 +47,11 @@ public class IncomingInterceptorDecorator implements PublisherDecorator {
             if (!matching.isEmpty()) {
                 IncomingInterceptor interceptor = matching.get(0);
                 multi = multi.map(m -> {
-                    Message<?> before = interceptor.onMessage(m);
-                    Message<?> withAck = before.withAck(() -> before.ack()
+                    Message<?> before = interceptor.afterMessageReceive(m);
+                    Message<?> withAck = before.withAckWithMetadata(metadata -> before.ack(metadata)
                             .thenAccept(Unchecked.consumer(x -> interceptor.onMessageAck(before))));
-                    return withAck.withNack(t -> withAck.nack(t)
-                            .thenAccept(Unchecked.consumer(x -> interceptor.onMessageNack(withAck, t))));
+                    return withAck.withNackWithMetadata((reason, metadata) -> withAck.nack(reason, metadata)
+                            .thenAccept(Unchecked.consumer(x -> interceptor.onMessageNack(withAck, reason))));
                 });
             }
         }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/OutgoingInterceptorDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/OutgoingInterceptorDecorator.java
@@ -49,10 +49,10 @@ public class OutgoingInterceptorDecorator implements SubscriberDecorator {
                 OutgoingInterceptor interceptor = matching.get(0);
                 multi = multi.map(m -> {
                     Message<?> before = interceptor.onMessage(m.addMetadata(new OutgoingMessageMetadata<>()));
-                    Message<?> withAck = before.withAck(() -> before.ack()
+                    Message<?> withAck = before.withAckWithMetadata((metadata) -> before.ack(before.getMetadata())
                             .thenAccept(Unchecked.consumer(x -> interceptor.onMessageAck(before))));
-                    return withAck.withNack(t -> withAck.nack(t)
-                            .thenAccept(Unchecked.consumer(x -> interceptor.onMessageNack(withAck, t))));
+                    return withAck.withNackWithMetadata((throwable, metadata) -> withAck.nack(throwable, metadata)
+                            .thenAccept(Unchecked.consumer(x -> interceptor.onMessageNack(withAck, throwable))));
                 });
             }
         }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/OutgoingInterceptorDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/OutgoingInterceptorDecorator.java
@@ -48,7 +48,7 @@ public class OutgoingInterceptorDecorator implements SubscriberDecorator {
             if (!matching.isEmpty()) {
                 OutgoingInterceptor interceptor = matching.get(0);
                 multi = multi.map(m -> {
-                    Message<?> before = interceptor.onMessage(m.addMetadata(new OutgoingMessageMetadata<>()));
+                    Message<?> before = interceptor.beforeMessageSend(m.addMetadata(new OutgoingMessageMetadata<>()));
                     Message<?> withAck = before.withAckWithMetadata((metadata) -> before.ack(before.getMetadata())
                             .thenAccept(Unchecked.consumer(x -> interceptor.onMessageAck(before))));
                     return withAck.withNackWithMetadata((throwable, metadata) -> withAck.nack(throwable, metadata)

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ObservationDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ObservationDecorator.java
@@ -1,0 +1,104 @@
+package io.smallrye.reactive.messaging.providers.extension;
+
+import static io.smallrye.mutiny.unchecked.Unchecked.consumer;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.PublisherDecorator;
+import io.smallrye.reactive.messaging.observation.MessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservationCollector;
+import io.smallrye.reactive.messaging.observation.ObservationContext;
+import io.smallrye.reactive.messaging.providers.ProcessingException;
+
+@ApplicationScoped
+public class ObservationDecorator implements PublisherDecorator {
+
+    @Inject
+    @ConfigProperty(name = "smallrye.messaging.observation.enabled", defaultValue = "true")
+    boolean enabled;
+
+    @Inject
+    ChannelRegistry registry;
+
+    @Inject
+    Instance<MessageObservationCollector<?>> observationCollector;
+
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> multi, List<String> channelName,
+            boolean isConnector) {
+        String channel = channelName.isEmpty() ? null : channelName.get(0);
+        boolean isEmitter = registry.getEmitterNames().contains(channel);
+        if (observationCollector.isResolvable() && enabled && (isConnector || isEmitter)) {
+            // if this is an emitter channel than it is an outgoing channel => incoming=false
+            return decorateObservation(observationCollector.get(), multi, channel, !isEmitter, isEmitter);
+        }
+        return multi;
+    }
+
+    static Multi<? extends Message<?>> decorateObservation(
+            MessageObservationCollector<? extends ObservationContext> obsCollector,
+            Multi<? extends Message<?>> multi,
+            String channel,
+            boolean incoming,
+            boolean emitter) {
+        MessageObservationCollector<ObservationContext> collector = (MessageObservationCollector<ObservationContext>) obsCollector;
+        ObservationContext context = collector.initObservation(channel, incoming, emitter);
+        if (context == null) {
+            return multi;
+        }
+        return multi.map(message -> {
+            MessageObservation observation = collector.onNewMessage(channel, message, context);
+            if (observation != null) {
+                return message.addMetadata(observation)
+                        .thenApply(msg -> msg.withAckWithMetadata(metadata -> msg.ack(metadata)
+                                .thenAccept(consumer(x -> getObservationMetadata(metadata)
+                                        .ifPresent(obs -> {
+                                            obs.onMessageAck(msg);
+                                            context.complete(obs);
+                                        })))))
+                        .thenApply(msg -> msg.withNackWithMetadata((reason, metadata) -> {
+                            getObservationMetadata(metadata).ifPresent(consumer(obs -> {
+                                obs.onMessageNack(msg, extractReason(reason));
+                                context.complete(obs);
+                            }));
+                            return msg.nack(reason, metadata);
+                        }));
+            } else {
+                return message;
+            }
+        });
+    }
+
+    static Optional<MessageObservation> getObservationMetadata(Metadata metadata) {
+        for (Object item : metadata) {
+            if (item instanceof MessageObservation) {
+                return Optional.of((MessageObservation) item);
+            }
+        }
+        return Optional.empty();
+    }
+
+    static Throwable extractReason(Throwable reason) {
+        if (reason instanceof ProcessingException) {
+            Throwable cause = reason.getCause();
+            if (cause instanceof InvocationTargetException) {
+                cause = ((InvocationTargetException) cause).getTargetException();
+            }
+            return cause;
+        }
+        return reason;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/OutgoingObservationDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/OutgoingObservationDecorator.java
@@ -1,0 +1,43 @@
+package io.smallrye.reactive.messaging.providers.extension;
+
+import static io.smallrye.reactive.messaging.providers.extension.ObservationDecorator.decorateObservation;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.SubscriberDecorator;
+import io.smallrye.reactive.messaging.observation.MessageObservationCollector;
+
+@ApplicationScoped
+public class OutgoingObservationDecorator implements SubscriberDecorator {
+
+    @Inject
+    @ConfigProperty(name = "smallrye.messaging.observation.enabled", defaultValue = "true")
+    boolean enabled;
+
+    @Inject
+    ChannelRegistry registry;
+
+    @Inject
+    Instance<MessageObservationCollector<?>> observationCollector;
+
+    @Override
+    public Multi<? extends Message<?>> decorate(Multi<? extends Message<?>> multi, List<String> channelName,
+            boolean isConnector) {
+        String channel = channelName.isEmpty() ? null : channelName.get(0);
+        boolean isEmitter = registry.getEmitterNames().contains(channel);
+        if (observationCollector.isResolvable() && enabled && !isEmitter && isConnector) {
+            return decorateObservation(observationCollector.get(), multi, channel, false, false);
+        }
+        return multi;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/IncomingInterceptorTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/IncomingInterceptorTest.java
@@ -1,0 +1,140 @@
+package io.smallrye.reactive.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.common.annotation.Identifier;
+
+public class IncomingInterceptorTest extends WeldTestBaseWithoutTails {
+
+    @BeforeEach
+    void setupConfig() {
+        installConfig("src/test/resources/config/interceptor.properties");
+    }
+
+    @Test
+    public void testIncomingInterceptorWithIdentifier() {
+        addBeanClass(DefaultInterceptor.class);
+        addBeanClass(InterceptorBean.class);
+        addBeanClass(MyMessageConsumer.class);
+
+        initialize();
+
+        InterceptorBean interceptor = container.getBeanManager().createInstance()
+                .select(InterceptorBean.class, Identifier.Literal.of("B")).get();
+        MyMessageConsumer consumerBean = get(MyMessageConsumer.class);
+        await().until(() -> interceptor.acks() == 2);
+        await().until(() -> interceptor.nacks() == 1);
+        assertThat(interceptor.interceptedMessages()).isEqualTo(3);
+        assertThat(consumerBean.received())
+                .isNotEmpty()
+                .allSatisfy(o -> assertThat(o).isInstanceOf(InterceptorBean.class));
+    }
+
+    @Test
+    public void testIncomingInterceptorWithDefault() {
+        addBeanClass(DefaultInterceptor.class);
+        addBeanClass(MyMessageConsumer.class);
+
+        initialize();
+
+        DefaultInterceptor interceptor = get(DefaultInterceptor.class);
+        await().until(() -> interceptor.acks() == 2);
+        await().until(() -> interceptor.nacks() == 1);
+    }
+
+    @ApplicationScoped
+    public static class MyMessageConsumer {
+
+        List<Object> receivedMetadata = new CopyOnWriteArrayList<>();
+
+        @Incoming("B")
+        public CompletionStage<Void> consume(Message<Integer> msg) {
+            msg.getMetadata(InterceptorBean.class).ifPresent(receivedMetadata::add);
+            if (msg.getPayload() == 3) {
+                return msg.nack(new RuntimeException("boom!"));
+            }
+            return msg.ack();
+        }
+
+        public List<Object> received() {
+            return receivedMetadata;
+        }
+    }
+
+    @Identifier("B")
+    @ApplicationScoped
+    static class InterceptorBean implements IncomingInterceptor {
+
+        final AtomicInteger acks = new AtomicInteger();
+        final AtomicInteger nacks = new AtomicInteger();
+        final AtomicInteger interceptedMessages = new AtomicInteger();
+
+        @Override
+        public Message<?> onMessage(Message<?> message) {
+            interceptedMessages.incrementAndGet();
+            return message.addMetadata(this);
+        }
+
+        @Override
+        public void onMessageAck(Message<?> message) {
+            acks.incrementAndGet();
+        }
+
+        @Override
+        public void onMessageNack(Message<?> message, Throwable failure) {
+            nacks.incrementAndGet();
+        }
+
+        public int interceptedMessages() {
+            return interceptedMessages.get();
+        }
+
+        public int acks() {
+            return acks.get();
+        }
+
+        public int nacks() {
+            return nacks.get();
+        }
+
+    }
+
+    @ApplicationScoped
+    static class DefaultInterceptor implements IncomingInterceptor {
+
+        final AtomicInteger acks = new AtomicInteger();
+        final AtomicInteger nacks = new AtomicInteger();
+
+        @Override
+        public void onMessageAck(Message<?> message) {
+            acks.incrementAndGet();
+        }
+
+        @Override
+        public void onMessageNack(Message<?> message, Throwable failure) {
+            nacks.incrementAndGet();
+        }
+
+        public int acks() {
+            return acks.get();
+        }
+
+        public int nacks() {
+            return nacks.get();
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 
+import io.smallrye.reactive.messaging.providers.IncomingInterceptorDecorator;
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.se.SeContainerInitializer;
 import jakarta.enterprise.inject.spi.Extension;
@@ -119,6 +120,7 @@ public class WeldTestBaseWithoutTails {
                 MutinyEmitterFactoryImpl.class,
                 LegacyEmitterFactoryImpl.class,
                 OutgoingInterceptorDecorator.class,
+                IncomingInterceptorDecorator.class,
 
                 // SmallRye config
                 io.smallrye.config.inject.ConfigProducer.class);

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
@@ -9,7 +9,6 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 
-import io.smallrye.reactive.messaging.providers.IncomingInterceptorDecorator;
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.se.SeContainerInitializer;
 import jakarta.enterprise.inject.spi.Extension;
@@ -21,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.providers.IncomingInterceptorDecorator;
 import io.smallrye.reactive.messaging.providers.MediatorFactory;
 import io.smallrye.reactive.messaging.providers.OutgoingInterceptorDecorator;
 import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
@@ -32,6 +32,8 @@ import io.smallrye.reactive.messaging.providers.extension.HealthCenter;
 import io.smallrye.reactive.messaging.providers.extension.LegacyEmitterFactoryImpl;
 import io.smallrye.reactive.messaging.providers.extension.MediatorManager;
 import io.smallrye.reactive.messaging.providers.extension.MutinyEmitterFactoryImpl;
+import io.smallrye.reactive.messaging.providers.extension.ObservationDecorator;
+import io.smallrye.reactive.messaging.providers.extension.OutgoingObservationDecorator;
 import io.smallrye.reactive.messaging.providers.extension.ReactiveMessagingExtension;
 import io.smallrye.reactive.messaging.providers.impl.ConfiguredChannelFactory;
 import io.smallrye.reactive.messaging.providers.impl.ConnectorFactories;
@@ -121,7 +123,9 @@ public class WeldTestBaseWithoutTails {
                 LegacyEmitterFactoryImpl.class,
                 OutgoingInterceptorDecorator.class,
                 IncomingInterceptorDecorator.class,
-
+                // Observation Decorator
+                ObservationDecorator.class,
+                OutgoingObservationDecorator.class,
                 // SmallRye config
                 io.smallrye.config.inject.ConfigProducer.class);
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/AppendingDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/AppendingDecorator.java
@@ -19,7 +19,7 @@ public class AppendingDecorator implements PublisherDecorator {
     private Message<?> appendString(Message<?> message, String string) {
         if (message.getPayload() instanceof String) {
             String payload = (String) message.getPayload();
-            return Message.of(payload + "-" + string, message::ack);
+            return Message.of(payload + "-" + string, () -> message.ack());
         } else {
             return message;
         }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/AppendingDeprecatedDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/decorator/AppendingDeprecatedDecorator.java
@@ -17,7 +17,7 @@ public class AppendingDeprecatedDecorator implements io.smallrye.reactive.messag
     private Message<?> appendString(Message<?> message, String string) {
         if (message.getPayload() instanceof String) {
             String payload = (String) message.getPayload();
-            return Message.of(payload + "-" + string, message::ack);
+            return Message.of(payload + "-" + string, metadata -> message.ack(metadata));
         } else {
             return message;
         }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterObservationTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterObservationTest.java
@@ -1,0 +1,131 @@
+package io.smallrye.reactive.messaging.inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.smallrye.reactive.messaging.observation.DefaultMessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservationCollector;
+import io.smallrye.reactive.messaging.observation.ObservationContext;
+
+public class EmitterObservationTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    void testObservationPointsWhenEmittingPayloads() {
+        addBeanClass(MyMessageObservationCollector.class);
+        addBeanClass(MyComponentWithAnEmitterOfPayload.class);
+
+        initialize();
+
+        MyMessageObservationCollector observation = container.select(MyMessageObservationCollector.class).get();
+        MyComponentWithAnEmitterOfPayload component = get(MyComponentWithAnEmitterOfPayload.class);
+
+        component.emit(1);
+        component.emit(2);
+        component.emit(3);
+
+        await().untilAsserted(() -> assertThat(observation.getObservations()).hasSize(3));
+        assertThat(observation.getObservations()).allSatisfy(obs -> {
+            assertThat(obs.isDone()).isTrue();
+            assertThat(obs.getReason()).isNull();
+            assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+            assertThat(obs.getCompletionTime()).isNotEqualTo(-1);
+        });
+
+    }
+
+    @Test
+    void testObservationPointsWhenEmittingMessages() {
+        addBeanClass(MyComponentWithAnEmitterOfMessage.class);
+        addBeanClass(MyMessageObservationCollector.class);
+
+        initialize();
+
+        MyMessageObservationCollector observation = container.select(MyMessageObservationCollector.class).get();
+        MyComponentWithAnEmitterOfMessage component = get(MyComponentWithAnEmitterOfMessage.class);
+
+        component.emit(Message.of(1));
+        component.emit(Message.of(2));
+        component.emit(Message.of(3));
+
+        await().untilAsserted(() -> assertThat(observation.getObservations()).hasSize(3));
+        assertThat(observation.getObservations()).allSatisfy(obs -> {
+            assertThat(obs.isDone()).isTrue();
+            assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+            assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+            assertThat(obs.getCompletionTime()).isNotEqualTo(-1);
+        });
+
+        assertThat(observation.getObservations().get(2).getReason()).isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+    @ApplicationScoped
+    public static class MyComponentWithAnEmitterOfPayload {
+
+        @Inject
+        @Channel("output")
+        Emitter<Integer> emitter;
+
+        public void emit(int i) {
+            emitter.send(i);
+        }
+
+        @Incoming("output")
+        public void consume(int i) {
+            // do nothing.
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyComponentWithAnEmitterOfMessage {
+
+        @Inject
+        @Channel("output")
+        Emitter<Integer> emitter;
+
+        public void emit(Message<Integer> i) {
+            emitter.send(i);
+        }
+
+        @Incoming("output")
+        public void consume(int i, MessageObservation mo) {
+            assertThat(mo).isNotNull();
+            if (i == 3) {
+                throw new IllegalArgumentException("boom");
+            }
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyMessageObservationCollector implements MessageObservationCollector<ObservationContext> {
+
+        private final List<MessageObservation> observations = new CopyOnWriteArrayList<>();
+
+        public List<MessageObservation> getObservations() {
+            return observations;
+        }
+
+        @Override
+        public MessageObservation onNewMessage(String channel, Message<?> message, ObservationContext ctx) {
+            MessageObservation observation = new DefaultMessageObservation(channel);
+            observations.add(observation);
+            return observation;
+        }
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MessageTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/MessageTest.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Metadata;
@@ -40,11 +40,11 @@ public class MessageTest {
         assertThat(message.getMetadata()).isEmpty();
         assertThat(message.ack()).isCompleted();
 
-        Supplier<CompletionStage<Void>> supplier = () -> CompletableFuture.completedFuture(null);
+        Function<Metadata, CompletionStage<Void>> supplier = metadata -> CompletableFuture.completedFuture(null);
         message = Message.of("hello", supplier);
         assertThat(message.getPayload()).isEqualTo("hello");
         assertThat(message.getMetadata()).isEmpty();
-        assertThat(message.getAck()).isEqualTo(supplier);
+        assertThat(message.getAckWithMetadata()).isEqualTo(supplier);
         assertThat(message.ack()).isCompleted();
 
         message = Message.of("hello", Metadata.of(new MyMetadata<>("v")));
@@ -57,14 +57,14 @@ public class MessageTest {
         assertThat(message.getPayload()).isEqualTo("hello");
         assertThat(message.getMetadata()).hasSize(1);
         assertThat(message.getMetadata(MyMetadata.class).map(m -> m.v)).hasValue("v");
-        assertThat(message.getAck()).isEqualTo(supplier);
+        assertThat(message.getAckWithMetadata()).isEqualTo(supplier);
         assertThat(message.ack()).isCompleted();
 
-        message = Message.of("hello", Metadata.of(new MyMetadata<>("v")), null);
+        message = Message.of("hello", Metadata.of(new MyMetadata<>("v")));
         assertThat(message.getPayload()).isEqualTo("hello");
         assertThat(message.getMetadata()).hasSize(1);
         assertThat(message.getMetadata(MyMetadata.class).map(m -> m.v)).hasValue("v");
-        assertThat(message.getAck()).isNotEqualTo(supplier);
+        assertThat(message.getAckWithMetadata()).isNotEqualTo(supplier);
         assertThat(message.ack()).isCompleted();
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/ObservationTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/ObservationTest.java
@@ -1,0 +1,301 @@
+package io.smallrye.reactive.messaging.providers.connectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.smallrye.reactive.messaging.observation.DefaultMessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservation;
+import io.smallrye.reactive.messaging.observation.MessageObservationCollector;
+import io.smallrye.reactive.messaging.observation.ObservationContext;
+
+public class ObservationTest extends WeldTestBaseWithoutTails {
+
+    @BeforeEach
+    void setupConfig() {
+        installConfig("src/test/resources/config/observation.properties");
+    }
+
+    @Test
+    void testMessageObservationPointsFromPayloadConsumer() {
+        addBeanClass(MyMessageObservationCollector.class);
+        addBeanClass(MyPayloadConsumer.class);
+
+        initialize();
+
+        MyMessageObservationCollector observation = container.select(MyMessageObservationCollector.class).get();
+        MyPayloadConsumer consumer = container.select(MyPayloadConsumer.class).get();
+
+        await().until(() -> observation.getObservations().size() == 3);
+        await().until(() -> consumer.received().size() == 3);
+
+        assertThat(observation.getObservations()).allSatisfy(obs -> {
+            assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+            assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+        });
+
+        assertThat(observation.getObservations().get(0).getReason()).isNull();
+        assertThat(observation.getObservations().get(1).getReason()).isInstanceOf(IOException.class);
+        assertThat(observation.getObservations().get(2).getReason()).isInstanceOf(MalformedURLException.class);
+    }
+
+    @Test
+    void testMessageObservationPointsFromMessageConsumer() {
+        addBeanClass(MyMessageObservationCollector.class);
+        addBeanClass(MyMessageConsumer.class);
+
+        initialize();
+
+        MyMessageObservationCollector observation = container.select(MyMessageObservationCollector.class).get();
+        MyMessageConsumer consumer = container.select(MyMessageConsumer.class).get();
+
+        await().until(() -> observation.getObservations().size() == 3);
+        await().until(() -> consumer.received().size() == 3);
+
+        assertThat(observation.getObservations()).allSatisfy(obs -> {
+            assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+            assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+        });
+
+        assertThat(observation.getObservations().get(0).getReason()).isNull();
+        assertThat(observation.getObservations().get(1).getReason()).isInstanceOf(IOException.class);
+        assertThat(observation.getObservations().get(2).getReason()).isInstanceOf(MalformedURLException.class);
+    }
+
+    @Test
+    void testMessageObservationPointsFromMessageProducer() {
+        addBeanClass(MyMessageObservationCollector.class);
+        addBeanClass(MyMessageProducer.class);
+
+        initialize();
+
+        MyMessageObservationCollector observation = container.select(MyMessageObservationCollector.class).get();
+        MyMessageProducer producer = container.select(MyMessageProducer.class).get();
+
+        await().until(() -> observation.getObservations().size() == 3);
+        await().until(() -> producer.acked().size() == 3);
+
+        assertThat(observation.getObservations()).allSatisfy(obs -> {
+            assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+            assertThat(obs.getReason()).isNull();
+            assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+        });
+    }
+
+    @Test
+    void testMessageObservationPointsFromPayloadProducer() {
+        addBeanClass(MyMessageObservationCollector.class);
+        addBeanClass(MyPayloadProducer.class);
+
+        initialize();
+
+        MyMessageObservationCollector observation = container.select(MyMessageObservationCollector.class).get();
+        MyPayloadProducer producer = container.select(MyPayloadProducer.class).get();
+
+        await().until(() -> observation.getObservations().size() == 3);
+
+        assertThat(observation.getObservations()).allSatisfy(obs -> {
+            assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+            assertThat(obs.getReason()).isNull();
+            assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+        });
+    }
+
+    @Test
+    void testMessageObservationPointsFromPayloadEmitter() {
+        addBeanClass(MyMessageObservationCollector.class);
+        addBeanClass(MyEmitterProducer.class);
+
+        initialize();
+
+        MyMessageObservationCollector observation = container.select(MyMessageObservationCollector.class).get();
+        MyEmitterProducer producer = container.select(MyEmitterProducer.class).get();
+
+        producer.produce();
+
+        await().until(() -> observation.getObservations().size() == 3);
+
+        assertThat(observation.getObservations()).allSatisfy(obs -> {
+            assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+            assertThat(obs.getReason()).isNull();
+            assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+        });
+    }
+
+    @Test
+    void testMessageObservationPointsFromMessageEmitter() {
+        addBeanClass(MyMessageObservationCollector.class);
+        addBeanClass(MyEmitterMessageProducer.class);
+
+        initialize();
+
+        MyMessageObservationCollector observation = container.select(MyMessageObservationCollector.class).get();
+        MyEmitterMessageProducer producer = container.select(MyEmitterMessageProducer.class).get();
+
+        producer.produceMessages();
+
+        await().until(() -> observation.getObservations().size() == 3);
+        await().until(() -> producer.acked().size() == 3);
+
+        assertThat(observation.getObservations()).allSatisfy(obs -> {
+            assertThat(obs.getCreationTime()).isNotEqualTo(-1);
+            assertThat(obs.getReason()).isNull();
+            assertThat(obs.getCompletionTime()).isNotEqualTo(-1).isGreaterThan(obs.getCreationTime());
+        });
+    }
+
+    @ApplicationScoped
+    public static class MyPayloadConsumer {
+        private final List<Integer> received = new CopyOnWriteArrayList<>();
+
+        @Incoming("A")
+        void consume(int payload, MessageObservation tracking) throws IOException {
+            received.add(payload);
+            assertThat(tracking).isNotNull();
+            if (payload == 3) {
+                throw new IOException();
+            }
+            if (payload == 4) {
+                throw new MalformedURLException();
+            }
+        }
+
+        public List<Integer> received() {
+            return received;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyMessageConsumer {
+
+        private final List<Integer> received = new CopyOnWriteArrayList<>();
+
+        @Incoming("A")
+        CompletionStage<Void> consume(Message<Integer> msg) {
+            int payload = msg.getPayload();
+            received.add(payload);
+            assertThat(msg.getMetadata(MessageObservation.class)).isNotEmpty();
+            if (payload == 3) {
+                return msg.nack(new IOException());
+            }
+            if (payload == 4) {
+                return msg.nack(new MalformedURLException());
+            }
+            return msg.ack();
+        }
+
+        public List<Integer> received() {
+            return received;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyPayloadProducer {
+
+        private final List<Integer> acked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("B")
+        Multi<Integer> produce() {
+            return Multi.createFrom().items(1, 2, 3);
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyMessageProducer {
+
+        private final List<Integer> acked = new CopyOnWriteArrayList<>();
+
+        @Outgoing("B")
+        Multi<Message<Integer>> produce() {
+            return Multi.createFrom().items(1, 2, 3)
+                    .map(i -> Message.of(i, () -> {
+                        acked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    }));
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyEmitterProducer {
+
+        @Inject
+        @Channel("B")
+        Emitter<Integer> emitter;
+
+        void produce() {
+            emitter.send(1);
+            emitter.send(2);
+            emitter.send(3);
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyEmitterMessageProducer {
+
+        private final List<Integer> acked = new CopyOnWriteArrayList<>();
+
+        @Inject
+        @Channel("B")
+        Emitter<Integer> emitter;
+
+        void produceMessages() {
+            for (int i = 0; i < 3; i++) {
+                int j = i;
+                emitter.send(Message.of(j, () -> {
+                    acked.add(j);
+                    return CompletableFuture.completedFuture(null);
+                }));
+            }
+        }
+
+        public List<Integer> acked() {
+            return acked;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyMessageObservationCollector implements MessageObservationCollector<ObservationContext> {
+
+        private final List<MessageObservation> observations = new CopyOnWriteArrayList<>();
+
+        @Override
+        public MessageObservation onNewMessage(String channel, Message<?> message, ObservationContext ctx) {
+            MessageObservation observation = new DefaultMessageObservation(channel);
+            observations.add(observation);
+            return observation;
+        }
+
+        public List<MessageObservation> getObservations() {
+            return observations;
+        }
+
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/resources/config/interceptor.properties
+++ b/smallrye-reactive-messaging-provider/src/test/resources/config/interceptor.properties
@@ -1,3 +1,4 @@
 # You should not be able to use the same channel name in an outgoing and incoming configuration
 mp.messaging.outgoing.A.connector=dummy
+mp.messaging.incoming.B.connector=dummy
 

--- a/smallrye-reactive-messaging-provider/src/test/resources/config/observation.properties
+++ b/smallrye-reactive-messaging-provider/src/test/resources/config/observation.properties
@@ -1,0 +1,4 @@
+# You should not be able to use the same channel name in an outgoing and incoming configuration
+mp.messaging.incoming.A.connector=dummy
+mp.messaging.outgoing.B.connector=dummy
+

--- a/smallrye-reactive-messaging-pulsar/src/main/java/io/smallrye/reactive/messaging/pulsar/PulsarIncomingMessage.java
+++ b/smallrye-reactive-messaging-pulsar/src/main/java/io/smallrye/reactive/messaging/pulsar/PulsarIncomingMessage.java
@@ -6,8 +6,8 @@ import static io.smallrye.reactive.messaging.pulsar.i18n.PulsarMessages.msg;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -89,23 +89,23 @@ public class PulsarIncomingMessage<T> implements PulsarMessage<T>, PulsarIdMessa
     }
 
     @Override
-    public CompletionStage<Void> ack() {
+    public CompletionStage<Void> ack(Metadata metadata) {
         return ackHandler.handle(this).subscribeAsCompletionStage();
     }
 
     @Override
-    public Supplier<CompletionStage<Void>> getAck() {
+    public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
         return this::ack;
+    }
+
+    @Override
+    public BiFunction<Throwable, Metadata, CompletionStage<Void>> getNackWithMetadata() {
+        return this::nack;
     }
 
     @Override
     public CompletionStage<Void> nack(Throwable reason, Metadata metadata) {
         return nackHandler.handle(this, reason, metadata).subscribeAsCompletionStage();
-    }
-
-    @Override
-    public Function<Throwable, CompletionStage<Void>> getNack() {
-        return this::nack;
     }
 
     @Override

--- a/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/ConcurrentProcessorTest.java
+++ b/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/ConcurrentProcessorTest.java
@@ -164,7 +164,7 @@ public class ConcurrentProcessorTest extends WeldTestBase {
             int value = input.getPayload();
             int next = value + 1;
             perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-            return Uni.createFrom().item(Message.of(next, input::ack))
+            return Uni.createFrom().item(input.withPayload(next))
                     .onItem().delayIt().by(Duration.ofMillis(100));
         }
 
@@ -196,7 +196,7 @@ public class ConcurrentProcessorTest extends WeldTestBase {
                         int value = input.getPayload();
                         int next = value + 1;
                         perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-                        return Uni.createFrom().item(Message.of(next, input::ack))
+                        return Uni.createFrom().item(input.withPayload(next))
                                 .onItem().delayIt().by(Duration.ofMillis(100));
                     });
         }

--- a/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/health/HealthCheckTest.java
+++ b/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/health/HealthCheckTest.java
@@ -151,7 +151,7 @@ public class HealthCheckTest extends WeldTestBase {
         @Outgoing("output")
         @Acknowledgment(Acknowledgment.Strategy.MANUAL)
         public Message<Integer> process(Message<Integer> input) {
-            return Message.of(input.getPayload() + 1, input::ack);
+            return input.withPayload(input.getPayload() + 1);
         }
 
         @Outgoing("data")

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessage.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMessage.java
@@ -9,8 +9,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Metadata;
@@ -83,18 +83,17 @@ public class IncomingRabbitMQMessage<T> implements ContextAwareMessage<T>, Metad
     }
 
     @Override
-    public Supplier<CompletionStage<Void>> getAck() {
+    public Function<Metadata, CompletionStage<Void>> getAckWithMetadata() {
         return this::ack;
-        //return () -> onAck.handle(this, context);
     }
 
     @Override
-    public Function<Throwable, CompletionStage<Void>> getNack() {
+    public BiFunction<Throwable, Metadata, CompletionStage<Void>> getNackWithMetadata() {
         return this::nack;
     }
 
     @Override
-    public CompletionStage<Void> ack() {
+    public CompletionStage<Void> ack(Metadata metadata) {
         try {
             // We must switch to the context having created the message.
             // This context is passed when this instance of message is created.

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ConcurrentProcessorTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ConcurrentProcessorTest.java
@@ -155,7 +155,7 @@ public class ConcurrentProcessorTest extends WeldTestBase {
             int value = Integer.parseInt(input.getPayload());
             int next = value + 1;
             perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-            return Uni.createFrom().item(Message.of(next, input::ack))
+            return Uni.createFrom().item(input.withPayload(next))
                     .onItem().delayIt().by(Duration.ofMillis(100));
         }
 
@@ -187,7 +187,7 @@ public class ConcurrentProcessorTest extends WeldTestBase {
                         int value = Integer.parseInt(input.getPayload());
                         int next = value + 1;
                         perThread.computeIfAbsent(Thread.currentThread(), t -> new CopyOnWriteArrayList<>()).add(next);
-                        return Uni.createFrom().item(Message.of(next, input::ack))
+                        return Uni.createFrom().item(input.withPayload(next))
                                 .onItem().delayIt().by(Duration.ofMillis(100));
                     });
         }

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ConsumptionBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ConsumptionBean.java
@@ -32,7 +32,7 @@ public class ConsumptionBean {
         } catch (ClassCastException e) {
             typeCastCounter.incrementAndGet();
         }
-        return Message.of(value + 1, input::ack);
+        return input.withPayload(value + 1);
     }
 
     @Incoming("sink")

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/NullProducingBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/NullProducingBean.java
@@ -23,7 +23,7 @@ public class NullProducingBean {
     @Outgoing("sink")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(Message<Integer> input) {
-        return Message.of(null, input::ack);
+        return input.withPayload(null);
     }
 
     @Outgoing("data")

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ProducingBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ProducingBean.java
@@ -23,7 +23,7 @@ public class ProducingBean {
     @Outgoing("sink")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public Message<Integer> process(Message<Integer> input) {
-        return Message.of(input.getPayload() + 1, input::ack);
+        return input.withPayload(input.getPayload() + 1);
     }
 
     @Outgoing("data")


### PR DESCRIPTION
Currently, message composition does not propagate message metadata. 
This makes message interception (through decorators etc.) practically unfeasible.

With this change `Message` acks and nacks receive an additional `Metadata` parameter.
Existing methods for acks/nacks and composition continue to work by delegating to the new ack/nack functions.
The `Message` interface from the `api` package is still compatible with the MP Messaging Spec `Message` interface, verified by the `MessageSpecCompatibilityTest` test.

Other changes related to message ack/nack composition :
- Deprecate `PublisherDecorator#decorate(String, String, boolean)`
- Introduce `IncomingInterceptor`
- Change message interceptor method names: 
  - `OutgoingInterceptor#onMessage` -> `beforeMessageSend`
  - `IncomingInterceptor#afterMessageReceive`
- Message Observation API: Allows a `MessageObservationCollector` to observe message creation, acks, nacks, and message processing duration. 


Resolves #334
