### PR TITLE
Additional NPE guard in Message getAckWithMetadata/getNackWithMetadata

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.microprofile.reactive.messaging;
 
+import static java.util.Objects.requireNonNullElse;
+
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -492,7 +494,7 @@ public interface Message<T> {
      * @return the supplier used to retrieve the acknowledgement {@link CompletionStage}.
      */
     default Supplier<CompletionStage<Void>> getAck() {
-        return () -> getAckWithMetadata().apply(this.getMetadata());
+        return () -> requireNonNullElse(getAckWithMetadata(), EMPTY_ACK).apply(this.getMetadata());
     }
 
     /**
@@ -507,7 +509,7 @@ public interface Message<T> {
      * @return the function used to retrieve the negative-acknowledgement asynchronous function.
      */
     default Function<Throwable, CompletionStage<Void>> getNack() {
-        return reason -> getNackWithMetadata().apply(reason, this.getMetadata());
+        return reason -> requireNonNullElse(getNackWithMetadata(), EMPTY_NACK).apply(reason, this.getMetadata());
     }
 
     /**

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ConsumerBackPressure.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ConsumerBackPressure.java
@@ -1,24 +1,21 @@
 package io.smallrye.reactive.messaging.rabbitmq;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.junit.jupiter.api.Test;
+
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.reactive.messaging.MutinyEmitter;
 import io.smallrye.reactive.messaging.providers.extension.HealthCenter;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.junit.jupiter.api.Test;
-
-import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 public class ConsumerBackPressure extends WeldTestBase {
 
@@ -51,7 +48,7 @@ public class ConsumerBackPressure extends WeldTestBase {
         publisher.generate();
 
         AtomicInteger i = new AtomicInteger(1);
-        while(consumer.getItems().size() < 10000) {
+        while (consumer.getItems().size() < 10000) {
             consumer.request(100);
             await().until(() -> consumer.getItems().size() == 100 * i.get());
             i.getAndIncrement();
@@ -60,11 +57,11 @@ public class ConsumerBackPressure extends WeldTestBase {
 
     }
 
-
     @ApplicationScoped
     public static class Publisher {
 
-        @Inject @Channel("to-rabbitmq")
+        @Inject
+        @Channel("to-rabbitmq")
         MutinyEmitter<String> emitter;
 
         public void generate() {
@@ -78,7 +75,9 @@ public class ConsumerBackPressure extends WeldTestBase {
     @ApplicationScoped
     public static class Subscriber {
 
-        @Inject @Channel("from-rabbitmq") Multi<String> multi;
+        @Inject
+        @Channel("from-rabbitmq")
+        Multi<String> multi;
 
         public Multi<String> getMulti() {
             return multi;


### PR DESCRIPTION
Guard against getAckWithMetadata and getNackWithMetadata returning null from a custom message implementation.