### PR TITLE
Run emitter publisher decorators after registering the emitter to channel registry

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/EmitterImpl.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/EmitterImpl.java
@@ -44,7 +44,7 @@ public class EmitterImpl<T> extends AbstractEmitter<T> implements Emitter<T> {
         if (msg == null) {
             throw ex.illegalArgumentForNullValue();
         }
-        emit(msg);
+        emit(ContextAwareMessage.withContextMetadata((Message<? extends T>) msg));
     }
 
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConfiguredChannelFactory.java
@@ -172,7 +172,7 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
         Multi<? extends Message<?>> publisher = MultiUtils.publisher(inboundConnector.getPublisher(config));
 
         for (PublisherDecorator decorator : getSortedInstances(publisherDecoratorInstance)) {
-            publisher = decorator.decorate(publisher, name, true);
+            publisher = decorator.decorate(publisher, List.of(name), true);
         }
 
         return publisher;

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/wiring/Wiring.java
@@ -30,7 +30,6 @@ import io.smallrye.reactive.messaging.providers.AbstractMediator;
 import io.smallrye.reactive.messaging.providers.extension.*;
 import io.smallrye.reactive.messaging.providers.helpers.MultiUtils;
 import io.smallrye.reactive.messaging.providers.i18n.ProviderLogging;
-import io.smallrye.reactive.messaging.providers.locals.ContextDecorator;
 
 @ApplicationScoped
 public class Wiring {
@@ -515,12 +514,12 @@ public class Wiring {
         private <T extends MessagePublisherProvider<?>> void registerEmitter(ChannelRegistry registry, int def) {
             EmitterFactory<?> emitterFactory = getEmitterFactory(configuration.emitterType());
             T emitter = (T) emitterFactory.createEmitter(configuration, def);
-            Multi<? extends Message<?>> publisher = Multi.createFrom().publisher(emitter.getPublisher());
-            for (PublisherDecorator decorator : getSortedInstances(decorators)) {
-                    publisher = decorator.decorate(publisher, configuration.name(), false);
-            }
             Class<T> type = (Class<T>) configuration.emitterType().value();
             registry.register(configuration.name(), type, emitter);
+            Multi<? extends Message<?>> publisher = Multi.createFrom().publisher(emitter.getPublisher());
+            for (PublisherDecorator decorator : getSortedInstances(decorators)) {
+                publisher = decorator.decorate(publisher, List.of(configuration.name()), false);
+            }
             //noinspection ReactiveStreamsUnusedPublisher
             registry.register(configuration.name(), publisher, broadcast());
         }


### PR DESCRIPTION
Fix after #2342

This way decorators can access channel registry to check if the channel is an emitter or not.
Additional changes :
- PublisherDecorator calls are made to the `decorate(Multi<Message>, List<String>, boolean)` method with list of channel names.
- `EmitterImpl#send(Message)` method now captures the context metadata – Don't know why it wasn't done before. Looks like it was forgotten.