### PR TITLE
Allow configuring the rabbitmq health checks

### DIFF
--- a/documentation/src/main/docs/rabbitmq/rabbitmq-health.md
+++ b/documentation/src/main/docs/rabbitmq/rabbitmq-health.md
@@ -10,3 +10,17 @@ On the outbound side (sending records to RabbitMQ), the check verifies
 that the sender is not disconnected from the broker; the sender *may*
 still be in an initialized state (connection not yet attempted), but
 this is regarded as live/ready.
+
+You can disable health reporting by setting the `health-enabled` attribute of the channel to `false`.
+It disables both liveness and readiness.
+You can disable readiness reporting by setting the `health-readiness-enabled` attribute of the channel to `false`.
+
+## @Channel and lazy subscription
+
+When you inject a channel using `@Channel` annotation, you are responsible for subscribing to the channel.
+Until the subscription happens, the channel is not connected to the broker and thus cannot receive messages.
+The default health check will fail in this case.
+
+To handle this use case, you need to configure the `health-lazy-subscription` attribute of the channel to `true`.
+It configures the health check to not fail if there are no subscription yet.
+

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/HealthTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/HealthTest.java
@@ -1,0 +1,141 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.providers.extension.HealthCenter;
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+
+public class HealthTest extends WeldTestBase {
+
+    private MapBasedConfig getBaseConfig() {
+        return new MapBasedConfig()
+                .with("mp.messaging.incoming.in.queue.name", "in")
+                .with("mp.messaging.incoming.in.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.in.host", host)
+                .with("mp.messaging.incoming.in.port", port)
+                .with("rabbitmq-username", username)
+                .with("rabbitmq-password", password)
+                .with("mp.messaging.outgoing.out.queue.name", "out")
+                .with("mp.messaging.outgoing.out.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .with("mp.messaging.outgoing.out.host", host)
+                .with("mp.messaging.outgoing.out.port", port);
+    }
+
+    @Test
+    void testReadinessAndLivenessEnabled() {
+        MapBasedConfig config = getBaseConfig();
+
+        addBeans(MyApp.class);
+        runApplication(config);
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        assertThat(health.getLiveness().isOk()).isTrue();
+        assertThat(health.getLiveness().getChannels()).anySatisfy(ci -> {
+            assertThat(ci.getChannel()).isEqualTo("in");
+            assertThat(ci.isOk()).isTrue();
+        })
+                .anySatisfy(ci -> {
+                    assertThat(ci.getChannel()).isEqualTo("out");
+                    assertThat(ci.isOk()).isTrue();
+                });
+
+        assertThat(health.getReadiness().isOk()).isTrue();
+        assertThat(health.getReadiness().getChannels()).anySatisfy(ci -> {
+            assertThat(ci.getChannel()).isEqualTo("in");
+            assertThat(ci.isOk()).isTrue();
+        })
+                .anySatisfy(ci -> {
+                    assertThat(ci.getChannel()).isEqualTo("out");
+                    assertThat(ci.isOk()).isTrue();
+                });
+    }
+
+    @Test
+    void testHealthDisabled() {
+        MapBasedConfig config = getBaseConfig()
+                .with("mp.messaging.incoming.in.health-enabled", false)
+                .with("mp.messaging.outgoing.out.health-enabled", false);
+
+        addBeans(MyApp.class);
+        runApplication(config);
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        assertThat(health.getLiveness().isOk()).isTrue();
+        assertThat(health.getLiveness().getChannels()).isEmpty();
+
+        assertThat(health.getReadiness().isOk()).isTrue();
+        assertThat(health.getReadiness().getChannels()).isEmpty();
+    }
+
+    @Test
+    void testReadinessDisabled() {
+        MapBasedConfig config = getBaseConfig()
+                .with("mp.messaging.incoming.in.health-readiness-enabled", false)
+                .with("mp.messaging.outgoing.out.health-readiness-enabled", false);
+
+        addBeans(MyApp.class);
+        runApplication(config);
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        assertThat(health.getLiveness().isOk()).isTrue();
+        assertThat(health.getLiveness().getChannels()).hasSize(2);
+
+        assertThat(health.getReadiness().isOk()).isTrue();
+        assertThat(health.getReadiness().getChannels()).isEmpty();
+    }
+
+    @Test
+    void testWithAppUsingChannels() {
+        MapBasedConfig config = getBaseConfig()
+                .with("mp.messaging.incoming.in.health-lazy-subscription", true);
+
+        addBeans(MyAppUsingChannels.class);
+        runApplication(config);
+        HealthCenter health = container.getBeanManager().createInstance().select(HealthCenter.class).get();
+        assertThat(health.getLiveness().isOk()).isTrue();
+        assertThat(health.getLiveness().getChannels()).anySatisfy(ci -> {
+            assertThat(ci.getChannel()).isEqualTo("in");
+            assertThat(ci.isOk()).isTrue();
+        })
+                .anySatisfy(ci -> {
+                    assertThat(ci.getChannel()).isEqualTo("out");
+                    assertThat(ci.isOk()).isTrue();
+                });
+
+        assertThat(health.getReadiness().isOk()).isTrue();
+        assertThat(health.getReadiness().getChannels()).anySatisfy(ci -> {
+            assertThat(ci.getChannel()).isEqualTo("in");
+            assertThat(ci.isOk()).isTrue();
+        })
+                .anySatisfy(ci -> {
+                    assertThat(ci.getChannel()).isEqualTo("out");
+                    assertThat(ci.isOk()).isTrue();
+                });
+    }
+
+    public static class MyApp {
+        @Incoming("in")
+        @Outgoing("out")
+        public String process(String in) {
+            return in;
+        }
+    }
+
+    public static class MyAppUsingChannels {
+
+        @Inject
+        @Channel("in")
+        Multi<String> in;
+
+        @Inject
+        @Channel("out")
+        Emitter<String> out;
+
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQBrokerTestBase.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQBrokerTestBase.java
@@ -98,7 +98,7 @@ public class RabbitMQBrokerTestBase {
 
         // Use strict mode for health because that indicates that outgoing channels have got to the point where
         // a declared exchange has been established.
-        return connector.getHealth(true).isOk();
+        return connector.getStrictHealth().isOk();
     }
 
     public boolean isRabbitMQConnectorReady(SeContainer container) {


### PR DESCRIPTION
Fix #2326 - allows disabling health check and readiness check per channel
Fix #2019 - add an attribute to support lazy subscription
