### PR TITLE
Seperate afterDeploymentValidation into two submethods

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ReactiveMessagingExtension.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/ReactiveMessagingExtension.java
@@ -105,7 +105,12 @@ public class ReactiveMessagingExtension implements Extension {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    void afterDeploymentValidation(@Observes AfterDeploymentValidation done, BeanManager beanManager) {
+    protected void afterDeploymentValidation(@Observes AfterDeploymentValidation done, BeanManager beanManager) {
+        MediatorManager mediatorManager = configureMediatorManager(beanManager);
+        startMediatorManager(mediatorManager);
+    }
+
+    protected MediatorManager configureMediatorManager(BeanManager beanManager) {
         Instance<Object> instance = beanManager.createInstance();
         MediatorManager mediatorManager = instance.select(MediatorManager.class).get();
         WorkerPoolRegistry workerPoolRegistry = instance.select(WorkerPoolRegistry.class).get();
@@ -129,6 +134,10 @@ public class ReactiveMessagingExtension implements Extension {
             workerPoolRegistry.analyzeWorker(workerPoolBean.annotatedType);
         }
 
+        return mediatorManager;
+    }
+
+    protected void startMediatorManager(MediatorManager mediatorManager) {
         mediatorManager.start();
     }
 


### PR DESCRIPTION
Hello

I have been working on getting reactive messaging to work with [InstantOn](https://openliberty.io/docs/latest/instanton.html) in open liberty. I have a proof of concept and have determined that if I prevent the line `mediatorManager.start()` in `ReactiveMessagingExtension` from running before the checkpoint, and instead run it after the restore, everything just works.

However because `mediatorManager.start()` is invoked as part of a larger method containing code that ideally will run before the checkpoint I had to modify that class locally. I would like to submit a simple change that makes  `ReactiveMessagingExtension.afterDeploymentValidation` call two subordinate methods. Then in my code I can simply extend, rather than modify, `ReactiveMessagingExtension` and call the subordinate methods directly at the appropriate times.