### PR TITLE
Follow the jandex relocation in build plugins

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -52,7 +52,7 @@
     <build>
       <plugins>
         <plugin>
-          <groupId>org.jboss.jandex</groupId>
+          <groupId>io.smallrye</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
         </plugin>
       </plugins>

--- a/smallrye-reactive-messaging-amqp/pom.xml
+++ b/smallrye-reactive-messaging-amqp/pom.xml
@@ -138,7 +138,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/smallrye-reactive-messaging-camel/pom.xml
+++ b/smallrye-reactive-messaging-camel/pom.xml
@@ -100,6 +100,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>

--- a/smallrye-reactive-messaging-gcp-pubsub/pom.xml
+++ b/smallrye-reactive-messaging-gcp-pubsub/pom.xml
@@ -64,6 +64,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>

--- a/smallrye-reactive-messaging-in-memory/pom.xml
+++ b/smallrye-reactive-messaging-in-memory/pom.xml
@@ -44,7 +44,7 @@
     <build>
       <plugins>
         <plugin>
-          <groupId>org.jboss.jandex</groupId>
+          <groupId>io.smallrye</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
           <executions>
             <execution>

--- a/smallrye-reactive-messaging-jms/pom.xml
+++ b/smallrye-reactive-messaging-jms/pom.xml
@@ -123,6 +123,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>

--- a/smallrye-reactive-messaging-kafka-api/pom.xml
+++ b/smallrye-reactive-messaging-kafka-api/pom.xml
@@ -34,7 +34,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -178,7 +178,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/smallrye-reactive-messaging-mqtt/pom.xml
+++ b/smallrye-reactive-messaging-mqtt/pom.xml
@@ -69,6 +69,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>

--- a/smallrye-reactive-messaging-provider/pom.xml
+++ b/smallrye-reactive-messaging-provider/pom.xml
@@ -91,7 +91,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/smallrye-reactive-messaging-pulsar/pom.xml
+++ b/smallrye-reactive-messaging-pulsar/pom.xml
@@ -165,7 +165,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/smallrye-reactive-messaging-rabbitmq/pom.xml
+++ b/smallrye-reactive-messaging-rabbitmq/pom.xml
@@ -82,6 +82,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
Added jandex plugin execution to other connectors: jms, gcp, camel, rabbitmq, mqtt