### PR TITLE
Message vs. Payload development model doc changes

### DIFF
--- a/api/revapi.json
+++ b/api/revapi.json
@@ -27,7 +27,17 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+        {
+            "ignore": true,
+            "code": "java.method.visibilityIncreased",
+            "old": "method org.eclipse.microprofile.reactive.messaging.Metadata io.smallrye.reactive.messaging.Messages::merge(org.eclipse.microprofile.reactive.messaging.Metadata, org.eclipse.microprofile.reactive.messaging.Metadata)",
+            "new": "method org.eclipse.microprofile.reactive.messaging.Metadata io.smallrye.reactive.messaging.Messages::merge(org.eclipse.microprofile.reactive.messaging.Metadata, org.eclipse.microprofile.reactive.messaging.Metadata)",
+            "oldVisibility": "private",
+            "newVisibility": "public",
+            "justification": "Metadata merge utility function exposed from the Messages API"
+        }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/api/src/main/java/io/smallrye/reactive/messaging/GenericPayload.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/GenericPayload.java
@@ -1,0 +1,115 @@
+package io.smallrye.reactive.messaging;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+
+/**
+ * A generic payload that can be used to wrap a payload with metadata.
+ * Allows associating a payload with metadata to be sent as a message,
+ * without using signatures supporting {@code Message<T>}.
+ *
+ * @param <T> the type of the payload
+ */
+public class GenericPayload<T> {
+
+    /**
+     * Creates a new payload with the given payload and empty metadata.
+     *
+     * @param payload the payload
+     * @param <T> the type of the payload
+     * @return the payload
+     */
+    public static <T> GenericPayload<T> of(T payload) {
+        return new GenericPayload<>(payload, Metadata.empty());
+    }
+
+    /**
+     * Creates a new payload with the given payload and metadata.
+     *
+     * @param payload the payload
+     * @param metadata the metadata
+     * @param <T> the type of the payload
+     * @return the payload
+     */
+    public static <T> GenericPayload<T> of(T payload, Metadata metadata) {
+        return new GenericPayload<>(payload, metadata);
+    }
+
+    /**
+     * Creates a new payload from the given message.
+     *
+     * @param message the message
+     * @param <T> the type of the payload
+     * @return the payload
+     */
+    public static <T> GenericPayload<T> from(Message<T> message) {
+        return new GenericPayload<>(message.getPayload(), message.getMetadata());
+    }
+
+    private final T payload;
+    private final Metadata metadata;
+
+    public GenericPayload(T payload, Metadata metadata) {
+        this.payload = payload;
+        this.metadata = metadata;
+    }
+
+    /**
+     * Gets the payload associated with this payload.
+     *
+     * @return the payload
+     */
+    public T getPayload() {
+        return payload;
+    }
+
+    /**
+     * Gets the metadata associated with this payload.
+     *
+     * @return the metadata
+     */
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Adds metadata to this payload.
+     *
+     * @param metadata the metadata to add
+     * @return a new payload with the added metadata
+     */
+    public GenericPayload<T> withMetadata(Metadata metadata) {
+        return GenericPayload.of(this.payload, metadata);
+    }
+
+    /**
+     * Adds metadata to this payload.
+     *
+     * @param payload the payload to add
+     * @return a new payload with the added metadata
+     */
+    public <R> GenericPayload<R> withPayload(R payload) {
+        return GenericPayload.of(payload, this.metadata);
+    }
+
+    /**
+     * Converts this payload to a message.
+     *
+     * @return the message with the payload and metadata
+     */
+    public Message<T> toMessage() {
+        return Message.of(payload, metadata);
+    }
+
+    /**
+     * Converts this payload to a message, merging the metadata with the given message.
+     *
+     * @param message the message to merge the metadata with
+     * @return the message with the payload and merged metadata
+     */
+    public Message<T> toMessage(Message<?> message) {
+        Metadata merged = Messages.merge(message.getMetadata(), this.metadata);
+        return message.withPayload(payload).withMetadata(merged);
+    }
+
+}

