### PR TITLE
Definition exception for multiple different emitter configurations for a channel

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/DefaultEmitterConfiguration.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/DefaultEmitterConfiguration.java
@@ -1,5 +1,7 @@
 package io.smallrye.reactive.messaging.providers;
 
+import java.util.Objects;
+
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 
 import io.smallrye.reactive.messaging.EmitterConfiguration;
@@ -66,5 +68,38 @@ public class DefaultEmitterConfiguration implements EmitterConfiguration {
     @Override
     public int numberOfSubscriberBeforeConnecting() {
         return numberOfSubscriberBeforeConnecting;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DefaultEmitterConfiguration that = (DefaultEmitterConfiguration) o;
+        return overflowBufferSize == that.overflowBufferSize
+                && broadcast == that.broadcast
+                && numberOfSubscriberBeforeConnecting == that.numberOfSubscriberBeforeConnecting
+                && Objects.equals(name, that.name)
+                && Objects.equals(emitterType, that.emitterType)
+                && overflowBufferStrategy == that.overflowBufferStrategy;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, emitterType, overflowBufferStrategy, overflowBufferSize, broadcast,
+                numberOfSubscriberBeforeConnecting);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultEmitterConfiguration{" +
+                "name='" + name + '\'' +
+                ", emitterType=" + emitterType +
+                ", overflowBufferStrategy=" + overflowBufferStrategy +
+                ", overflowBufferSize=" + overflowBufferSize +
+                ", broadcast=" + broadcast +
+                ", numberOfSubscriberBeforeConnecting=" + numberOfSubscriberBeforeConnecting +
+                '}';
     }
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderExceptions.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderExceptions.java
@@ -296,4 +296,8 @@ public interface ProviderExceptions {
 
     @Message(id = 1006, value = "Only one subscriber allowed")
     IllegalStateException illegalStateOnlyOneSubscriber();
+
+    @Message(id = 1008, value = "Emitter configuration for channel `%s` in %s is different than a previous configuration : %s")
+    DefinitionException differentEmitterConfigurationPerInjection(String channel, String injectionPoint, String config);
+
 }


### PR DESCRIPTION
This may happen if an emitter channel is defined (injected) in multiple points with different descriptions of overflow strategy, broadcast etc.

Closes #2351