### PR TITLE
Kafka config override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
 
     <nats-embedded.version>2.1.1</nats-embedded.version>
     <slf4j-log4j12.version>1.7.36</slf4j-log4j12.version>
+    <slf4j-reload4j.version>2.0.9</slf4j-reload4j.version>
     <opencsv.version>5.9</opencsv.version>
     <strimzi-test-container.version>0.105.0</strimzi-test-container.version>
 
@@ -309,6 +310,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <version>${slf4j-log4j12.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-reload4j</artifactId>
+        <version>${slf4j-reload4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/smallrye-reactive-messaging-kafka-test-companion/pom.xml
+++ b/smallrye-reactive-messaging-kafka-test-companion/pom.xml
@@ -67,10 +67,10 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- Ensure log4j1 log backend with slf4j -->
+    <!-- Ensure log4j log backend with slf4j -->
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/smallrye-reactive-messaging-kafka/pom.xml
+++ b/smallrye-reactive-messaging-kafka/pom.xml
@@ -130,10 +130,10 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Ensure log4j1 log backend with slf4j -->
+    <!-- Ensure log4j log backend with slf4j -->
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterSerializationHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterSerializationHandler.java
@@ -10,16 +10,21 @@ import static io.smallrye.reactive.messaging.kafka.DeserializationFailureHandler
 import java.util.Arrays;
 import java.util.Objects;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.kafka.SerializationFailureHandler;
 
-public class KafkaDeadLetterSerializationHandler<T> implements SerializationFailureHandler<T> {
+@ApplicationScoped
+@Identifier("dlq-serialization")
+public class KafkaDeadLetterSerializationHandler implements SerializationFailureHandler<Object> {
 
     @Override
-    public byte[] decorateSerialization(Uni<byte[]> serialization, String topic, boolean isKey, String serializer, T data,
+    public byte[] decorateSerialization(Uni<byte[]> serialization, String topic, boolean isKey, String serializer, Object data,
             Headers headers) {
         // deserializer failure
         if (headers.lastHeader(DESERIALIZATION_FAILURE_DESERIALIZER) != null) {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/base/WeldTestBase.java
@@ -21,6 +21,7 @@ import io.smallrye.reactive.messaging.kafka.commit.KafkaIgnoreCommit;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaLatestCommit;
 import io.smallrye.reactive.messaging.kafka.commit.KafkaThrottledLatestProcessedCommit;
 import io.smallrye.reactive.messaging.kafka.fault.KafkaDeadLetterQueue;
+import io.smallrye.reactive.messaging.kafka.fault.KafkaDeadLetterSerializationHandler;
 import io.smallrye.reactive.messaging.kafka.fault.KafkaFailStop;
 import io.smallrye.reactive.messaging.kafka.fault.KafkaFailureHandler;
 import io.smallrye.reactive.messaging.kafka.fault.KafkaIgnoreFailure;
@@ -98,6 +99,7 @@ public class WeldTestBase {
         weld.addBeanClass(KafkaFailStop.Factory.class);
         weld.addBeanClass(KafkaIgnoreFailure.Factory.class);
         weld.addBeanClass(KafkaDeadLetterQueue.Factory.class);
+        weld.addBeanClass(KafkaDeadLetterSerializationHandler.class);
         weld.addBeanClass(KafkaCDIEvents.class);
         weld.addBeanClass(KafkaConnector.class);
         weld.addBeanClass(KafkaClientServiceImpl.class);

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/metrics/ObservationTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/metrics/ObservationTest.java
@@ -232,7 +232,6 @@ public class ObservationTest extends KafkaCompanionTestBase {
                 if (metadata.isPresent()) {
                     Instant inst = metadata.get().getTimestamp();
                     recordTs = inst.toEpochMilli();
-                    System.out.println("record " + recordTs);
                 } else {
                     recordTs = 0L;
                 }
@@ -242,7 +241,6 @@ public class ObservationTest extends KafkaCompanionTestBase {
             public void onMessageAck(Message<?> message) {
                 super.onMessageAck(message);
                 completedMs = System.currentTimeMillis();
-                System.out.println("completed in " + completedMs);
                 done = true;
             }
         }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/OverrideConnectorConfig.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/OverrideConnectorConfig.java
@@ -1,0 +1,189 @@
+package io.smallrye.reactive.messaging.providers.impl;
+
+import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.CHANNEL_NAME_ATTRIBUTE;
+import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.CONNECTOR_PREFIX;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.eclipse.microprofile.config.Config;
+
+/**
+ * Represents a configuration class that allows overriding specific properties for a connector.
+ * If a nested-channel is defined, property lookups will be in the following order
+ * <ol>
+ * <li>If nested-channel is given try [prefix].[channel].[nested-channel].[property-key]</li>
+ * <li>If an override function is given for a property-key, calls it converts the return value</li>
+ * <li>Calls the {@link ConnectorConfig} base function</li>
+ * </ol>
+ * The function {@link #getOriginalValue(String, Class)} allows accessing the connector config without override.
+ *
+ * @see ConnectorConfig
+ */
+public class OverrideConnectorConfig extends ConnectorConfig {
+
+    private final String nestedChannel;
+    private final Map<String, Function<OverrideConnectorConfig, Object>> overrides;
+
+    public OverrideConnectorConfig(String prefix, Config overall, String channel,
+            Map<String, Function<OverrideConnectorConfig, Object>> overrides) {
+        this(prefix, overall, channel, null, overrides);
+    }
+
+    public OverrideConnectorConfig(String prefix, Config overall, String channel, String nestedChannel) {
+        this(prefix, overall, channel, nestedChannel, new HashMap<>());
+    }
+
+    public OverrideConnectorConfig(String prefix, Config overall, String channel, String nestedChannel,
+            Map<String, Function<OverrideConnectorConfig, Object>> overrides) {
+        super(prefix, overall, channel);
+        this.nestedChannel = nestedChannel;
+        this.overrides = overrides;
+    }
+
+    protected String nestedChannelKey(String keyName) {
+        return nestedChannel == null ? keyName : nestedChannel + "." + keyName;
+    }
+
+    public <T> Optional<T> getOriginalValue(String propertyName, Class<T> propertyType) {
+        return super.getOptionalValue(propertyName, propertyType);
+    }
+
+    @Override
+    public <T> T getValue(String propertyName, Class<T> propertyType) {
+        if (nestedChannel != null) {
+            // First check if the nestedChannel channel configuration contains the desired attribute.
+            Optional<T> maybeResult = super.getOptionalValue(nestedChannelKey(propertyName), propertyType);
+            if (maybeResult.isPresent()) {
+                return maybeResult.get();
+            }
+        }
+        Function<OverrideConnectorConfig, Object> function = overrides.get(propertyName);
+        if (function != null) {
+            Object o = function.apply(this);
+            if (o != null) {
+                if (propertyType.isInstance(o)) {
+                    return (T) o;
+                }
+                if (o instanceof String) {
+                    return convert(((String) o), propertyType);
+                }
+            }
+        }
+        return super.getValue(propertyName, propertyType);
+    }
+
+    @Override
+    public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+        if (nestedChannel != null) {
+            // First check if the nestedChannel channel configuration contains the desired attribute.
+            Optional<T> maybe = super.getOptionalValue(nestedChannelKey(propertyName), propertyType);
+            if (maybe.isPresent()) {
+                return maybe;
+            }
+        }
+        Function<OverrideConnectorConfig, Object> function = overrides.get(propertyName);
+        if (function != null) {
+            Object o = function.apply(this);
+            if (o != null) {
+                if (propertyType.isInstance(o)) {
+                    return Optional.of((T) o);
+                }
+                if (o instanceof String) {
+                    return convertOptional((String) o, propertyType);
+                }
+                return Optional.empty();
+            }
+        }
+        return super.getOptionalValue(propertyName, propertyType);
+    }
+
+    /**
+     * Gets the lists of config keys for the given connector.
+     * Note that the list contains property names from the config and env variables.
+     * It includes keys from the connector config and channel config.
+     *
+     * @return the list of keys
+     */
+    @Override
+    public Iterable<String> getPropertyNames() {
+        String prefix = channelPrefix;
+        String nestedPrefix = channelPrefix + nestedChannel + ".";
+        String prefixAlpha = toAlpha(prefix);
+        String nestedPrefixAlpha = toAlpha(nestedPrefix);
+        String prefixAlphaUpper = prefixAlpha.toUpperCase();
+        String nestedPrefixAlphaUpper = nestedPrefixAlpha.toUpperCase();
+        String connectorPrefix = CONNECTOR_PREFIX + connector + ".";
+        String connectorNestedPrefix = connectorPrefix + nestedChannel + ".";
+        String connectorPrefixAlpha = toAlpha(connectorPrefix);
+        String connectorNestedPrefixAlpha = toAlpha(connectorNestedPrefix);
+        String connectorPrefixAlphaUpper = connectorPrefixAlpha.toUpperCase();
+        String connectorNestedPrefixAlphaUpper = connectorNestedPrefixAlpha.toUpperCase();
+
+        Set<String> names = new HashSet<>();
+        for (String name : overall.getPropertyNames()) {
+            if (name.startsWith(connectorNestedPrefix)) {
+                String computed = name.substring(connectorNestedPrefix.length());
+                names.add(computed);
+            } else if (name.startsWith(connectorPrefix)) {
+                String computed = name.substring(connectorPrefix.length());
+                names.add(computed);
+            } else if (name.startsWith(connectorNestedPrefixAlpha)) {
+                String computed = name.substring(connectorNestedPrefixAlpha.length());
+                if (nameExists(connectorNestedPrefix + computed)) {
+                    names.add(computed);
+                }
+            } else if (name.startsWith(connectorPrefixAlpha)) {
+                String computed = name.substring(connectorPrefixAlpha.length());
+                if (nameExists(connectorPrefix + computed)) {
+                    names.add(computed);
+                }
+            } else if (name.startsWith(connectorNestedPrefixAlphaUpper)) {
+                String computed = name.substring(connectorNestedPrefixAlphaUpper.length());
+                if (nameExists(connectorNestedPrefix + computed)) {
+                    names.add(computed);
+                }
+            } else if (name.startsWith(connectorPrefixAlphaUpper)) {
+                String computed = name.substring(connectorPrefixAlphaUpper.length());
+                if (nameExists(connectorPrefix + computed)) {
+                    names.add(computed);
+                }
+            } else if (name.startsWith(prefix)) {
+                String computed = name.substring(prefix.length());
+                names.add(computed);
+            } else if (name.startsWith(nestedPrefix)) {
+                String computed = name.substring(nestedPrefix.length());
+                names.add(computed);
+            } else if (name.startsWith(prefixAlpha)) {
+                String computed = name.substring(prefixAlpha.length());
+                if (nameExists(prefix + computed)) {
+                    names.add(computed);
+                }
+            } else if (name.startsWith(nestedPrefixAlpha)) {
+                String computed = name.substring(nestedPrefixAlpha.length());
+                if (nameExists(nestedPrefix + computed)) {
+                    names.add(computed);
+                }
+            } else if (name.startsWith(prefixAlphaUpper)) {
+                String computed = name.substring(prefixAlphaUpper.length());
+                if (nameExists(prefix + computed)) {
+                    names.add(computed);
+                }
+            } else if (name.startsWith(nestedPrefixAlphaUpper)) {
+                String computed = name.substring(nestedPrefixAlphaUpper.length());
+                if (nameExists(nestedPrefix + computed)) {
+                    names.add(computed);
+                }
+            }
+        }
+
+        names.add(CHANNEL_NAME_ATTRIBUTE);
+        names.addAll(overrides.keySet());
+        return names;
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/impl/OverrideConnectorConfigTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/impl/OverrideConnectorConfigTest.java
@@ -1,0 +1,189 @@
+package io.smallrye.reactive.messaging.providers.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.reactive.messaging.test.common.config.SetEnvironmentVariable;
+
+@SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_ATTR", value = "new-value")
+@SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_AT_TR", value = "another-value")
+@SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_KEY", value = "another-value-from-connector")
+@SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_OTHER_KEY", value = "another-value-other")
+@SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR1", value = "should not be used")
+@SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR3", value = "used")
+@SetEnvironmentVariable(key = "mp_messaging_connector_some_connector_attr4", value = "used")
+@SetEnvironmentVariable(key = "mp_messaging_connector_SOME_CONNECTOR_mixedcase", value = "used")
+class OverrideConnectorConfigTest {
+
+    private SmallRyeConfig overallConfig;
+    private OverrideConnectorConfig config;
+    private OverrideConnectorConfig config2;
+
+    @BeforeEach
+    public void createTestConfig() {
+        Map<String, String> cfg = new HashMap<>();
+        cfg.put("mp.messaging.incoming.bar.connector", "some-connector");
+        cfg.put("mp.messaging.incoming.bar.test", "test");
+        cfg.put("mp.messaging.incoming.foo.connector", "some-connector");
+        cfg.put("mp.messaging.incoming.foo.attr1", "value");
+        cfg.put("mp.messaging.incoming.foo.attr2", "23");
+        cfg.put("mp.messaging.incoming.foo.attr.2", "test");
+        cfg.put("mp.messaging.incoming.foo.at-tr", "test");
+        cfg.put("mp.messaging.incoming.foo.bar.qux", "value");
+        cfg.put("mp.messaging.connector.some-connector.key", "value");
+        cfg.put("mp.messaging.connector.some-connector.some-key", "should not be used");
+        cfg.put("mp.messaging.connector.some-connector.bar.other-key", "another-value");
+        cfg.put("MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_CAPSKEY", "should not be used");
+
+        SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
+        builder.addDefaultSources();
+        builder.withSources(new ConfigSource() {
+            @Override
+            public Map<String, String> getProperties() {
+                return cfg;
+            }
+
+            @Override
+            public Set<String> getPropertyNames() {
+                return cfg.keySet();
+            }
+
+            @Override
+            public int getOrdinal() {
+                return ConfigSource.DEFAULT_ORDINAL;
+            }
+
+            @Override
+            public String getValue(String s) {
+                return cfg.get(s);
+            }
+
+            @Override
+            public String getName() {
+                return "test";
+            }
+        });
+        overallConfig = builder.build();
+        config = new OverrideConnectorConfig("mp.messaging.incoming.", overallConfig, "foo", "bar");
+        config2 = new OverrideConnectorConfig("mp.messaging.incoming.", overallConfig, "foo", "bar",
+                Map.of("attr1", c -> "some-other-value",
+                        "attr2", c -> c.getOriginalValue("attr2", Integer.class).map(i -> i + 10)
+                                .orElse(10)));
+    }
+
+    @Test
+    public void testGetConfigValue() {
+        ConfigValue attr1 = config.getConfigValue("attr1");
+        assertThat(attr1.getName()).isEqualTo("mp.messaging.incoming.foo.attr1");
+        assertThat(attr1.getValue()).isEqualTo("value");
+        assertThat(attr1.getRawValue()).isEqualTo("value");
+        assertThat(attr1.getSourceName()).isEqualTo("test");
+        assertThat(attr1.getSourceOrdinal()).isEqualTo(ConfigSource.DEFAULT_ORDINAL);
+
+        ConfigValue attr3 = config.getConfigValue("attr3");
+        assertThat(attr3.getName()).isEqualTo("mp.messaging.connector.some-connector.attr3"); // The value looked up in the overall config
+        assertThat(attr3.getValue()).isEqualTo("used");
+        assertThat(attr3.getRawValue()).isEqualTo("used");
+        assertThat(attr3.getSourceOrdinal()).isEqualTo(300); // Env config source default ordinal
+
+        ConfigValue channelName = config.getConfigValue("channel-name");
+        assertThat(channelName.getName()).isEqualTo("channel-name");
+        assertThat(channelName.getValue()).isEqualTo("foo");
+        assertThat(channelName.getRawValue()).isEqualTo("foo");
+        assertThat(channelName.getSourceName()).isEqualTo("ConnectorConfig internal");
+        assertThat(channelName.getSourceOrdinal()).isEqualTo(0);
+    }
+
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_ATTR", value = "new-value")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_AT_TR", value = "another-value")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_BAR_KEY", value = "some-other-value")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_KEY", value = "another-value-from-connector")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_OTHER_KEY", value = "another-value-other")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR1", value = "should not be used")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR3", value = "used")
+    @SetEnvironmentVariable(key = "mp_messaging_connector_some_connector_attr4", value = "used")
+    @SetEnvironmentVariable(key = "mp_messaging_connector_SOME_CONNECTOR_mixedcase", value = "used")
+    @Test
+    public void testPropertyNames() {
+        // Base config behaviour:
+        // Even though looking up both properties would return the value of the environment variable,
+        // both are included in the set returned from getPropertyNames.
+        assertThat(overallConfig.getPropertyNames())
+                .contains("mp.messaging.incoming.foo.at-tr",
+                        "MP_MESSAGING_INCOMING_FOO_AT_TR");
+
+        Iterable<String> names = config.getPropertyNames();
+        assertThat(names)
+                .containsExactlyInAnyOrder("connector", "ATTR1", "attr1", "attr2", "attr.2", "ATTR", "attr", "AT_TR",
+                        "at-tr", "bar.key", "BAR_KEY", "bar.qux", "other-key", "key",
+                        "SOME_KEY", "some-key", "SOME_OTHER_KEY", "ATTR3", "attr4", "channel-name");
+
+        assertThat(config.getOptionalValue("connector", String.class)).hasValue("some-connector");
+        assertThat(config.getOptionalValue("attr1", String.class)).hasValue("value");
+        assertThat(config.getOptionalValue("attr2", Integer.class)).hasValue(23);
+        assertThat(config.getOptionalValue("attr.2", String.class)).hasValue("test");
+        assertThat(config.getOptionalValue("at-tr", String.class)).hasValue("another-value");
+        assertThat(config.getOptionalValue("AT_TR", String.class)).hasValue("another-value");
+        assertThat(config.getOptionalValue("some-key", String.class)).hasValue("another-value-from-connector");
+        assertThat(config.getOptionalValue("SOME_KEY", String.class)).hasValue("another-value-from-connector");
+        assertThat(config.getOptionalValue("key", String.class)).hasValue("some-other-value");
+        assertThat(config.getOptionalValue("attr3", String.class)).hasValue("used");
+        assertThat(config.getOptionalValue("ATTR3", String.class)).hasValue("used");
+        assertThat(config.getOptionalValue("attr4", String.class)).hasValue("used");
+        assertThat(config.getOptionalValue("attr1", String.class)).hasValue("value");
+        assertThat(config.getOptionalValue("qux", String.class)).hasValue("value");
+        assertThat(config.getOptionalValue("bar.qux", String.class)).hasValue("value");
+        assertThat(config.getOptionalValue("bar.other-key", String.class)).hasValue("another-value");
+    }
+
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_ATTR", value = "new-value")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_AT_TR", value = "another-value")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_INCOMING_FOO_BAR_KEY", value = "some-other-value")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_KEY", value = "another-value-from-connector")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_SOME_OTHER_KEY", value = "another-value-other")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR1", value = "should not be used")
+    @SetEnvironmentVariable(key = "MP_MESSAGING_CONNECTOR_SOME_CONNECTOR_ATTR3", value = "used")
+    @SetEnvironmentVariable(key = "mp_messaging_connector_some_connector_attr4", value = "used")
+    @SetEnvironmentVariable(key = "mp_messaging_connector_SOME_CONNECTOR_mixedcase", value = "used")
+    @Test
+    public void testPropertyNamesOverriden() {
+        // Base config behaviour:
+        // Even though looking up both properties would return the value of the environment variable,
+        // both are included in the set returned from getPropertyNames.
+        assertThat(overallConfig.getPropertyNames())
+                .contains("mp.messaging.incoming.foo.at-tr",
+                        "MP_MESSAGING_INCOMING_FOO_AT_TR");
+
+        Iterable<String> names = config2.getPropertyNames();
+        assertThat(names)
+                .containsExactlyInAnyOrder("connector", "ATTR1", "attr1", "attr2", "attr.2", "ATTR", "attr", "AT_TR",
+                        "at-tr", "bar.key", "BAR_KEY", "bar.qux", "other-key", "key",
+                        "SOME_KEY", "some-key", "SOME_OTHER_KEY", "ATTR3", "attr4", "channel-name");
+
+        assertThat(config2.getOptionalValue("connector", String.class)).hasValue("some-connector");
+        assertThat(config2.getOptionalValue("attr1", String.class)).hasValue("some-other-value");
+        assertThat(config2.getOptionalValue("attr2", Integer.class)).hasValue(33);
+        assertThat(config2.getOptionalValue("attr.2", String.class)).hasValue("test");
+        assertThat(config2.getOptionalValue("at-tr", String.class)).hasValue("another-value");
+        assertThat(config2.getOptionalValue("AT_TR", String.class)).hasValue("another-value");
+        assertThat(config2.getOptionalValue("some-key", String.class)).hasValue("another-value-from-connector");
+        assertThat(config2.getOptionalValue("SOME_KEY", String.class)).hasValue("another-value-from-connector");
+        assertThat(config2.getOptionalValue("key", String.class)).hasValue("some-other-value");
+        assertThat(config2.getOptionalValue("attr3", String.class)).hasValue("used");
+        assertThat(config2.getOptionalValue("ATTR3", String.class)).hasValue("used");
+        assertThat(config2.getOptionalValue("attr4", String.class)).hasValue("used");
+        assertThat(config2.getOptionalValue("qux", String.class)).hasValue("value");
+        assertThat(config2.getOptionalValue("bar.qux", String.class)).hasValue("value");
+        assertThat(config2.getOptionalValue("bar.other-key", String.class)).hasValue("another-value");
+    }
+}

--- a/smallrye-reactive-messaging-pulsar/pom.xml
+++ b/smallrye-reactive-messaging-pulsar/pom.xml
@@ -116,10 +116,10 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Ensure log4j1 log backend with slf4j -->
+    <!-- Ensure log4j log backend with slf4j -->
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Allow creating nested connector configs for configuring inner clients/channels. Useful for Kafka clients created for Kafka DLQ and Delayed Retry 