### PR TITLE
Retrieve kafka config in places where Override connector config is used

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterQueue.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/fault/KafkaDeadLetterQueue.java
@@ -36,6 +36,7 @@ import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
 import io.smallrye.reactive.messaging.kafka.KafkaProducer;
 import io.smallrye.reactive.messaging.kafka.SerializationFailureHandler;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.impl.ConfigHelper;
 import io.smallrye.reactive.messaging.kafka.impl.ReactiveKafkaProducer;
 import io.smallrye.reactive.messaging.providers.impl.ConnectorConfig;
 import io.smallrye.reactive.messaging.providers.impl.OverrideConnectorConfig;
@@ -84,6 +85,10 @@ public class KafkaDeadLetterQueue implements KafkaFailureHandler {
         @Inject
         Instance<Config> rootConfig;
 
+        @Inject
+        @Any
+        Instance<Map<String, Object>> configurations;
+
         @Override
         public KafkaFailureHandler create(KafkaConnectorIncomingConfiguration config,
                 Vertx vertx,
@@ -104,7 +109,8 @@ public class KafkaDeadLetterQueue implements KafkaFailureHandler {
                             "key-serialization-failure-handler", c -> "dlq-serialization",
                             "value-serialization-failure-handler", c -> "dlq-serialization",
                             INTERCEPTOR_CLASSES_CONFIG, c -> ""));
-            KafkaConnectorOutgoingConfiguration producerConfig = new KafkaConnectorOutgoingConfiguration(connectorConfig);
+            Config kafkaConfig = ConfigHelper.retrieveChannelConfiguration(configurations, connectorConfig);
+            KafkaConnectorOutgoingConfiguration producerConfig = new KafkaConnectorOutgoingConfiguration(kafkaConfig);
 
             String deadQueueTopic = config.getDeadLetterQueueTopic().orElse("dead-letter-topic-" + config.getChannel());
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyFactory.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyFactory.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.kafka.reply;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
@@ -70,9 +71,13 @@ public class KafkaRequestReplyFactory implements EmitterFactory<KafkaRequestRepl
     @Inject
     Instance<Config> config;
 
+    @Inject
+    @Any
+    Instance<Map<String, Object>> configurations;
+
     @Override
     public KafkaRequestReplyImpl<Object, Object> createEmitter(EmitterConfiguration configuration, long defaultBufferSize) {
-        return new KafkaRequestReplyImpl<>(configuration, defaultBufferSize, config.get(), holder.vertx(),
+        return new KafkaRequestReplyImpl<>(configuration, defaultBufferSize, config.get(), configurations, holder.vertx(),
                 kafkaCDIEvents, commitStrategyFactories, failureStrategyFactories, failureHandlers,
                 correlationIdHandlers, replyFailureHandlers, rebalanceListeners);
     }


### PR DESCRIPTION
Regression since [4.13.0](https://github.com/smallrye/smallrye-reactive-messaging/releases/tag/4.13.0) : usages of OverrideConnectorConfig didn't take global kafka configurations into account.

Notified in https://github.com/quarkusio/quarkus/issues/38700