### PR TITLE
Apply DLQ strategy on deserialization failure

### DIFF
--- a/documentation/src/main/docs/kafka/receiving-kafka-records.md
+++ b/documentation/src/main/docs/kafka/receiving-kafka-records.md
@@ -449,6 +449,20 @@ produce a `null` value. To enable this behavior, set the
 `mp.messaging.incoming.$channel.fail-on-deserialization-failure`
 attribute to `false`.
 
+If the `fail-on-deserialization-failure` attribute is set to `false` and
+the `failure-strategy` attribute is `dead-letter-queue` the failed record
+will be sent to the corresponding *dead letter queue* topic.
+The forwarded record will have the original key and value,
+and the following headers set:
+
+- `deserialization-failure-reason`: The deserialization failure message
+- `deserialization-failure-cause`: The deserialization failure cause if any
+- `deserialization-failure-key`: Whether the deserialization failure happened on a key
+- `deserialization-failure-topic`: The topic of the incoming message when a deserialization failure happen
+- `deserialization-failure-deserializer`: The class name of the underlying deserializer
+- `deserialization-failure-key-data`: If applicable the key data that was not able to be deserialized
+- `deserialization-failure-value-data`: If applicable the value data that was not able to be deserialized
+
 ## Receiving Cloud Events
 
 The Kafka connector supports [Cloud Events](https://cloudevents.io/).

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/DeserializationFailureHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/DeserializationFailureHandler.java
@@ -50,9 +50,24 @@ public interface DeserializationFailureHandler<T> {
     String DESERIALIZATION_FAILURE_DATA = "deserialization-failure-data";
 
     /**
+     * Header name passing the key data that was not able to be deserialized.
+     */
+    String DESERIALIZATION_FAILURE_KEY_DATA = "deserialization-failure-key-data";
+
+    /**
+     * Header name passing the value data that was not able to be deserialized.
+     */
+    String DESERIALIZATION_FAILURE_VALUE_DATA = "deserialization-failure-value-data";
+
+    /**
      * Header name passing the class name of the underlying deserializer.
      */
     String DESERIALIZATION_FAILURE_DESERIALIZER = "deserialization-failure-deserializer";
+
+    /**
+     * Header name passing the class name of the underlying deserializer.
+     */
+    String DESERIALIZATION_FAILURE_DLQ = "deserialization-failure-dlq";
 
     byte[] TRUE_VALUE = "true".getBytes(StandardCharsets.UTF_8);
 
@@ -111,6 +126,7 @@ public interface DeserializationFailureHandler<T> {
 
         if (headers != null) {
             headers.add(DESERIALIZATION_FAILURE_DESERIALIZER, deserializer.getBytes(StandardCharsets.UTF_8));
+            headers.add(DESERIALIZATION_FAILURE_DLQ, TRUE_VALUE);
             headers.add(DESERIALIZATION_FAILURE_TOPIC, topic.getBytes(StandardCharsets.UTF_8));
 
             if (isKey) {
@@ -124,6 +140,12 @@ public interface DeserializationFailureHandler<T> {
                 headers.add(DESERIALIZATION_FAILURE_CAUSE, cause.getBytes(StandardCharsets.UTF_8));
             }
             if (data != null) {
+                if (isKey) {
+                    headers.add(DESERIALIZATION_FAILURE_KEY_DATA, data);
+                } else {
+                    headers.add(DESERIALIZATION_FAILURE_VALUE_DATA, data);
+                }
+                // Do not break retro-compatibility
                 headers.add(DESERIALIZATION_FAILURE_DATA, data);
             }
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/DeserializerWrapper.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/DeserializerWrapper.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.kafka.fault;
 
+import static io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler.addFailureDetailsToHeaders;
+
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -114,6 +116,9 @@ public class DeserializerWrapper<T> implements Deserializer<T> {
                     }
                     throw new KafkaException(e);
                 }
+                // insert failure details to headers
+                addFailureDetailsToHeaders(delegate.getClass().getName(), topic, handleKeys, headers, data, e);
+                // fallback to null
                 return null;
             }
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterSerializationHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterSerializationHandler.java
@@ -1,0 +1,48 @@
+package io.smallrye.reactive.messaging.kafka.fault;
+
+import static io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler.DESERIALIZATION_FAILURE_DATA;
+import static io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler.DESERIALIZATION_FAILURE_DESERIALIZER;
+import static io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler.DESERIALIZATION_FAILURE_IS_KEY;
+import static io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler.DESERIALIZATION_FAILURE_KEY_DATA;
+import static io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler.DESERIALIZATION_FAILURE_VALUE_DATA;
+import static io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler.TRUE_VALUE;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.SerializationFailureHandler;
+
+public class KafkaDeadLetterSerializationHandler<T> implements SerializationFailureHandler<T> {
+
+    @Override
+    public byte[] decorateSerialization(Uni<byte[]> serialization, String topic, boolean isKey, String serializer, T data,
+            Headers headers) {
+        // deserializer failure
+        if (headers.lastHeader(DESERIALIZATION_FAILURE_DESERIALIZER) != null) {
+            // data exists
+            Header dataHeader = headers.lastHeader(DESERIALIZATION_FAILURE_DATA);
+            if (dataHeader != null) {
+                // if this is the key serialization we look at the _KEY_DATA header
+                if (isKey) {
+                    Header isKeyHeader = headers.lastHeader(DESERIALIZATION_FAILURE_IS_KEY);
+                    if (isKeyHeader != null && Arrays.equals(isKeyHeader.value(), TRUE_VALUE)) {
+                        Header keyDataHeader = headers.lastHeader(DESERIALIZATION_FAILURE_KEY_DATA);
+                        // fallback to data header
+                        return Objects.requireNonNullElse(keyDataHeader, dataHeader).value();
+                    }
+                    // if this is the value serialization we look at the _VALUE_DATA header
+                } else {
+                    Header valueDataHeader = headers.lastHeader(DESERIALIZATION_FAILURE_VALUE_DATA);
+                    // fallback to data header
+                    return Objects.requireNonNullElse(valueDataHeader, dataHeader).value();
+                }
+            }
+        }
+        // call serialization
+        return SerializationFailureHandler.super.decorateSerialization(serialization, topic, isKey, serializer, data, headers);
+    }
+}


### PR DESCRIPTION
From doc change: 

If the `fail-on-deserialization-failure` attribute is set to `false` and the `failure-strategy` attribute is `dead-letter-queue` the failed record will be sent to the corresponding *dead letter queue* topic. The forwarded record will have the original key and value, and the following headers set:

- `deserialization-failure-reason`: The deserialization failure message
- `deserialization-failure-cause`: The deserialization failure cause if any
- `deserialization-failure-key`: Whether the deserialization failure happened on a key
- `deserialization-failure-topic`: The topic of the incoming message when a deserialization failure happen
- `deserialization-failure-deserializer`: The class name of the underlying deserializer
- `deserialization-failure-key-data`: If applicable the key data that was not able to be deserialized
- `deserialization-failure-value-data`: If applicable the value data that was not able to be deserialized
