### PR TITLE
Rabbitmq queue/exchange custom arguments

### DIFF
--- a/documentation/src/main/docs/rabbitmq/receiving-messages-from-rabbitmq.md
+++ b/documentation/src/main/docs/rabbitmq/receiving-messages-from-rabbitmq.md
@@ -263,3 +263,23 @@ one of `short`.
     declare queue bindings, you’ll need to supply a valid value for the
     exchange in question.
 
+## Custom arguments for Queue declaration
+
+When queue declaration is made by the Reactive Messaging channel, using the `queue.declare=true` configuration,
+custom queue arguments can be specified using the `queue.arguments` attribute.
+`queue.arguments` accepts the identifier (using the `@Identifier` qualifier) of a `Map<String, Object>` exposed as a CDI bean.
+If no arguments has been configured, the default **rabbitmq-queue-arguments** identifier is looked for.
+
+The following CDI bean produces such a configuration identified with **my-arguments**:
+
+``` java
+{{ insert('rabbitmq/customization/ArgumentProducers.java') }}
+```
+
+Then the channel can be configured to use those arguments in exchange declaration:
+
+```properties
+mp.messaging.outgoing.data.queue.arguments=my-arguments
+```
+
+Similarly, the `dead-letter-queue.arguments` allows configuring custom arguments for dead letter queue when one is declared (`auto-bind-dlq=true`).

