### PR TITLE
Bump Smallrye Mutiny from 2.1.0 to 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 
     <micrometer.version>1.11.3</micrometer.version>
 
-    <mutiny.version>2.1.0</mutiny.version>
+    <mutiny.version>2.4.0</mutiny.version>
     <artemis.version>2.30.0</artemis.version>
     <commons-io.version>2.13.0</commons-io.version>
 

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/KafkaTask.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/KafkaTask.java
@@ -242,9 +242,9 @@ public abstract class KafkaTask<T, SELF extends KafkaTask<T, SELF>> implements I
      *
      * @return self
      */
-    public SELF stop() {
-        subscriber.cancel();
+    public synchronized SELF stop() {
         subscriber.onComplete();
+        subscriber.cancel();
         return self();
     }
 


### PR DESCRIPTION
- Adapt Kafka companion KafkaTask to changed AssertSubscriber behavior for subscription cancels.
- Fix flaky Kafka companion behavior to preventing reusing consumers