### PR TITLE
Avoid generating jandex index for health module

### DIFF
--- a/smallrye-reactive-messaging-health/pom.xml
+++ b/smallrye-reactive-messaging-health/pom.xml
@@ -15,6 +15,10 @@
 
   <name>SmallRye Reactive Messaging : Health</name>
 
+  <properties>
+    <!-- Doesn't provide jandex index in order for the Quarkus bean exclusion to work -->
+    <jandex.skip>true</jandex.skip>
+  </properties>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Revert d91491577a5a68b78436a94f48472deed7097e6f for smallrye-reactive-messaging-health

For https://github.com/quarkusio/quarkus/issues/38613