--- a/documentation/src/main/docs/rabbitmq/sending-messages-to-rabbitmq.md
+++ b/documentation/src/main/docs/rabbitmq/sending-messages-to-rabbitmq.md
@@ -149,3 +149,24 @@ The name of the exchange needs to be set to `""`.
 mp.messaging.outgoing.channel-name-for-default-exchange.connector=smallrye-rabbitmq
 mp.messaging.outgoing.channel-name-for-default-exchange.exchange.name=""
 ```
+
+## Custom arguments for Exchange declaration
+
+When exchange declaration is made by the Reactive Messaging channel, using the `exchange.declare=true` configuration,
+custom exchange arguments can be specified using the `exchange.arguments` attribute.
+`exchange.arguments` accepts the identifier (using the `@Identifier` qualifier) of a `Map<String, Object>` exposed as a CDI bean.
+If no arguments has been configured, the default **rabbitmq-exchange-arguments** identifier is looked for.
+
+The following CDI bean produces such a configuration identified with **my-arguments**:
+
+``` java
+{{ insert('rabbitmq/customization/ArgumentProducers.java') }}
+```
+
+Then the channel can be configured to use those arguments in exchange declaration:
+
+```properties
+mp.messaging.outgoing.data.exchange.arguments=my-arguments
+```
+
+Similarly, the `dead-letter-exchange.arguments` allows configuring custom arguments for dead letter exchange when one is declared (`dlx.declare=true`).

--- a/documentation/src/main/java/rabbitmq/customization/ArgumentProducers.java
+++ b/documentation/src/main/java/rabbitmq/customization/ArgumentProducers.java
@@ -1,0 +1,17 @@
+package rabbitmq.customization;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+
+@ApplicationScoped
+public class ArgumentProducers {
+    @Produces
+    @Identifier("my-arguments")
+    Map<String, Object> customArguments() {
+        return Map.of("custom-arg", "value");
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ArgumentsConfigBean.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ArgumentsConfigBean.java
@@ -1,0 +1,30 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import io.smallrye.common.annotation.Identifier;
+
+@ApplicationScoped
+public class ArgumentsConfigBean {
+
+    @Produces
+    @Identifier("my-args")
+    public Map<String, Object> produceArgs() {
+        return Map.of("my-str-arg", "str-value", "my-int-arg", 4);
+    }
+
+    @Produces
+    @Identifier("rabbitmq-queue-arguments")
+    public Map<String, Object> defaultQueueArgs() {
+        return Map.of("default-queue-arg", "default-value");
+    }
+
+    @Produces
+    @Identifier("rabbitmq-exchange-arguments")
+    public Map<String, Object> defaultExchangeArgs() {
+        return Map.of("default-exchange-arg", "default-value");
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQArgumentsCDIConfigTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQArgumentsCDIConfigTest.java
@@ -1,0 +1,191 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
+import io.vertx.core.json.JsonObject;
+
+public class RabbitMQArgumentsCDIConfigTest extends RabbitMQBrokerTestBase {
+
+    private WeldContainer container;
+
+    String queueName;
+
+    @BeforeEach
+    public void initQueue(TestInfo testInfo) {
+        String cn = testInfo.getTestClass().map(Class::getSimpleName).orElse(UUID.randomUUID().toString());
+        String mn = testInfo.getTestMethod().map(Method::getName).orElse(UUID.randomUUID().toString());
+        queueName = cn + "-" + mn + "-" + UUID.randomUUID().getMostSignificantBits();
+    }
+
+    @Test
+    public void testConfigByCDIQueueArguments() throws IOException {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ArgumentsConfigBean.class);
+        weld.addBeanClass(ConsumptionBean.class);
+
+        new MapBasedConfig()
+                .with("mp.messaging.incoming.data.queue.name", queueName)
+                .with("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.host", host)
+                .with("mp.messaging.incoming.data.port", port)
+                .with("rabbitmq-username", username)
+                .with("rabbitmq-password", password)
+                .with("mp.messaging.incoming.data.queue.arguments", "my-args")
+                .with("mp.messaging.incoming.data.tracing-enabled", false)
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAlive(container));
+        await().until(() -> isRabbitMQConnectorReady(container));
+        List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
+        assertThat(list).isEmpty();
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers("data", queueName, "", counter::getAndIncrement);
+
+        JsonObject queue = usage.getQueue(queueName);
+        assertThat(queue.getJsonObject("arguments").getMap())
+                .containsExactlyInAnyOrderEntriesOf(Map.of("my-str-arg", "str-value", "my-int-arg", 4));
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
+        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void testConfigByCDIQueueDefaultArguments() throws IOException {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ArgumentsConfigBean.class);
+        weld.addBeanClass(ConsumptionBean.class);
+
+        new MapBasedConfig()
+                .with("mp.messaging.incoming.data.queue.name", queueName)
+                .with("mp.messaging.incoming.data.exchange.name", queueName)
+                .with("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.host", host)
+                .with("mp.messaging.incoming.data.port", port)
+                .with("rabbitmq-username", username)
+                .with("rabbitmq-password", password)
+                .with("mp.messaging.incoming.data.tracing-enabled", false)
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAlive(container));
+        await().until(() -> isRabbitMQConnectorReady(container));
+        List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
+        assertThat(list).isEmpty();
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers(queueName, queueName, "", counter::getAndIncrement);
+
+        JsonObject queue = usage.getQueue(queueName);
+        assertThat(queue.getJsonObject("arguments").getMap())
+                .containsExactlyInAnyOrderEntriesOf(Map.of("default-queue-arg", "default-value"));
+
+        JsonObject exchange = usage.getExchange(queueName);
+        assertThat(exchange.getJsonObject("arguments").getMap())
+                .containsExactlyInAnyOrderEntriesOf(Map.of("default-exchange-arg", "default-value"));
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
+        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void testConfigByCDIExchangeArguments() throws IOException {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ArgumentsConfigBean.class);
+        weld.addBeanClass(ConsumptionBean.class);
+
+        new MapBasedConfig()
+                .with("mp.messaging.incoming.data.queue.name", queueName)
+                .with("mp.messaging.incoming.data.exchange.name", queueName)
+                .with("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.host", host)
+                .with("mp.messaging.incoming.data.port", port)
+                .with("rabbitmq-username", username)
+                .with("rabbitmq-password", password)
+                .with("mp.messaging.incoming.data.exchange.arguments", "my-args")
+                .with("mp.messaging.incoming.data.tracing-enabled", false)
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAlive(container));
+        await().until(() -> isRabbitMQConnectorReady(container));
+        List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
+        assertThat(list).isEmpty();
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers(queueName, queueName, "", counter::getAndIncrement);
+
+        JsonObject exchange = usage.getExchange(queueName);
+        assertThat(exchange.getJsonObject("arguments").getMap())
+                .containsExactlyInAnyOrderEntriesOf(Map.of("my-str-arg", "str-value", "my-int-arg", 4));
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
+        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void testConfigByCDIDLQArguments() throws IOException {
+        Weld weld = new Weld();
+
+        weld.addBeanClass(ArgumentsConfigBean.class);
+        weld.addBeanClass(ConsumptionBean.class);
+
+        String dlqName = queueName + ".dlq";
+
+        new MapBasedConfig()
+                .with("mp.messaging.incoming.data.queue.name", queueName)
+                .with("mp.messaging.incoming.data.exchange.name", queueName)
+                .with("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .with("mp.messaging.incoming.data.host", host)
+                .with("mp.messaging.incoming.data.port", port)
+                .with("rabbitmq-username", username)
+                .with("rabbitmq-password", password)
+                .with("mp.messaging.incoming.data.auto-bind-dlq", true)
+                .with("mp.messaging.incoming.data.dlx.declare", true)
+                .with("mp.messaging.incoming.data.dead-letter-queue.arguments", "my-args")
+                .with("mp.messaging.incoming.data.dead-letter-exchange.arguments", "my-args")
+                .with("mp.messaging.incoming.data.tracing-enabled", false)
+                .write();
+
+        container = weld.initialize();
+        await().until(() -> isRabbitMQConnectorAlive(container));
+        await().until(() -> isRabbitMQConnectorReady(container));
+        List<Integer> list = container.select(ConsumptionBean.class).get().getResults();
+        assertThat(list).isEmpty();
+
+        AtomicInteger counter = new AtomicInteger();
+        usage.produceTenIntegers(queueName, queueName, "", counter::getAndIncrement);
+
+        JsonObject queue = usage.getQueue(dlqName);
+        assertThat(queue.getJsonObject("arguments").getMap())
+                .containsExactlyInAnyOrderEntriesOf(Map.of("my-str-arg", "str-value", "my-int-arg", 4));
+
+        JsonObject exchange = usage.getExchange("DLX");
+        assertThat(exchange.getJsonObject("arguments").getMap())
+                .containsExactlyInAnyOrderEntriesOf(Map.of("my-str-arg", "str-value", "my-int-arg", 4));
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> list.size() >= 10);
+        assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+}


### PR DESCRIPTION
RabbitMQ queue and exchange custom arguments using configuration map bean exposed as CDI bean.

Fixed an issue with the default dlq name containing Optional toString instead of the chosen queueName.

Closes #2038
Closes #2135
Closes #1659