### PR TITLE
Test flakiness : getMaxNumberOfEventLoop falls back to 1 if number of cores is 4.

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/KafkaCompanionTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/KafkaCompanionTestBase.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import io.smallrye.reactive.messaging.kafka.companion.test.KafkaBrokerExtension;
 import io.smallrye.reactive.messaging.kafka.companion.test.KafkaBrokerExtension.KafkaBootstrapServers;
+import io.vertx.core.impl.cpu.CpuCoreSensor;
 import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.core.Vertx;
 
@@ -83,4 +84,15 @@ public class KafkaCompanionTestBase extends WeldTestBase {
                 "graceful-shutdown", false,
                 "channel-name", topic);
     }
+
+    public int getMaxNumberOfEventLoop(int expected) {
+        // On Github Actions, only one event loop is created.
+        int cpus = CpuCoreSensor.availableProcessors();
+        // For some reason when Github Actions has 4 cores it'll still run on 1 event loop thread
+        if (cpus <= 4) {
+            return 1;
+        }
+        return Math.min(expected, cpus / 2);
+    }
+
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/FileCheckpointStateStoreTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/FileCheckpointStateStoreTest.java
@@ -864,9 +864,4 @@ public class FileCheckpointStateStoreTest extends KafkaCompanionTestBase {
         }
     }
 
-    private int getMaxNumberOfEventLoop(int expected) {
-        // On Github Actions, only one event loop is created.
-        return Math.min(expected, Runtime.getRuntime().availableProcessors() / 2);
-    }
-
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/PartitionTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/PartitionTest.java
@@ -144,9 +144,4 @@ public class PartitionTest extends KafkaCompanionTestBase {
         }
     }
 
-    private int getMaxNumberOfEventLoop(int expected) {
-        // On Github Actions, only one event loop is created.
-        return Math.min(expected, Runtime.getRuntime().availableProcessors() / 2);
-    }
-
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/RedisCheckpointStateStoreTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/RedisCheckpointStateStoreTest.java
@@ -997,8 +997,4 @@ public class RedisCheckpointStateStoreTest extends KafkaCompanionTestBase {
         }
     }
 
-    private int getMaxNumberOfEventLoop(int expected) {
-        // On Github Actions, only one event loop is created.
-        return Math.min(expected, Runtime.getRuntime().availableProcessors() / 2);
-    }
 }


### PR DESCRIPTION
For some reason even when the number of cpus is 4 in GitHub Actions, there is only a single event loop created. 