### PR TITLE
Update to Vert.x 4.5.4

### DIFF
--- a/documentation/src/main/java/amqp/customization/ClientProducers.java
+++ b/documentation/src/main/java/amqp/customization/ClientProducers.java
@@ -24,7 +24,7 @@ public class ClientProducers {
                 .setPemKeyCertOptions(keycert)
                 .setPemTrustOptions(trust)
                 .addEnabledSaslMechanism("EXTERNAL")
-                .setHostnameVerificationAlgorithm("")
+                .setHostnameVerificationAlgorithm("") // Disable hostname verification
                 .setConnectTimeout(30000)
                 .setReconnectInterval(5000)
                 .setContainerId("my-container");

--- a/documentation/src/main/java/mqtt/customization/ClientProducers.java
+++ b/documentation/src/main/java/mqtt/customization/ClientProducers.java
@@ -23,7 +23,7 @@ public class ClientProducers {
                 .setSsl(true)
                 .setPemKeyCertOptions(keycert)
                 .setPemTrustOptions(trust)
-                .setHostnameVerificationAlgorithm("")
+                .setHostnameVerificationAlgorithm("HTTPS")
                 .setConnectTimeout(30000)
                 .setReconnectInterval(5000);
     }

--- a/documentation/src/main/java/rabbitmq/customization/RabbitMQProducers.java
+++ b/documentation/src/main/java/rabbitmq/customization/RabbitMQProducers.java
@@ -25,7 +25,7 @@ public class RabbitMQProducers {
                 .setSsl(true)
                 .setPemKeyCertOptions(keycert)
                 .setPemTrustOptions(trust)
-                .setHostnameVerificationAlgorithm("")
+                .setHostnameVerificationAlgorithm("HTTPS")
                 .setConnectTimeout(30000)
                 .setReconnectInterval(5000);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 
-    <vertx.version>4.5.3</vertx.version>
+    <vertx.version>4.5.4</vertx.version>
     <rxjava.version>2.2.21</rxjava.version>
     <cloudevent.version>1.1.0</cloudevent.version>
     <weld.version>5.1.2.Final</weld.version>

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
@@ -34,6 +34,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "auto-keep-alive", type = "boolean", direction = INCOMING_AND_OUTGOING, description = "Set if the MQTT client must handle `PINGREQ` automatically", defaultValue = "true")
 @ConnectorAttribute(name = "health-enabled", type = "boolean", direction = INCOMING_AND_OUTGOING, description = "Whether health reporting is enabled (default) or disabled", defaultValue = "true")
 @ConnectorAttribute(name = "ssl", type = "boolean", direction = INCOMING_AND_OUTGOING, description = "Set whether SSL/TLS is enabled", defaultValue = "false")
+@ConnectorAttribute(name = "ssl.hostname-verification-algorithm", type = "string", direction = INCOMING_AND_OUTGOING, description = "Set the hostname verifier algorithm for the TLS connection.Accepted values are `HTTPS`, `LDAPS`, and `NONE` (defaults). `NONE` disables the hostname verification.", defaultValue = "NONE")
 @ConnectorAttribute(name = "ssl.keystore.type", type = "string", direction = INCOMING_AND_OUTGOING, description = "Set the keystore type [`pkcs12`, `jks`, `pem`]", defaultValue = "pkcs12")
 @ConnectorAttribute(name = "ssl.keystore.location", type = "string", direction = INCOMING_AND_OUTGOING, description = "Set the keystore location. In case of `pem` type this is the server ca cert path")
 @ConnectorAttribute(name = "ssl.keystore.password", type = "string", direction = INCOMING_AND_OUTGOING, description = "Set the keystore password. In case of `pem` type this is the key path")

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/internal/MqttHelpers.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/internal/MqttHelpers.java
@@ -43,6 +43,14 @@ public class MqttHelpers {
         options.setPort(config.getPort().orElseGet(() -> config.getSsl() ? 8883 : 1883));
         options.setReconnectDelay(getReconnectDelayOptions(config));
         options.setSsl(config.getSsl());
+
+        String algorithm = config.getSslHostnameVerificationAlgorithm();
+        if ("NONE".equalsIgnoreCase(algorithm)) {
+            options.setHostnameVerificationAlgorithm("");
+        } else {
+            options.setHostnameVerificationAlgorithm(algorithm);
+        }
+
         options.setKeyCertOptions(getKeyCertOptions(config));
         options.setServerName(config.getServerName());
         options.setTrustOptions(getTrustOptions(config));
@@ -53,6 +61,7 @@ public class MqttHelpers {
         options.setWillRetain(config.getWillRetain());
         options.setUnsubscribeOnDisconnect(config.getUnsubscribeOnDisconnection());
         options.setMetricsName("mqtt|" + config.getChannel());
+
         return options;
     }
 

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/MqttClientSessionOptions.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/session/MqttClientSessionOptions.java
@@ -428,7 +428,11 @@ public class MqttClientSessionOptions extends MqttClientOptions {
 
     @Override
     public MqttClientSessionOptions setHostnameVerificationAlgorithm(String hostnameVerificationAlgorithm) {
-        super.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+        if ("NONE".equalsIgnoreCase(hostnameVerificationAlgorithm)) {
+            super.setHostnameVerificationAlgorithm("");
+        } else {
+            super.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+        }
         return this;
     }
 

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -50,6 +50,7 @@ import io.vertx.rabbitmq.RabbitMQOptions;
 @ConnectorAttribute(name = "port", direction = INCOMING_AND_OUTGOING, description = "The broker port", type = "int", alias = "rabbitmq-port", defaultValue = "5672")
 @ConnectorAttribute(name = "addresses", direction = INCOMING_AND_OUTGOING, description = "The multiple addresses for cluster mode, when given overrides the host and port", type = "string", alias = "rabbitmq-addresses")
 @ConnectorAttribute(name = "ssl", direction = INCOMING_AND_OUTGOING, description = "Whether or not the connection should use SSL", type = "boolean", alias = "rabbitmq-ssl", defaultValue = "false")
+@ConnectorAttribute(name = "ssl.hostname-verification-algorithm", type = "string", direction = INCOMING_AND_OUTGOING, description = "Set the hostname verifier algorithm for the TLS connection. Accepted values are `HTTPS`, and `NONE` (defaults). `NONE` disables the hostname verification.", defaultValue = "NONE")
 @ConnectorAttribute(name = "trust-all", direction = INCOMING_AND_OUTGOING, description = "Whether to skip trust certificate verification", type = "boolean", alias = "rabbitmq-trust-all", defaultValue = "false")
 @ConnectorAttribute(name = "trust-store-path", direction = INCOMING_AND_OUTGOING, description = "The path to a JKS trust store", type = "string", alias = "rabbitmq-trust-store-path")
 @ConnectorAttribute(name = "trust-store-password", direction = INCOMING_AND_OUTGOING, description = "The password of the JKS trust store", type = "string", alias = "rabbitmq-trust-store-password")

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/RabbitMQClientHelper.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/RabbitMQClientHelper.java
@@ -107,6 +107,12 @@ public class RabbitMQClientHelper {
                 .setUseNio(config.getUseNio())
                 .setVirtualHost(config.getVirtualHost());
 
+        if ("NONE".equals(config.getSslHostnameVerificationAlgorithm())) {
+            options.setHostnameVerificationAlgorithm("");
+        } else {
+            options.setHostnameVerificationAlgorithm(config.getSslHostnameVerificationAlgorithm());
+        }
+
         // JKS TrustStore
         Optional<String> trustStorePath = config.getTrustStorePath();
         if (trustStorePath.isPresent()) {


### PR DESCRIPTION
In this commit, an adjustment was made for MQTT functionality. Specifically, the hostname verifier now requires explicit configuration. Consequently, this commit introduces a new property and configures it with the previously utilized value (""). Since MQTT does not define a verifier algorithm, users needs to verify which algorithm is suitable, as it depends on the broker.