### PR TITLE
fix: failure metadata creation when partition is null

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -316,7 +316,7 @@ public interface KafkaLogging extends BasicLogger {
     @Message(id = 18274, value = "Error caught in producer interceptor `onSend` for channel %s")
     void interceptorOnSendError(String channel, @Cause Throwable cause);
 
-    @LogMessage(level = Logger.Level.TRACE)
+    @LogMessage(level = Logger.Level.INFO)
     @Message(id = 18275, value = "Error caught in producer interceptor `onAcknowledge` for channel %s")
     void interceptorOnAcknowledgeError(String channel, @Cause Throwable cause);
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaProducer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaProducer.java
@@ -356,8 +356,9 @@ public class ReactiveKafkaProducer<K, V> implements io.smallrye.reactive.messagi
         }
     }
 
-    private static RecordMetadata getRecordMetadataForFailure(ProducerRecord<?, ?> record) {
-        return new RecordMetadata(new TopicPartition(record.topic(), record.partition()),
+    private static RecordMetadata getRecordMetadataForFailure(ProducerRecord<?, ?> producerRecord) {
+        return new RecordMetadata(new TopicPartition(producerRecord.topic(),
+                producerRecord.partition() != null ? producerRecord.partition() : RecordMetadata.UNKNOWN_PARTITION),
                 -1, -1, RecordBatch.NO_TIMESTAMP, -1, -1);
     }
 


### PR DESCRIPTION
Fix for #2486 

Prevent autoboxing failure when a Kafka exception is thrown from the internal producer and the ProducerRecord partition is null.
Change the log level of onAckownledgement error to INFO rather than TRACE