### PR TITLE
Require 2 builds for codecov test coverage report

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,7 @@
 codecov:
     require_ci_to_pass: yes
+    notify:
+        after_n_builds: 2
 
 coverage:
     precision: 2


### PR DESCRIPTION
Hoping this will fix the incomplete coverage reports from codecov