--- a/api/src/main/java/io/smallrye/reactive/messaging/Messages.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/Messages.java
@@ -142,7 +142,7 @@ public interface Messages {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private static Metadata merge(Metadata first, Metadata second) {
+    static Metadata merge(Metadata first, Metadata second) {
         Metadata result = first;
         for (Object meta : second) {
             Class<?> clazz = meta.getClass();

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
             - 'Advanced Configuration' : concepts/advanced-config.md
             - 'Message Context' : concepts/message-context.md
             - 'Metadata Injection': concepts/incoming-metadata-injection.md
+            - 'Generic Payloads': concepts/generic-payloads.md
 
   - Kafka:
         - kafka/kafka.md

--- a/documentation/src/main/docs/concepts/generic-payloads.md
+++ b/documentation/src/main/docs/concepts/generic-payloads.md
@@ -1,0 +1,34 @@
+# Generic Payloads
+
+!!!warning "Experimental"
+    Generic payloads are an experimental feature and the API is subject to change.
+
+When using reactive messaging, `Message` flow in your system
+each message has a payload but can also contain _metadata_, as explained in [Messages, Payload, Metadata](concepts.md#messages-payload-metadata).
+The metadata can hold information, for example in an outgoing channel, additional properties of the outgoing message to be sent to the broker.
+
+It is sometimes preferable to continue using the [payload signatures](model.md#messages-vs-payloads),
+and also being able to attach metadata.
+Using `GenericPayload` allows customizing metadata when handling payloads in SmallRye Reactive Messaging `@Incoming` and `@Outgoing` methods.
+`GenericPayload` is a wrapper type, like the `Message`, containing a payload and metadata,
+without requiring handling acknowledgments manually.
+
+``` java
+{{ insert('genericpayload/GenericPayloadExample.java', 'code') }}
+```
+
+You can combine generic payloads with [metadata injection](incoming-metadata-injection.md) :
+
+
+``` java
+{{ insert('genericpayload/GenericPayloadExample.java', 'injection') }}
+```
+
+Note that the metadata provided with the outgoing generic payload is merged with the incoming message metadata.
+
+!!! warning "Limitations"
+    There are several limitations for the use of `GenericPayload`:
+    `GenericPayload` is not supported in emitters, as normal outgoing `Message` can be used for that purpose.
+    While `GenericPayload<T>` can be used as an incoming payload type,
+    [message converters](converters.md) are not applied to the payload type `T`.
+

--- a/documentation/src/main/docs/concepts/model.md
+++ b/documentation/src/main/docs/concepts/model.md
@@ -17,8 +17,8 @@ These annotations are used on *methods*:
 {{ insert('beans/MessageProcessingBean.java') }}
 ```
 
-!!! note
-Reactive Messaging beans can either be in the *application* scope (`@ApplicationScoped`) or dependent scope (`@Dependent`).
+!!!note
+    Reactive Messaging beans can either be in the *application* scope (`@ApplicationScoped`) or dependent scope (`@Dependent`).
 
 Manipulating messages can be cumbersome.
 When you are only interested in the payload, you can use the following syntax: The following code is equivalent to the snippet from above:
@@ -27,10 +27,10 @@ When you are only interested in the payload, you can use the following syntax: T
 {{ insert('beans/PayloadProcessingBean.java') }}
 ```
 
-!!! important
-You should not call methods annotated with `@Incoming` and/or
-`@Outgoing` directly from your code. They are invoked by the framework.
-Having user code invoking them would not have the expected outcome.
+!!!important
+    You should not call methods annotated with `@Incoming` and/or
+    `@Outgoing` directly from your code. They are invoked by the framework.
+    Having user code invoking them would not have the expected outcome.
 
 
 SmallRye Reactive Messaging automatically binds matching `@Outgoing` to
@@ -83,15 +83,41 @@ You can also create new instance of `Message` from an existing one:
 ``` java
 {{ insert('messages/MessageExamples.java', 'copy') }}
 ```
-
-!!! note "Acknowledgement?"
-Acknowledgement is an important part of messaging systems. This will be
-covered in the [acknowledgement](acknowledgement.md)
-section.
+!!! warning "Acknowledgement?"
+    Acknowledgement is an important part of messaging systems. This will be covered in the [acknowledgement](acknowledgement.md) section.
 
 !!! note "Connector Metadata"
-Most connectors are providing metadata to let you extract technical
-details about the message, but also customize the outbound dispatching.
+    Most connectors are providing metadata to let you extract technical
+    details about the message, but also customize the outbound dispatching.
+
+## Messages vs. Payloads
+
+Reactive messaging offers flexibility when it comes to handling messages and their acknowledgements.
+The application developer can choose to finely handle acknowledgements per-message basis, by handling the
+`Message`-based signatures. Otherwise, when handling payloads, acknowledgements
+(and negative-acknowledgements) are handled by the framework.
+The following sections in this documentation detail both development models.
+
+While being the easier development model, in the past using payload-based signatures did not allow associating connector-specific metadata,
+making the `Message`-based signatures the de-facto choice even for the most common scenarios.
+This lead to using the connector custom-message implementation types,
+such as `IncomingKafkaRecord`, `KafkaRecord` or `IncomingRabbitMQMessage`,
+as a convenience for accessing connector-specific metadata.
+
+Not only this forces to handle acknowledgements manually,
+it also doesn't allow for incoming or outgoing `Messages` to be [intercepted](decorators.md#intercepting-incoming-and-outgoing-messages)
+or [observed](observability.md).
+
+!!! warning "Custom `Message` types & Message interception"
+    Custom `Message` types such as `IncomingKafkaRecord`, `KafkaRecord` or `IncomingRabbitMQMessage`
+    are not compatible with features intercepting messages.
+    Therefore, it is no longer recommended to use custom `Message` implementations in consumptions methods.
+    Instead, you can either use the generic `Message` type and access specific metadata,
+    or use the payload with [metadata injection](incoming-metadata-injection.md)
+
+Since [incoming metadata injection](incoming-metadata-injection.md) and [generic payloads](generic-payloads.md)
+features added to SmallRye Reactive Messaging,
+it is easier to use payload signatures and benefit from acknowledgement handling and still access connector-specific metadata.
 
 ## Generating Messages
 
@@ -109,10 +135,10 @@ called for every *request* from the downstream:
 ```
 
 !!! note "Requests?"
-Reactive Messaging connects components to build a reactive stream.
-In a  reactive stream, the emissions are controlled by the consumer
-(downstream) indicating to the publisher (upstream) how many items it
-can consume. With this protocol, the consumers are never flooded.
+    Reactive Messaging connects components to build a reactive stream.
+    In a reactive stream, the emissions are controlled by the consumer
+    (downstream) indicating to the publisher (upstream) how many items it
+    can consume. With this protocol, the consumers are never flooded.
 
 
 ### Generating messages using CompletionStage
@@ -300,7 +326,7 @@ directly either synchronously or asynchronously:
 ```
 
 !!! note "What about metadata?"
-With these methods, the metadata are automatically propagated.
+    With these methods, the metadata are automatically propagated.
 
 ## Processing streams
 
@@ -322,7 +348,7 @@ You can receive either a (Reactive Streams) `Publisher`, a
 `Publisher` or a `Publisher` directly.
 
 !!!important
-These signatures do not support metadata propagation. In the case of a
-stream of `Message`, you need to propagate the metadata manually. In the
-case of a stream of payload, propagation is not supported, and incoming
-metadata are lost.
+    These signatures do not support metadata propagation. In the case of a
+    stream of `Message`, you need to propagate the metadata manually. In the
+    case of a stream of payload, propagation is not supported, and incoming
+    metadata are lost.

--- a/documentation/src/main/java/genericpayload/GenericPayloadExample.java
+++ b/documentation/src/main/java/genericpayload/GenericPayloadExample.java
@@ -1,0 +1,35 @@
+package genericpayload;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.GenericPayload;
+import messages.MyMetadata;
+
+@ApplicationScoped
+public class GenericPayloadExample {
+
+    // <code>
+    @Outgoing("out")
+    Multi<GenericPayload<String>> produce() {
+        return Multi.createFrom().range(0, 100)
+                .map(i -> GenericPayload.of(">> " + i, Metadata.of(new MyMetadata())));
+    }
+    // </code>
+
+    // <injection>
+    @Incoming("in")
+    @Outgoing("out")
+    GenericPayload<String> process(int payload, MyMetadata metadata) {
+        // use the injected metadata
+        String id = metadata.getId();
+        return GenericPayload.of(">> " + payload + " " + id,
+                Metadata.of(metadata, new MyMetadata("Bob", "Alice")));
+    }
+    // </injection>
+
+}

--- a/documentation/src/main/java/kafka/inbound/KafkaCheckpointExample.java
+++ b/documentation/src/main/java/kafka/inbound/KafkaCheckpointExample.java
@@ -5,8 +5,8 @@ import java.util.concurrent.CompletionStage;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
 
-import io.smallrye.reactive.messaging.kafka.KafkaRecord;
 import io.smallrye.reactive.messaging.kafka.commit.CheckpointMetadata;
 
 @ApplicationScoped
@@ -14,7 +14,7 @@ public class KafkaCheckpointExample {
 
     // <code>
     @Incoming("prices")
-    public CompletionStage<Void> consume(KafkaRecord<String, Double> record) {
+    public CompletionStage<Void> consume(Message<Double> record) {
         // Get the `CheckpointMetadata` from the incoming message
         CheckpointMetadata<Double> checkpoint = CheckpointMetadata.fromMessage(record);
 

--- a/documentation/src/main/java/kafka/inbound/KafkaDeadLetterExample.java
+++ b/documentation/src/main/java/kafka/inbound/KafkaDeadLetterExample.java
@@ -7,9 +7,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Metadata;
 
-import io.smallrye.reactive.messaging.kafka.KafkaRecord;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 
 @ApplicationScoped
@@ -17,7 +17,7 @@ public class KafkaDeadLetterExample {
 
     // <code>
     @Incoming("in")
-    public CompletionStage<Void> consume(KafkaRecord<String, String> message) {
+    public CompletionStage<Void> consume(Message<String> message) {
         return message.nack(new Exception("Failed!"), Metadata.of(
                 OutgoingKafkaRecordMetadata.builder()
                         .withKey("failed-record")

--- a/documentation/src/main/java/kafka/inbound/KafkaRebalancedConsumer.java
+++ b/documentation/src/main/java/kafka/inbound/KafkaRebalancedConsumer.java
@@ -7,15 +7,14 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-
-import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import org.eclipse.microprofile.reactive.messaging.Message;
 
 @ApplicationScoped
 public class KafkaRebalancedConsumer {
 
     @Incoming("rebalanced-example")
     @Acknowledgment(Acknowledgment.Strategy.NONE)
-    public CompletionStage<Void> consume(IncomingKafkaRecord<Integer, String> message) {
+    public CompletionStage<Void> consume(Message<String> message) {
         // We don't need to ACK messages because in this example we set offset during consumer re-balance
         return CompletableFuture.completedFuture(null);
     }

--- a/documentation/src/main/java/pulsar/inbound/PulsarMessageBatchExample.java
+++ b/documentation/src/main/java/pulsar/inbound/PulsarMessageBatchExample.java
@@ -1,38 +1,36 @@
 package pulsar.inbound;
 
+import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.Messages;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
 
-import io.smallrye.reactive.messaging.pulsar.PulsarIncomingBatchMessage;
-import io.smallrye.reactive.messaging.pulsar.PulsarIncomingMessageMetadata;
-import io.smallrye.reactive.messaging.pulsar.PulsarMessage;
+import io.smallrye.reactive.messaging.pulsar.PulsarIncomingBatchMessageMetadata;
 
 @ApplicationScoped
 public class PulsarMessageBatchExample {
 
     // <code>
     @Incoming("prices")
-    public CompletionStage<Void> consumeMessage(PulsarIncomingBatchMessage<Double> messages) {
-        for (PulsarMessage<Double> msg : messages) {
-            msg.getMetadata(PulsarIncomingMessageMetadata.class).ifPresent(metadata -> {
-                String key = metadata.getKey();
-                String topic = metadata.getTopicName();
-                long timestamp = metadata.getEventTime();
+    public CompletionStage<Void> consumeMessage(Message<List<Double>> messages) {
+        messages.getMetadata(PulsarIncomingBatchMessageMetadata.class).ifPresent(metadata -> {
+            for (org.apache.pulsar.client.api.Message<Object> message : metadata.getMessages()) {
+                String key = message.getKey();
+                String topic = message.getTopicName();
+                long timestamp = message.getEventTime();
                 //... process messages
-            });
-        }
+            }
+        });
         // ack will commit the latest offsets (per partition) of the batch.
         return messages.ack();
     }
 
     @Incoming("prices")
-    public void consumeRecords(Messages<Double> messages) {
-        for (Message<Double> msg : messages) {
+    public void consumeRecords(org.apache.pulsar.client.api.Messages<Double> messages) {
+        for (org.apache.pulsar.client.api.Message<Double> msg : messages) {
             //... process messages
         }
     }

--- a/smallrye-reactive-messaging-kafka-test-companion/revapi.json
+++ b/smallrye-reactive-messaging-kafka-test-companion/revapi.json
@@ -24,7 +24,29 @@
     "criticality" : "highlight",
     "minSeverity" : "POTENTIALLY_BREAKING",
     "minCriticality" : "documented",
-    "differences" : [ ]
+    "differences" : [
+        {
+            "code": "java.method.parameterTypeChanged",
+            "old": "parameter io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder<K, V> io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder<K, V>::withProp(java.lang.String, ===java.lang.String===)",
+            "new": "parameter io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder<K, V> io.smallrye.reactive.messaging.kafka.companion.ConsumerBuilder<K, V>::withProp(java.lang.String, ===java.lang.Object===)",
+            "parameterIndex": "1",
+            "justification": "Companion producer/consumer withProp methods"
+        },
+        {
+            "code": "java.method.parameterTypeChanged",
+            "old": "parameter io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder<K, V> io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder<K, V>::withProp(java.lang.String, ===java.lang.String===)",
+            "new": "parameter io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder<K, V> io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder<K, V>::withProp(java.lang.String, ===java.lang.Object===)",
+            "parameterIndex": "1",
+            "justification": "Companion producer/consumer withProp methods"
+        },
+        {
+            "code": "java.method.parameterTypeParameterChanged",
+            "old": "parameter io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder<K, V> io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder<K, V>::withProps(===java.util.Map<java.lang.String, java.lang.String>===)",
+            "new": "parameter io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder<K, V> io.smallrye.reactive.messaging.kafka.companion.ProducerBuilder<K, V>::withProps(===java.util.Map<java.lang.String, java.lang.Object>===)",
+            "parameterIndex": "0",
+            "justification": "Companion producer/consumer withProp methods"
+        }
+    ]
   }
 }, {
   "extension" : "revapi.reporter.json",

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
@@ -251,7 +251,7 @@ public class ConsumerBuilder<K, V> implements ConsumerRebalanceListener, Closeab
      * @param value the value for property
      * @return this {@link ConsumerBuilder}
      */
-    public ConsumerBuilder<K, V> withProp(String key, String value) {
+    public ConsumerBuilder<K, V> withProp(String key, Object value) {
         props.put(key, value);
         return this;
     }

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ProducerBuilder.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ProducerBuilder.java
@@ -209,7 +209,7 @@ public class ProducerBuilder<K, V> implements Closeable {
      * @param value the value for property
      * @return this {@link ProducerBuilder}
      */
-    public ProducerBuilder<K, V> withProp(String key, String value) {
+    public ProducerBuilder<K, V> withProp(String key, Object value) {
         props.put(key, value);
         return this;
     }
@@ -220,7 +220,7 @@ public class ProducerBuilder<K, V> implements Closeable {
      * @param properties the properties
      * @return this {@link ProducerBuilder}
      */
-    public ProducerBuilder<K, V> withProps(Map<String, String> properties) {
+    public ProducerBuilder<K, V> withProps(Map<String, Object> properties) {
         props.putAll(properties);
         return this;
     }

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ProducerTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ProducerTest.java
@@ -97,7 +97,7 @@ public class ProducerTest extends KafkaCompanionTestBase {
 
     @Test
     void testProducerWithProps() {
-        Map<String, String> props = new HashMap<>();
+        Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BATCH_SIZE_CONFIG, "5");
         props.put(ProducerConfig.LINGER_MS_CONFIG, "100");
         ProducerTask records = companion.produceIntegers()

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/GenericPayloadTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/GenericPayloadTest.java
@@ -1,0 +1,73 @@
+package io.smallrye.reactive.messaging.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.GenericPayload;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
+import io.smallrye.reactive.messaging.kafka.converters.ConsumerRecordConverter;
+import io.smallrye.reactive.messaging.providers.helpers.GenericPayloadConverter;
+
+public class GenericPayloadTest extends KafkaCompanionTestBase {
+    private static final String TOPIC_NAME_BASE = "GenericPayloadTest-" + UUID.randomUUID() + "-";
+
+    @Test
+    public void testProduce() {
+        for (int i = 0; i < 10; i++) {
+            companion.topics().createAndWait(TOPIC_NAME_BASE + i, 1);
+        }
+
+        addBeans(GenericPayloadConverter.class);
+        addBeans(ConsumerRecordConverter.class);
+        runApplication(kafkaConfig("mp.messaging.outgoing.generated-producer")
+                .put("topic", "nonexistent-topic")
+                .put("key.serializer", StringSerializer.class.getName())
+                .put("value.serializer", StringSerializer.class.getName()), MyApp.class);
+
+        assertThat(companion.consumeStrings().fromTopics(Pattern.compile(TOPIC_NAME_BASE + ".+"), 10)
+                .awaitCompletion()).allSatisfy(consumerRecord -> {
+                    assertThat(consumerRecord.key()).startsWith("key-");
+                    assertThat(consumerRecord.value()).startsWith("value-");
+                    assertThat(consumerRecord.topic()).startsWith(TOPIC_NAME_BASE);
+
+                    assertThat(consumerRecord.headers()).allSatisfy(header -> {
+                        assertThat(header.key()).startsWith("my-header-");
+                        assertThat(new String(header.value(), StandardCharsets.UTF_8)).startsWith("my-header-value-");
+                    });
+                });
+
+    }
+
+    @ApplicationScoped
+    public static class MyApp {
+
+        @Outgoing("generated-producer")
+        public Multi<GenericPayload<String>> produce() {
+            return Multi.createFrom().range(0, 10).map(id -> {
+                Headers headersToBeUsed = new RecordHeaders()
+                        .add("my-header-" + id, ("my-header-value-" + id).getBytes(StandardCharsets.UTF_8));
+                return GenericPayload.of("value-" + id, Metadata.of(
+                        OutgoingKafkaRecordMetadata.<String> builder()
+                                .withTopic(TOPIC_NAME_BASE + id)
+                                .withKey("key-" + id)
+                                .withHeaders(headersToBeUsed)
+                                .build()));
+            });
+        }
+
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/AbstractMediator.java
@@ -327,4 +327,8 @@ public abstract class AbstractMediator {
         return Uni.createFrom().item(message);
     }
 
+    protected Message<Object> payloadToMessage(Object payload) {
+        return (payload instanceof GenericPayload) ? ((GenericPayload<Object>) payload).toMessage() : Message.of(payload);
+    }
+
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/PublisherMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/PublisherMediator.java
@@ -112,7 +112,8 @@ public class PublisherMediator extends AbstractMediator {
 
     private <P> void produceAPublisherBuilderOfPayloads() {
         PublisherBuilder<P> builder = invoke();
-        this.publisher = decorate(MultiUtils.publisher(AdaptersToFlow.publisher(builder.map(Message::of).buildRs())));
+        this.publisher = decorate(MultiUtils.publisher(
+                AdaptersToFlow.publisher(builder.map(this::payloadToMessage).buildRs())));
     }
 
     private void produceAPublisherOfMessages() {
@@ -127,12 +128,12 @@ public class PublisherMediator extends AbstractMediator {
 
     private <P> void produceAPublisherOfPayloads() {
         Flow.Publisher<P> pub = invoke();
-        this.publisher = decorate(MultiUtils.publisher(pub).map(Message::of));
+        this.publisher = decorate(MultiUtils.publisher(pub).map(this::payloadToMessage));
     }
 
     private <P> void produceAReactiveStreamsPublisherOfPayloads() {
         Publisher<P> pub = invoke();
-        this.publisher = decorate(Multi.createFrom().publisher(AdaptersToFlow.publisher(pub)).map(Message::of));
+        this.publisher = decorate(Multi.createFrom().publisher(AdaptersToFlow.publisher(pub)).map(this::payloadToMessage));
     }
 
     private void produceIndividualMessages() {
@@ -160,15 +161,15 @@ public class PublisherMediator extends AbstractMediator {
             if (configuration.isBlockingExecutionOrdered()) {
                 this.publisher = decorate(MultiUtils.createFromGenerator(this::invokeBlocking)
                         .onItem().transformToUniAndConcatenate(u -> u)
-                        .onItem().transform(Message::of));
+                        .onItem().transform(this::payloadToMessage));
             } else {
                 this.publisher = decorate(MultiUtils.createFromGenerator(this::invokeBlocking)
                         .onItem().transformToUni(u -> u).merge(maxConcurrency())
-                        .onItem().transform(Message::of));
+                        .onItem().transform(this::payloadToMessage));
             }
         } else {
             this.publisher = decorate(MultiUtils.createFromGenerator(this::invoke)
-                    .onItem().transform(Message::of));
+                    .onItem().transform(this::payloadToMessage));
         }
     }
 
@@ -179,7 +180,7 @@ public class PublisherMediator extends AbstractMediator {
 
     private <P> void produceIndividualCompletionStageOfPayloads() {
         this.publisher = decorate(MultiUtils.<CompletionStage<P>> createFromGenerator(this::invoke)
-                .onItem().transformToUniAndConcatenate(cs -> Uni.createFrom().completionStage(cs).map(Message::of)));
+                .onItem().transformToUniAndConcatenate(cs -> Uni.createFrom().completionStage(cs).map(this::payloadToMessage)));
     }
 
     private void produceIndividualUniOfMessages() {
@@ -189,6 +190,6 @@ public class PublisherMediator extends AbstractMediator {
 
     private void produceIndividualUniOfPayloads() {
         this.publisher = decorate(MultiUtils.<Uni<?>> createFromGenerator(this::invoke)
-                .onItem().transformToUniAndConcatenate(u -> u.map(Message::of)));
+                .onItem().transformToUniAndConcatenate(u -> u.map(this::payloadToMessage)));
     }
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/StreamTransformerMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/StreamTransformerMediator.java
@@ -261,7 +261,7 @@ public class StreamTransformerMediator extends AbstractMediator {
             PublisherBuilder<Object> result = invoke(argument);
             Objects.requireNonNull(result, msg.methodReturnedNull(configuration.methodAsString()));
             return MultiUtils.publisher(AdaptersToFlow.publisher(result.buildRs()))
-                    .onItem().transform(Message::of);
+                    .onItem().transform(this::payloadToMessage);
         };
     }
 
@@ -273,7 +273,7 @@ public class StreamTransformerMediator extends AbstractMediator {
             Publisher<Object> result = invoke(argument);
             Objects.requireNonNull(result, msg.methodReturnedNull(configuration.methodAsString()));
             return Multi.createFrom().publisher(AdaptersToFlow.publisher(result))
-                    .onItem().transform(Message::of);
+                    .onItem().transform(this::payloadToMessage);
         };
     }
 
@@ -291,7 +291,7 @@ public class StreamTransformerMediator extends AbstractMediator {
         MultiSplitter<?, K> result = invoke(argument);
         Map<K, String> keyChannelMappings = findKeyOutgoingChannelMappings(result.keyType().getEnumConstants());
         keyChannelMappings.forEach((key, outgoing) -> {
-            Multi<? extends Message<?>> m = result.get(key).onItem().transform(Message::of)
+            Multi<? extends Message<?>> m = result.get(key).onItem().transform(this::payloadToMessage)
                     // concat map with prefetch handles the request starvation issue with SplitMulti and also syncs requests
                     .onItem().transformToUni(u -> Uni.createFrom().item(u)).concatenate(true);
             outgoingPublisherMap.put(outgoing, m);
@@ -307,7 +307,7 @@ public class StreamTransformerMediator extends AbstractMediator {
             Flow.Publisher<Object> result = invoke(argument);
             Objects.requireNonNull(result, msg.methodReturnedNull(configuration.methodAsString()));
             return MultiUtils.publisher(result)
-                    .onItem().transform(Message::of);
+                    .onItem().transform(this::payloadToMessage);
         };
     }
 
@@ -319,7 +319,7 @@ public class StreamTransformerMediator extends AbstractMediator {
                     .flatMap(km -> {
                         Flow.Publisher<?> result = invoke(km);
                         return Objects.requireNonNull(result, msg.methodReturnedNull(configuration.methodAsString()));
-                    }).map(Message::of);
+                    }).map(this::payloadToMessage);
         };
     }
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/GenericPayloadConverter.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/GenericPayloadConverter.java
@@ -1,0 +1,24 @@
+package io.smallrye.reactive.messaging.providers.helpers;
+
+import java.lang.reflect.Type;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import io.smallrye.reactive.messaging.GenericPayload;
+import io.smallrye.reactive.messaging.MessageConverter;
+
+@ApplicationScoped
+public class GenericPayloadConverter implements MessageConverter {
+
+    @Override
+    public boolean canConvert(Message<?> in, Type target) {
+        return TypeUtils.getRawTypeIfParameterized(target).equals(GenericPayload.class);
+    }
+
+    @Override
+    public Message<?> convert(Message<?> in, Type target) {
+        return in.withPayload(GenericPayload.from(in));
+    }
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/GenericPayloadTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/GenericPayloadTest.java
@@ -1,0 +1,161 @@
+package io.smallrye.reactive.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.providers.helpers.GenericPayloadConverter;
+
+public class GenericPayloadTest extends WeldTestBaseWithoutTails {
+
+    @Test
+    public void testIncomingGenericPayload() {
+        addBeanClass(MyCollector.class);
+        addBeanClass(GenericPayloadConverter.class);
+        addBeanClass(GenericPayloadConsumer.class);
+
+        initialize();
+
+        GenericPayloadConsumer consumer = get(GenericPayloadConsumer.class);
+        await().untilAsserted(() -> assertThat(consumer.received())
+                .hasSize(10)
+                .extracting(GenericPayload::getPayload)
+                .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+    }
+
+    @ApplicationScoped
+    public static class GenericPayloadConsumer {
+
+        List<GenericPayload<Integer>> payloads = new CopyOnWriteArrayList<>();
+
+        @Incoming("count")
+        void consume(GenericPayload<Integer> payload) {
+            payloads.add(payload);
+        }
+
+        public List<GenericPayload<Integer>> received() {
+            return payloads;
+        }
+    }
+
+    @Test
+    public void testOutgoingGenericPayload() {
+        addBeanClass(MyCollector.class);
+        addBeanClass(GenericPayloadProducer.class);
+
+        initialize();
+
+        GenericPayloadProducer producer = get(GenericPayloadProducer.class);
+        MyCollector collector = get(MyCollector.class);
+        await().untilAsserted(() -> assertThat(collector.messages())
+                .hasSize(10)
+                .allSatisfy(m -> assertThat(m.getMetadata(Object.class)).hasValue(producer.metadata()))
+                .extracting(Message::getPayload)
+                .containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"));
+    }
+
+    @ApplicationScoped
+    public static class GenericPayloadProducer {
+
+        Object metadata = new Object();
+
+        @Outgoing("sink")
+        Multi<GenericPayload<String>> produce() {
+            return Multi.createFrom().range(0, 10)
+                    .map(i -> GenericPayload.of("" + i, Metadata.of(metadata)));
+        }
+
+        public Object metadata() {
+            return metadata;
+        }
+
+    }
+
+    @Test
+    public void testProcessorGenericPayload() {
+        addBeanClass(MyCollector.class);
+        addBeanClass(GenericPayloadProcessor.class);
+        addBeanClass(GenericPayloadConverter.class);
+
+        initialize();
+
+        GenericPayloadProcessor processor = get(GenericPayloadProcessor.class);
+        MyCollector collector = get(MyCollector.class);
+        await().untilAsserted(() -> assertThat(collector.messages())
+                .hasSize(10)
+                .allSatisfy(m -> assertThat(m.getMetadata(Object.class).get()).isEqualTo(processor.metadata()))
+                .extracting(Message::getPayload)
+                .containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"));
+    }
+
+    @ApplicationScoped
+    private static class GenericPayloadProcessor {
+        Object metadata = new Object();
+
+        @Incoming("count")
+        @Outgoing("sink")
+        GenericPayload<String> process(GenericPayload<Integer> payload) {
+            return payload.withPayload("" + payload.getPayload())
+                    .withMetadata(Metadata.of(metadata));
+        }
+
+        public Object metadata() {
+            return metadata;
+        }
+
+    }
+
+    @Test
+    public void testEmitterGenericPayloadNotSupported() {
+        addBeanClass(MyCollector.class);
+        addBeanClass(GenericPayloadEmitter.class);
+        addBeanClass(GenericPayloadConverter.class);
+
+        initialize();
+
+        GenericPayloadEmitter emitter = get(GenericPayloadEmitter.class);
+        MyCollector collector = get(MyCollector.class);
+
+        emitter.send10();
+
+        await().untilAsserted(() -> assertThat(collector.messages())
+                .hasSize(10)
+                .allSatisfy(m -> assertThat(m.getMetadata(Object.class)).isEmpty())
+                .extracting(m -> (GenericPayload) (Object) m.getPayload())
+                .allSatisfy(p -> assertThat(p).isInstanceOf(GenericPayload.class)));
+    }
+
+    @ApplicationScoped
+    private static class GenericPayloadEmitter {
+
+        Object metadata = new Object();
+
+        @Inject
+        @Channel("sink")
+        Emitter<GenericPayload<String>> emitter;
+
+        void send10() {
+            for (int i = 0; i < 10; i++) {
+                emitter.send(GenericPayload.of("" + i, Metadata.of(metadata)));
+            }
+        }
+
+        public Object metadata() {
+            return metadata;
+        }
+    }
+}


### PR DESCRIPTION
Introduces `GenericPayload`, (`PayloadWithMetadata` could be an alternative name) to treat payload+metadata as a payload type, primarily for outgoing messages.
This enables more usages of `@Incoming/@Outgoing` without using `Message` types.

Limitations:
- The incoming converters are not supported for types wrapped with GenericPayload
- Usage of GenericPayload with emitters isn't supported as `Message` already works as expected for those cases.
