### PR TITLE
Use Kafka channel instead of producer in DLQ and Delayed retry topic

### DIFF
--- a/smallrye-reactive-messaging-aws-sqs/src/main/java/io/smallrye/reactive/messaging/aws/sqs/SqsMessage.java
+++ b/smallrye-reactive-messaging-aws-sqs/src/main/java/io/smallrye/reactive/messaging/aws/sqs/SqsMessage.java
@@ -14,7 +14,6 @@ import io.smallrye.reactive.messaging.aws.sqs.i18n.AwsSqsExceptions;
 import io.smallrye.reactive.messaging.json.JsonMapping;
 import io.smallrye.reactive.messaging.providers.MetadataInjectableMessage;
 import io.smallrye.reactive.messaging.providers.locals.ContextAwareMessage;
-
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 


### PR DESCRIPTION
This would allow to enable tracing and observation (metrics) as the DLQ would be an outgoing channel.