### PR TITLE
Context-aware message dispatch on in-memory connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -558,7 +558,7 @@
               </goals>
               <configuration>
                 <versionFormat>^\d+\.\d+\.\d+$</versionFormat>
-                <failSeverity>breaking</failSeverity>
+                <failCriticality>error</failCriticality>
                 <checkDependencies>false</checkDependencies>
                 <analysisConfigurationFiles>
                   <file>${project.basedir}/revapi.json</file>

--- a/smallrye-reactive-messaging-connector-archetype/src/main/resources/archetype-resources/src/main/java/__connectorPrefix__IncomingChannel.java
+++ b/smallrye-reactive-messaging-connector-archetype/src/main/resources/archetype-resources/src/main/java/__connectorPrefix__IncomingChannel.java
@@ -1,5 +1,6 @@
 package ${package};
 
+import java.util.Objects;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -38,8 +39,9 @@ public class ${connectorPrefix}IncomingChannel {
         this.failureHandler = ${connectorPrefix}FailureHandler.create(this.client);
         this.tracingEnabled = cfg.getTracingEnabled();
         Multi<? extends Message<?>> receiveMulti = Multi.createBy().repeating()
-                .uni(() -> Uni.createFrom().completionStage(this.client.poll()))
+                .uni(() -> Uni.createFrom().completionStage(this.client == null ? null : this.client.poll()))
                 .until(__ -> closed.get())
+                .filter(Objects::nonNull)
                 .emitOn(context::runOnContext)
                 .map(consumed -> new ${connectorPrefix}Message<>(consumed, ackHandler, failureHandler));
 

--- a/smallrye-reactive-messaging-in-memory/revapi.json
+++ b/smallrye-reactive-messaging-in-memory/revapi.json
@@ -24,7 +24,30 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+        {
+        "code": "java.method.removed",
+        "old": "method org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder<? extends org.eclipse.microprofile.reactive.messaging.Message<?>> io.smallrye.reactive.messaging.memory.InMemoryConnector::getPublisherBuilder(org.eclipse.microprofile.config.Config)",
+        "justification": "Migrated InMemoryConnector to InboundConnector"
+        },
+        {
+            "code": "java.method.removed",
+            "old": "method org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder<? extends org.eclipse.microprofile.reactive.messaging.Message<?>, java.lang.Void> io.smallrye.reactive.messaging.memory.InMemoryConnector::getSubscriberBuilder(org.eclipse.microprofile.config.Config)",
+            "justification": "Migrated InMemoryConnector to OutboundConnector"
+        },
+        {
+            "code": "java.annotation.added",
+            "old": "class io.smallrye.reactive.messaging.memory.InMemoryConnector",
+            "new": "class io.smallrye.reactive.messaging.memory.InMemoryConnector",
+            "annotation": "@io.smallrye.reactive.messaging.annotations.ConnectorAttributes({@io.smallrye.reactive.messaging.annotations.ConnectorAttribute(name = \"run-on-vertx-context\", type = \"boolean\", direction = .INCOMING, description = \"Whether messages are dispatched on the Vert.x context or not.\", defaultValue = \"false\"), @io.smallrye.reactive.messaging.annotations.ConnectorAttribute(name = \"broadcast\", type = \"boolean\", direction = .INCOMING, description = \"Whether the messages are dispatched to multiple consumer\", defaultValue = \"false\")})",
+            "justification": "Added connector attribute for dispatching messages on Vert.x context"
+        },
+        {
+            "code": "java.method.addedToInterface",
+            "new": "method io.smallrye.reactive.messaging.memory.InMemorySource<T> io.smallrye.reactive.messaging.memory.InMemorySource<T>::runOnVertxContext(boolean)",
+            "justification": "Added method to InMemorySource for dispatching messages on Vert.x context"
+        }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/memory/InMemorySource.java
+++ b/smallrye-reactive-messaging-in-memory/src/main/java/io/smallrye/reactive/messaging/memory/InMemorySource.java
@@ -23,6 +23,14 @@ public interface InMemorySource<T> {
     InMemorySource<T> send(T messageOrPayload);
 
     /**
+     * The flag to enable dispatching messages on Vert.x context.
+     *
+     * @param runOnVertxContext whether to dispatch messages on Vert.x context or not
+     * @return this to allow chaining calls.
+     */
+    InMemorySource<T> runOnVertxContext(boolean runOnVertxContext);
+
+    /**
      * Sends the completion event.
      */
     void complete();

--- a/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/providers/connectors/InMemoryConnectorRunOnContextTest.java
+++ b/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/providers/connectors/InMemoryConnectorRunOnContextTest.java
@@ -1,0 +1,227 @@
+package io.smallrye.reactive.messaging.providers.connectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.awaitility.Awaitility.await;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySink;
+import io.smallrye.reactive.messaging.memory.InMemorySource;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class InMemoryConnectorRunOnContextTest extends WeldTestBase {
+
+    @BeforeEach
+    public void install() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("mp.messaging.incoming.foo.connector", InMemoryConnector.CONNECTOR);
+        conf.put("mp.messaging.incoming.foo.data", "not read");
+        conf.put("mp.messaging.incoming.foo.run-on-vertx-context", "true");
+        conf.put("mp.messaging.outgoing.bar.connector", InMemoryConnector.CONNECTOR);
+        conf.put("mp.messaging.outgoing.bar.data", "not read");
+        installConfig(new MapBasedConfig(conf));
+
+    }
+
+    @AfterEach
+    public void cleanup() {
+        releaseConfig();
+    }
+
+    @Test
+    public void testWithStrings() {
+        addBeanClass(MyBeanReceivingString.class);
+        initialize();
+        InMemoryConnector bean = container.getBeanManager().createInstance()
+                .select(InMemoryConnector.class, ConnectorLiteral.of(InMemoryConnector.CONNECTOR)).get();
+        assertThat(bean).isNotNull();
+        InMemorySink<String> bar = bean.sink("bar");
+        InMemorySource<String> foo = bean.source("foo");
+        foo.send("hello");
+        await().untilAsserted(
+                () -> assertThat(bar.received()).hasSize(1).extracting(Message::getPayload).containsExactly("HELLO"));
+    }
+
+    @Test
+    public void testWithMessages() {
+        addBeanClass(MyBeanReceivingMessage.class);
+        initialize();
+        AtomicBoolean acked = new AtomicBoolean();
+        InMemoryConnector bean = container.getBeanManager().createInstance()
+                .select(InMemoryConnector.class, ConnectorLiteral.of(InMemoryConnector.CONNECTOR)).get();
+        assertThat(bean).isNotNull();
+        InMemorySource<Message<String>> foo = bean.source("foo");
+        InMemorySink<String> bar = bean.sink("bar");
+
+        Message<String> msg = Message.of("hello", () -> {
+            acked.set(true);
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            future.complete(null);
+            return future;
+        });
+        foo.send(msg);
+        await().untilAsserted(
+                () -> assertThat(bar.received()).hasSize(1).extracting(Message::getPayload).containsExactly("HELLO"));
+        assertThat(acked).isTrue();
+    }
+
+    @Test
+    public void testWithMultiplePayloads() {
+        addBeanClass(MyBeanReceivingString.class);
+        initialize();
+        InMemoryConnector bean = container.getBeanManager().createInstance()
+                .select(InMemoryConnector.class, ConnectorLiteral.of(InMemoryConnector.CONNECTOR)).get();
+        assertThat(bean).isNotNull();
+        InMemorySource<String> foo = bean.source("foo");
+        InMemorySink<String> bar = bean.sink("bar");
+        foo.send("1");
+        foo.send("2");
+        foo.send("3");
+        await().untilAsserted(
+                () -> assertThat(bar.received()).hasSize(3).extracting(Message::getPayload).containsExactly("1", "2", "3"));
+        bar.clear();
+        foo.send("4");
+        foo.send("5");
+        foo.send("6");
+        foo.complete();
+
+        await().untilAsserted(() -> {
+            assertThat(bar.received()).hasSize(3).extracting(Message::getPayload).containsExactly("4", "5", "6");
+            assertThat(bar.hasCompleted()).isTrue();
+            assertThat(bar.hasFailed()).isFalse();
+        });
+    }
+
+    @Test
+    public void testWithFailure() {
+        addBeanClass(MyBeanReceivingString.class);
+        initialize();
+        InMemoryConnector bean = container.getBeanManager().createInstance()
+                .select(InMemoryConnector.class, ConnectorLiteral.of(InMemoryConnector.CONNECTOR)).get();
+        assertThat(bean).isNotNull();
+        InMemorySource<String> foo = bean.source("foo");
+        InMemorySink<String> bar = bean.sink("bar");
+        foo.send("1");
+        foo.send("2");
+        foo.send("3");
+        await().untilAsserted(
+                () -> assertThat(bar.received()).hasSize(3).extracting(Message::getPayload).containsExactly("1", "2", "3"));
+        foo.fail(new Exception("boom"));
+
+        await().untilAsserted(() -> {
+            assertThat(bar.hasCompleted()).isFalse();
+            assertThat(bar.hasFailed()).isTrue();
+            assertThat(bar.getFailure()).hasMessageContaining("boom");
+        });
+
+        bar.clear();
+        assertThat(bar.hasCompleted()).isFalse();
+        assertThat(bar.hasFailed()).isFalse();
+        assertThat(bar.getFailure()).isNull();
+
+    }
+
+    @Test
+    public void testWithUnknownSource() {
+        addBeanClass(MyBeanReceivingString.class);
+        initialize();
+        InMemoryConnector bean = container.getBeanManager().createInstance()
+                .select(InMemoryConnector.class, ConnectorLiteral.of(InMemoryConnector.CONNECTOR)).get();
+        assertThat(bean).isNotNull();
+        assertThatThrownBy(() -> bean.source("unknown")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testWithUnknownSink() {
+        addBeanClass(MyBeanReceivingString.class);
+        initialize();
+        InMemoryConnector bean = container.getBeanManager().createInstance()
+                .select(InMemoryConnector.class, ConnectorLiteral.of(InMemoryConnector.CONNECTOR)).get();
+        assertThat(bean).isNotNull();
+        assertThatThrownBy(() -> bean.sink("unknown")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testSwitchAndClear() {
+        assertThat(System.getProperties()).doesNotContainKeys(
+                "mp.messaging.incoming.a.connector", "mp.messaging.incoming.b.connector",
+                "mp.messaging.outgoing.x.connector", "mp.messaging.outgoing.y.connector");
+
+        InMemoryConnector.switchIncomingChannelsToInMemory("a", "b");
+        InMemoryConnector.switchOutgoingChannelsToInMemory("x", "y");
+        assertThat(System.getProperties())
+                .contains(entry("mp.messaging.incoming.a.connector", InMemoryConnector.CONNECTOR));
+        assertThat(System.getProperties())
+                .contains(entry("mp.messaging.incoming.b.connector", InMemoryConnector.CONNECTOR));
+        assertThat(System.getProperties())
+                .contains(entry("mp.messaging.outgoing.x.connector", InMemoryConnector.CONNECTOR));
+        assertThat(System.getProperties())
+                .contains(entry("mp.messaging.outgoing.y.connector", InMemoryConnector.CONNECTOR));
+
+        InMemoryConnector.clear();
+
+        assertThat(System.getProperties()).doesNotContainKeys(
+                "mp.messaging.incoming.a.connector", "mp.messaging.incoming.b.connector",
+                "mp.messaging.outgoing.x.connector", "mp.messaging.outgoing.y.connector");
+    }
+
+    @Test
+    public void testSwitchOnApplication() {
+        addBeanClass(MyBeanReceivingString.class);
+        Map<String, String> map1 = InMemoryConnector.switchIncomingChannelsToInMemory("foo");
+        Map<String, String> map2 = InMemoryConnector.switchOutgoingChannelsToInMemory("bar");
+        initialize();
+
+        assertThat(map1).containsExactly(entry("mp.messaging.incoming.foo.connector", InMemoryConnector.CONNECTOR));
+        assertThat(map2).containsExactly(entry("mp.messaging.outgoing.bar.connector", InMemoryConnector.CONNECTOR));
+
+        InMemoryConnector connector = container.getBeanManager().createInstance()
+                .select(InMemoryConnector.class, ConnectorLiteral.of(InMemoryConnector.CONNECTOR)).get();
+
+        connector.source("foo").send("hello");
+        await().untilAsserted(() -> assertThat(connector.sink("bar").received().stream()
+                .map(Message::getPayload).collect(Collectors.toList())).containsExactly("HELLO"));
+    }
+
+    @ApplicationScoped
+    public static class MyBeanReceivingString {
+
+        @Incoming("foo")
+        @Outgoing("bar")
+        @Blocking
+        public String process(String s) {
+            return s.toUpperCase();
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyBeanReceivingMessage {
+
+        @Incoming("foo")
+        @Outgoing("bar")
+        public Message<String> process(Message<String> s) {
+            return s.withPayload(s.getPayload().toUpperCase());
+        }
+
+    }
+
+}

--- a/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/providers/connectors/LocalPropagationTest.java
+++ b/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/providers/connectors/LocalPropagationTest.java
@@ -1,0 +1,612 @@
+package io.smallrye.reactive.messaging.providers.connectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.RepeatedTest;
+
+import io.smallrye.common.vertx.ContextLocals;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+import io.smallrye.reactive.messaging.annotations.Merge;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySource;
+import io.smallrye.reactive.messaging.providers.locals.LocalContextMetadata;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.core.impl.ConcurrentHashSet;
+import io.vertx.mutiny.core.Context;
+
+public class LocalPropagationTest extends WeldTestBaseWithoutTails {
+
+    private MapBasedConfig config() {
+        return new MapBasedConfig()
+                .with("mp.messaging.incoming.data.connector", InMemoryConnector.CONNECTOR)
+                .with("mp.messaging.incoming.data.run-on-vertx-context", true);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        releaseConfig();
+    }
+
+    void sendMessagesWithSource() {
+        InMemoryConnector connector = getConnector();
+        InMemorySource<Integer> data = connector.source("data");
+        data.send(1).send(2).send(3).send(4).send(5);
+    }
+
+    @RepeatedTest(30)
+    public void testLinearPipeline() {
+        LinearPipeline bean = runApplication(config(), LinearPipeline.class);
+        sendMessagesWithSource();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.getResults().size() >= 5);
+        assertThat(bean.getResults()).containsExactly(2, 3, 4, 5, 6);
+    }
+
+    @RepeatedTest(30)
+    public void testPipelineWithABlockingStage() {
+        PipelineWithABlockingStage bean = runApplication(config(), PipelineWithABlockingStage.class);
+        sendMessagesWithSource();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.getResults().size() >= 5);
+        assertThat(bean.getResults()).containsExactly(2, 3, 4, 5, 6);
+    }
+
+    @RepeatedTest(30)
+    public void testPipelineWithAnAsyncStage() {
+        PipelineWithAnAsyncStage bean = runApplication(config(), PipelineWithAnAsyncStage.class);
+        sendMessagesWithSource();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.getResults().size() >= 5);
+        assertThat(bean.getResults()).containsExactly(2, 3, 4, 5, 6);
+    }
+
+    @RepeatedTest(30)
+    public void testPipelineWithAnUnorderedBlockingStage() {
+        PipelineWithAnUnorderedBlockingStage bean = runApplication(config(), PipelineWithAnUnorderedBlockingStage.class);
+        sendMessagesWithSource();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.getResults().size() >= 5);
+        assertThat(bean.getResults()).containsExactlyInAnyOrder(2, 3, 4, 5, 6);
+
+    }
+
+    @RepeatedTest(30)
+    public void testPipelineWithMultipleBlockingStages() {
+        PipelineWithMultipleBlockingStages bean = runApplication(config(), PipelineWithMultipleBlockingStages.class);
+        sendMessagesWithSource();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.getResults().size() >= 5);
+        assertThat(bean.getResults()).containsExactlyInAnyOrder(2, 3, 4, 5, 6);
+    }
+
+    @RepeatedTest(30)
+    public void testPipelineWithBroadcastAndMerge() {
+        PipelineWithBroadcastAndMerge bean = runApplication(config(), PipelineWithBroadcastAndMerge.class);
+        sendMessagesWithSource();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.getResults().size() >= 10);
+        assertThat(bean.getResults()).hasSize(10).contains(2, 3, 4, 5, 6);
+    }
+
+    @RepeatedTest(30)
+    public void testLinearPipelineWithAckOnCustomThread() {
+        LinearPipelineWithAckOnCustomThread bean = runApplication(config(), LinearPipelineWithAckOnCustomThread.class);
+        sendMessagesWithSource();
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.getResults().size() >= 5);
+        assertThat(bean.getResults()).containsExactly(2, 3, 4, 5, 6);
+    }
+
+    @ApplicationScoped
+    public static class LinearPipeline {
+
+        private final List<Integer> list = new CopyOnWriteArrayList<>();
+        private final Set<String> uuids = new ConcurrentHashSet<>();
+
+        @Incoming("data")
+        @Outgoing("process")
+        @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+        public Message<Integer> process(Message<Integer> input) {
+            String value = UUID.randomUUID().toString();
+            ContextLocals.put("uuid", value);
+            ContextLocals.put("input", input.getPayload());
+
+            return input.withPayload(input.getPayload() + 1);
+        }
+
+        @Incoming("process")
+        @Outgoing("after-process")
+        public Integer handle(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            assertThat(uuids.add(uuid)).isTrue();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("after-process")
+        @Outgoing("sink")
+        public Integer afterProcess(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("sink")
+        public void sink(int val) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(val);
+            list.add(val);
+        }
+
+        public List<Integer> getResults() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class LinearPipelineWithAckOnCustomThread {
+
+        private final List<Integer> list = new CopyOnWriteArrayList<>();
+        private final Set<String> uuids = new ConcurrentHashSet<>();
+
+        private final Executor executor = Executors.newFixedThreadPool(4);
+
+        @Incoming("data")
+        @Outgoing("process")
+        @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+        public Message<Integer> process(Message<Integer> input) {
+            String value = UUID.randomUUID().toString();
+            assertThat((String) ContextLocals.get("uuid", null)).isNull();
+            ContextLocals.put("uuid", value);
+            ContextLocals.put("input", input.getPayload());
+
+            return input.withPayload(input.getPayload() + 1)
+                    .withAck(() -> {
+                        CompletableFuture<Void> cf = new CompletableFuture<>();
+                        executor.execute(() -> cf.complete(null));
+                        return cf;
+                    });
+        }
+
+        @Incoming("process")
+        @Outgoing("after-process")
+        public Integer handle(int payload) {
+            try {
+                String uuid = ContextLocals.get("uuid", null);
+                assertThat(uuid).isNotNull();
+
+                assertThat(uuids.add(uuid)).isTrue();
+
+                int p = ContextLocals.get("input", null);
+                assertThat(p + 1).isEqualTo(payload);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            return payload;
+        }
+
+        @Incoming("after-process")
+        @Outgoing("sink")
+        public Integer afterProcess(int payload) {
+            try {
+                String uuid = ContextLocals.get("uuid", null);
+                assertThat(uuid).isNotNull();
+
+                int p = ContextLocals.get("input", null);
+                assertThat(p + 1).isEqualTo(payload);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            return payload;
+        }
+
+        @Incoming("sink")
+        public void sink(int val) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(val);
+            list.add(val);
+        }
+
+        public List<Integer> getResults() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PipelineWithABlockingStage {
+
+        private final List<Integer> list = new CopyOnWriteArrayList<>();
+        private final Set<String> uuids = new ConcurrentHashSet<>();
+
+        @Incoming("data")
+        @Outgoing("process")
+        @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+        public Message<Integer> process(Message<Integer> input) {
+            String value = UUID.randomUUID().toString();
+            assertThat((String) ContextLocals.get("uuid", null)).isNull();
+            ContextLocals.put("uuid", value);
+            ContextLocals.put("input", input.getPayload());
+
+            assertThat(input.getMetadata(LocalContextMetadata.class)).isPresent();
+
+            return input.withPayload(input.getPayload() + 1);
+        }
+
+        @Incoming("process")
+        @Outgoing("after-process")
+        @Blocking
+        public Integer handle(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            assertThat(uuids.add(uuid)).isTrue();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("after-process")
+        @Outgoing("sink")
+        public Integer afterProcess(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("sink")
+        public void sink(int val) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(val);
+            list.add(val);
+        }
+
+        public List<Integer> getResults() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PipelineWithAnAsyncStage {
+
+        private final List<Integer> list = new CopyOnWriteArrayList<>();
+        private final Set<String> uuids = new ConcurrentHashSet<>();
+
+        @Incoming("data")
+        @Outgoing("process")
+        @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+        public Message<Integer> process(Message<Integer> input) {
+            String value = UUID.randomUUID().toString();
+            assertThat((String) ContextLocals.get("uuid", null)).isNull();
+            ContextLocals.put("uuid", value);
+            ContextLocals.put("input", input.getPayload());
+
+            assertThat(input.getMetadata(LocalContextMetadata.class)).isPresent();
+
+            return input.withPayload(input.getPayload() + 1);
+        }
+
+        @Incoming("process")
+        @Outgoing("after-process")
+        public Uni<Integer> handle(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            assertThat(uuids.add(uuid)).isTrue();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return Uni.createFrom().item(() -> payload)
+                    .runSubscriptionOn(Infrastructure.getDefaultExecutor());
+        }
+
+        @Incoming("after-process")
+        @Outgoing("sink")
+        public Integer afterProcess(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("sink")
+        public void sink(int val) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(val);
+            list.add(val);
+        }
+
+        public List<Integer> getResults() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PipelineWithAnUnorderedBlockingStage {
+
+        private final List<Integer> list = new CopyOnWriteArrayList<>();
+        private final Set<String> uuids = new ConcurrentHashSet<>();
+
+        @Incoming("data")
+        @Outgoing("process")
+        @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+        public Message<Integer> process(Message<Integer> input) {
+            String value = UUID.randomUUID().toString();
+            assertThat((String) ContextLocals.get("uuid", null)).isNull();
+            ContextLocals.put("uuid", value);
+            ContextLocals.put("input", input.getPayload());
+
+            assertThat(input.getMetadata(LocalContextMetadata.class)).isPresent();
+
+            return input.withPayload(input.getPayload() + 1);
+        }
+
+        private final Random random = new Random();
+
+        @Incoming("process")
+        @Outgoing("after-process")
+        @Blocking(ordered = false)
+        public Integer handle(int payload) throws InterruptedException {
+            Thread.sleep(random.nextInt(10));
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+            assertThat(uuids.add(uuid)).isTrue();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("after-process")
+        @Outgoing("sink")
+        public Integer afterProcess(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("sink")
+        public void sink(int val) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(val);
+            list.add(val);
+        }
+
+        public List<Integer> getResults() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PipelineWithMultipleBlockingStages {
+
+        private final List<Integer> list = new CopyOnWriteArrayList<>();
+        private final Set<String> uuids = new ConcurrentHashSet<>();
+
+        @Incoming("data")
+        @Outgoing("process")
+        @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+        public Message<Integer> process(Message<Integer> input) {
+            String value = UUID.randomUUID().toString();
+            assertThat((String) ContextLocals.get("uuid", null)).isNull();
+            ContextLocals.put("uuid", value);
+            ContextLocals.put("input", input.getPayload());
+
+            assertThat(input.getMetadata(LocalContextMetadata.class)).isPresent();
+
+            return input.withPayload(input.getPayload() + 1);
+        }
+
+        private final Random random = new Random();
+
+        @Incoming("process")
+        @Outgoing("second-blocking")
+        @Blocking(ordered = false)
+        public Integer handle(int payload) throws InterruptedException {
+            Thread.sleep(random.nextInt(10));
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+            assertThat(uuids.add(uuid)).isTrue();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("second-blocking")
+        @Outgoing("after-process")
+        @Blocking
+        public Integer handle2(int payload) throws InterruptedException {
+            Thread.sleep(random.nextInt(10));
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("after-process")
+        @Outgoing("sink")
+        public Integer afterProcess(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("sink")
+        public void sink(int val) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(val);
+            list.add(val);
+        }
+
+        public List<Integer> getResults() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PipelineWithBroadcastAndMerge {
+
+        private final List<Integer> list = new CopyOnWriteArrayList<>();
+        private final Set<String> branch1 = new ConcurrentHashSet<>();
+        private final Set<String> branch2 = new ConcurrentHashSet<>();
+
+        @Incoming("data")
+        @Outgoing("process")
+        @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+        @Broadcast(2)
+        public Message<Integer> process(Message<Integer> input) {
+            String value = UUID.randomUUID().toString();
+            assertThat((String) ContextLocals.get("uuid", null)).isNull();
+            ContextLocals.put("uuid", value);
+            ContextLocals.put("input", input.getPayload());
+
+            assertThat(input.getMetadata(LocalContextMetadata.class)).isPresent();
+
+            return input.withPayload(input.getPayload() + 1);
+        }
+
+        @Incoming("process")
+        @Outgoing("after-process")
+        public Integer branch1(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+            assertThat(branch1.add(uuid)).isTrue();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("process")
+        @Outgoing("after-process")
+        public Integer branch2(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+            assertThat(branch2.add(uuid)).isTrue();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("after-process")
+        @Outgoing("sink")
+        @Merge
+        public Integer afterProcess(int payload) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(payload);
+            return payload;
+        }
+
+        @Incoming("sink")
+        public void sink(int val) {
+            String uuid = ContextLocals.get("uuid", null);
+            assertThat(uuid).isNotNull();
+
+            int p = ContextLocals.get("input", null);
+            assertThat(p + 1).isEqualTo(val);
+            list.add(val);
+        }
+
+        public List<Integer> getResults() {
+            return list;
+        }
+    }
+
+    @ApplicationScoped
+    public static class EmitterOnContext {
+
+        @Inject
+        ExecutionHolder executionHolder;
+
+        @Inject
+        @Channel("data")
+        Emitter<Integer> emitter;
+
+        public void emitMessages(List<Integer> payloads) {
+            Context context = executionHolder.vertx().getOrCreateContext();
+            context.runOnContext(() -> payloads.forEach(p -> emitter.send(p)));
+        }
+    }
+
+    @ApplicationScoped
+    public static class MutinyEmitterOnContext {
+
+        @Inject
+        ExecutionHolder executionHolder;
+
+        @Inject
+        @Channel("data")
+        MutinyEmitter<Integer> emitter;
+
+        public Uni<Void> emitMessages(List<Integer> payloads) {
+            Context context = executionHolder.vertx().getOrCreateContext();
+            return Multi.createFrom().iterable(payloads)
+                    .onItem()
+                    .transformToUniAndConcatenate(p -> emitter.send(p).runSubscriptionOn(context::runOnContext))
+                    .toUni().replaceWithVoid();
+        }
+    }
+
+}

--- a/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/providers/connectors/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-in-memory/src/test/java/io/smallrye/reactive/messaging/providers/connectors/WeldTestBaseWithoutTails.java
@@ -1,0 +1,215 @@
+package io.smallrye.reactive.messaging.providers.connectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.spi.Extension;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.providers.MediatorFactory;
+import io.smallrye.reactive.messaging.providers.OutgoingInterceptorDecorator;
+import io.smallrye.reactive.messaging.providers.extension.ChannelProducer;
+import io.smallrye.reactive.messaging.providers.extension.EmitterFactoryImpl;
+import io.smallrye.reactive.messaging.providers.extension.HealthCenter;
+import io.smallrye.reactive.messaging.providers.extension.LegacyEmitterFactoryImpl;
+import io.smallrye.reactive.messaging.providers.extension.MediatorManager;
+import io.smallrye.reactive.messaging.providers.extension.MutinyEmitterFactoryImpl;
+import io.smallrye.reactive.messaging.providers.extension.ReactiveMessagingExtension;
+import io.smallrye.reactive.messaging.providers.impl.ConfiguredChannelFactory;
+import io.smallrye.reactive.messaging.providers.impl.ConnectorFactories;
+import io.smallrye.reactive.messaging.providers.impl.InternalChannelRegistry;
+import io.smallrye.reactive.messaging.providers.locals.ContextDecorator;
+import io.smallrye.reactive.messaging.providers.metrics.MetricDecorator;
+import io.smallrye.reactive.messaging.providers.metrics.MicrometerDecorator;
+import io.smallrye.reactive.messaging.providers.wiring.Wiring;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class WeldTestBaseWithoutTails {
+
+    static final List<String> EXPECTED = Multi.createFrom().range(1, 11).flatMap(i -> Multi.createFrom().items(i, i))
+            .map(i -> Integer.toString(i))
+            .collect().asList()
+            .await().indefinitely();
+
+    protected SeContainerInitializer initializer;
+
+    protected SeContainer container;
+
+    @BeforeAll
+    public static void disableLogging() {
+        System.setProperty("java.util.logging.config.file", "logging.properties");
+    }
+
+    public static void releaseConfig() {
+        SmallRyeConfigProviderResolver.instance()
+                .releaseConfig(ConfigProvider.getConfig(WeldTestBaseWithoutTails.class.getClassLoader()));
+        clearConfigFile();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private static void clearConfigFile() {
+        File out = new File("target/test-classes/META-INF/microprofile-config.properties");
+        if (out.isFile()) {
+            out.delete();
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public static void installConfig(String path) {
+        releaseConfig();
+        File file = new File(path);
+        if (file.isFile()) {
+            File out = new File("target/test-classes/META-INF/microprofile-config.properties");
+            if (out.isFile()) {
+                out.delete();
+            }
+            out.getParentFile().mkdirs();
+            try {
+                Files.copy(file.toPath(), out.toPath());
+                System.out.println("Installed configuration:");
+                List<String> list = Files.readAllLines(out.toPath());
+                list.forEach(System.out::println);
+                System.out.println("---------");
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        } else {
+            throw new IllegalArgumentException("File " + file.getAbsolutePath() + " does not exist " + path);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        releaseConfig();
+        initializer = SeContainerInitializer.newInstance();
+
+        initializer.addBeanClasses(MediatorFactory.class,
+                Wiring.class,
+                ExecutionHolder.class,
+                MediatorManager.class,
+                WorkerPoolRegistry.class,
+                InternalChannelRegistry.class,
+                ChannelProducer.class,
+                ConfiguredChannelFactory.class,
+                ConnectorFactories.class,
+                MicrometerDecorator.class,
+                MetricDecorator.class,
+                HealthCenter.class,
+                ContextDecorator.class,
+                // Messaging provider
+                InMemoryConnector.class,
+                // Emitter factories
+                EmitterFactoryImpl.class,
+                MutinyEmitterFactoryImpl.class,
+                LegacyEmitterFactoryImpl.class,
+                OutgoingInterceptorDecorator.class,
+
+                // SmallRye config
+                io.smallrye.config.inject.ConfigProducer.class);
+
+        List<Class<?>> beans = getBeans();
+        initializer.addBeanClasses(beans.toArray(new Class<?>[0]));
+        initializer.disableDiscovery();
+        initializer.addExtensions(new ReactiveMessagingExtension());
+    }
+
+    public List<Class<?>> getBeans() {
+        return Collections.emptyList();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (container != null && container.isRunning()) {
+            container.close();
+            container = null;
+        }
+    }
+
+    protected ChannelRegistry registry(SeContainer container) {
+        return container.select(ChannelRegistry.class).get();
+    }
+
+    public void addBeanClass(Class<?>... beanClass) {
+        initializer.addBeanClasses(beanClass);
+    }
+
+    @SafeVarargs
+    public final void addExtensionClass(Class<? extends Extension>... extensionClasses) {
+        initializer.addExtensions(extensionClasses);
+    }
+
+    public <T> T runApplication(MapBasedConfig config, Class<T> clazz) {
+        addBeanClass(clazz);
+        runApplication(config);
+        return get(clazz);
+    }
+
+    public void runApplication(MapBasedConfig config) {
+        if (config != null) {
+            config.write();
+        } else {
+            MapBasedConfig.cleanup();
+        }
+
+        initialize();
+    }
+
+    public static void addConfig(MapBasedConfig config) {
+        if (config != null) {
+            config.write();
+        } else {
+            MapBasedConfig.cleanup();
+        }
+    }
+
+    public void initialize() {
+        assert container == null;
+        container = initializer.initialize();
+    }
+
+    protected <T> T installInitializeAndGet(Class<T> beanClass) {
+        return installInitializeAndGet(beanClass, true);
+    }
+
+    protected <T> T installInitializeAndGet(Class<T> beanClass, boolean assertNoWiringErrors) {
+        initializer.addBeanClasses(beanClass);
+        initialize();
+
+        if (assertNoWiringErrors) {
+            assertNoWiringErrors();
+        }
+
+        return get(beanClass);
+    }
+
+    private void assertNoWiringErrors() {
+        Wiring wiring = get(Wiring.class);
+        assertThat(wiring.getGraph().hasWiringErrors()).isFalse();
+    }
+
+    protected <T> T get(Class<T> c) {
+        return container.getBeanManager().createInstance().select(c).get();
+    }
+
+    protected InMemoryConnector getConnector() {
+        return container.getBeanManager().createInstance().select(InMemoryConnector.class,
+                ConnectorLiteral.of(InMemoryConnector.CONNECTOR)).get();
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/MultiUtils.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/MultiUtils.java
@@ -158,8 +158,11 @@ public class MultiUtils {
             if (isDoneOrCancelled()) {
                 return;
             }
-
             this.done = true;
+            Flow.Subscriber<? super T> subscriber = downstream;
+            if (subscriber != null) {
+                subscriber.onError(failure);
+            }
         }
 
         @Override
@@ -168,6 +171,10 @@ public class MultiUtils {
                 return;
             }
             this.done = true;
+            Flow.Subscriber<? super T> subscriber = downstream;
+            if (subscriber != null) {
+                subscriber.onComplete();
+            }
         }
 
         @Override


### PR DESCRIPTION
In-memory connector config and flag for dispatching messages on Vert.x context. 
The in-memory incoming channels can configure `run-on-vertx-context` attribute, or set `InMemorySource#runOnVertxContext` flag during a test for the channel to dispatch events (messages, failure and completion) on Vert.x context. The dispatched messages are wrapped in `ContextAwareMessage` to associate and propagate the message context. 
- Migrates the connector to InboundConnector and OutboundConnector
- Contains fix for `MultiUtils.via` for dispatching failure and completion events.