### PR TITLE
Let emitters report message metrics

### DIFF
--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/EmitterInjectionTest.java
@@ -669,6 +669,7 @@ public class EmitterInjectionTest extends WeldTestBaseWithoutTails {
                 return 128;
             }
         };
+        initialize();
         EmitterConfiguration config = new DefaultEmitterConfiguration("my-channel", EMITTER, overflow, null);
         EmitterImpl<String> emitter = new EmitterImpl<>(config, 128);
         Flow.Publisher<Message<? extends String>> publisher = emitter.getPublisher();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterInjectionTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/inject/MutinyEmitterInjectionTest.java
@@ -752,6 +752,7 @@ public class MutinyEmitterInjectionTest extends WeldTestBaseWithoutTails {
                 return 128;
             }
         };
+        initialize();
         EmitterConfiguration config = new DefaultEmitterConfiguration("my-channel", MUTINY_EMITTER, overflow, null);
         MutinyEmitterImpl<String> emitter = new MutinyEmitterImpl<>(config, 128);
         Flow.Publisher<Message<? extends String>> publisher = emitter.getPublisher();

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/metrics/MetricsTestBean.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/metrics/MetricsTestBean.java
@@ -4,7 +4,10 @@ import java.util.Arrays;
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
@@ -24,6 +27,22 @@ public class MetricsTestBean {
     @Outgoing("sink")
     public PublisherBuilder<String> duplicate(String input) {
         return ReactiveStreams.of(input, input);
+    }
+
+    @Inject
+    @Channel("emitter")
+    Emitter<String> emitter;
+
+    public void send() {
+        for (String s : TEST_MESSAGES) {
+            emitter.send(s);
+        }
+        emitter.complete();
+    }
+
+    @Incoming("emitter")
+    void consume(String s) {
+
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/metrics/MicrometerDecoratorTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/metrics/MicrometerDecoratorTest.java
@@ -49,6 +49,19 @@ public class MicrometerDecoratorTest extends WeldTestBase {
         assertEquals(MetricsTestBean.TEST_MESSAGES.size() * 2, getCounter("sink").count());
     }
 
+    @Test
+    public void testMetricsWithEmitter() {
+        releaseConfig();
+        addBeanClass(MetricsTestBean.class);
+        initialize();
+
+        MetricsTestBean bean = container.select(MetricsTestBean.class).get();
+        bean.send();
+
+        await().untilAsserted(() -> assertEquals(MetricsTestBean.TEST_MESSAGES.size(), getCounter("emitter").count()));
+
+    }
+
     private Counter getCounter(String channelName) {
         return Metrics.counter("mp.messaging.message.count", "channel", channelName);
     }


### PR DESCRIPTION
Fix https://github.com/smallrye/smallrye-reactive-messaging/issues/2332

I've decided to use the beans directly and not apply all the decorators. The reason is that I think we need to change the decorator interface to have an `isEmitter` flag so the decorator knows if it's an emitter or not, like for connectors. 
