### PR TITLE
Support metadata injection for interfaces

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
@@ -64,10 +64,18 @@ public abstract class AbstractMediator {
                         extractors[i] = Message::getPayload;
                     } else if (parameters.get(i) == Optional.class) {
                         Class<?> c = configuration.getParameterDescriptor().getGenericParameterType(i, 0);
-                        extractors[i] = msg -> msg.getMetadata().get(c);
+                        if (c.isInterface()) {
+                            extractors[i] = msg -> msg.getMetadata(c);
+                        } else {
+                            extractors[i] = msg -> msg.getMetadata().get(c);
+                        }
                     } else {
                         Class<?> type = parameters.get(i);
-                        extractors[i] = msg -> msg.getMetadata().get(type).orElse(null);
+                        if (type.isInterface()) {
+                            extractors[i] = msg -> msg.getMetadata(type).orElse(null);
+                        } else {
+                            extractors[i] = msg -> msg.getMetadata().get(type).orElse(null);
+                        }
                     }
                 }
                 mapper = msg -> Arrays.stream(extractors).map(extractor -> extractor.apply(msg)).toArray(Object[]::new);

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/IncomingMetadataInjectionProcessorTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/IncomingMetadataInjectionProcessorTest.java
@@ -28,9 +28,11 @@ public class IncomingMetadataInjectionProcessorTest extends WeldTestBaseWithoutT
     @ParameterizedTest
     @ValueSource(classes = { ProcessorIngestingPayload.class, ProcessorIngestingPayloadWithOptional.class,
             ProcessorIngestingPayloadWithMultipleMetadata.class, ProcessorIngestingPayloadWithMultipleMetadataAndBlocking.class,
-            ProcessorIngestingPayloadBlocking.class, ProcessorIngestingPayloadWithOptionalAndBlocking.class })
-    void testMetadataInjectingInProcessorIngestingPayload() {
-        addBeanClass(Source.class, Sink.class, ProcessorIngestingPayload.class);
+            ProcessorIngestingPayloadBlocking.class, ProcessorIngestingPayloadWithOptionalAndBlocking.class,
+            ProcessorIngestingPayloadWithInterfaceMetadata.class,
+            ProcessorIngestingPayloadWithOptionalInterfaceMetadata.class })
+    void testMetadataInjectingInProcessorIngestingPayload(Class<?> processor) {
+        addBeanClass(Source.class, Sink.class, processor);
         initialize();
         IncomingMetadataInjectionProcessorTest.Sink sink = container.select(IncomingMetadataInjectionProcessorTest.Sink.class)
                 .get();
@@ -95,6 +97,32 @@ public class IncomingMetadataInjectionProcessorTest extends WeldTestBaseWithoutT
             assertThat(p).isNotNull();
             assertThat(metadata).isNotNull().isPresent();
             assertThat(metadata.get().getMessage()).isEqualTo("foo");
+            return p;
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProcessorIngestingPayloadWithOptionalInterfaceMetadata {
+        @Incoming("source")
+        @Outgoing("sink")
+        public String process(String p, Optional<SimplePropagationTest.InterfaceMetadata> metadata) {
+            assertThat(Infrastructure.canCallerThreadBeBlocked()).isTrue();
+            assertThat(p).isNotNull();
+            assertThat(metadata).isNotNull().isPresent();
+            assertThat(metadata.get().getMessage()).isEqualTo("foo");
+            return p;
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProcessorIngestingPayloadWithInterfaceMetadata {
+        @Incoming("source")
+        @Outgoing("sink")
+        public String process(String p, SimplePropagationTest.InterfaceMetadata metadata) {
+            assertThat(Infrastructure.canCallerThreadBeBlocked()).isTrue();
+            assertThat(p).isNotNull();
+            assertThat(metadata).isNotNull();
+            assertThat(metadata.getMessage()).isEqualTo("foo");
             return p;
         }
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/SimplePropagationTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/metadata/SimplePropagationTest.java
@@ -68,7 +68,7 @@ public class SimplePropagationTest extends WeldTestBaseWithoutTails {
 
     }
 
-    public static class MsgMetadata {
+    public static class MsgMetadata implements InterfaceMetadata {
 
         private final String message;
 
@@ -76,9 +76,15 @@ public class SimplePropagationTest extends WeldTestBaseWithoutTails {
             this.message = m;
         }
 
-        String getMessage() {
+        public String getMessage() {
             return message;
         }
+
+    }
+
+    public interface InterfaceMetadata {
+
+        String getMessage();
 
     }
 


### PR DESCRIPTION
Currently, the metadata type that is trying to be injected into the consumer method matches exactly to the class type using `getMetadata().get()`. This relaxes that check for injecting interfaces using the `getMessage(Class<?> type)`.