### PR TITLE
Pulsar outgoing max pending messages rename

### DIFF
--- a/smallrye-reactive-messaging-pulsar/src/main/java/io/smallrye/reactive/messaging/pulsar/PulsarConnector.java
+++ b/smallrye-reactive-messaging-pulsar/src/main/java/io/smallrye/reactive/messaging/pulsar/PulsarConnector.java
@@ -65,7 +65,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "batchReceive", type = "boolean", direction = ConnectorAttribute.Direction.INCOMING, description = "Whether batch receive is used to consume messages", defaultValue = "false")
 
 @ConnectorAttribute(name = "producer-configuration", type = "string", direction = ConnectorAttribute.Direction.OUTGOING, description = "Identifier of a CDI bean that provides the default Pulsar producer configuration for this channel. The channel configuration can still override any attribute. The bean must have a type of Map<String, Object> and must use the @io.smallrye.common.annotation.Identifier qualifier to set the identifier.")
-@ConnectorAttribute(name = "maxPendingMessages", type = "int", direction = ConnectorAttribute.Direction.OUTGOING, description = "The maximum size of a queue holding pending messages, i.e messages waiting to receive an acknowledgment from a broker", defaultValue = "1000")
+@ConnectorAttribute(name = "max-inflight-messages", type = "int", direction = ConnectorAttribute.Direction.OUTGOING, description = "The maximum size of a queue holding pending messages, i.e messages waiting to receive an acknowledgment from a broker. Defaults to 1000 messages")
 @ConnectorAttribute(name = "waitForWriteCompletion", type = "boolean", direction = ConnectorAttribute.Direction.OUTGOING, description = "Whether the client waits for the broker to acknowledge the written record before acknowledging the message", defaultValue = "true")
 public class PulsarConnector implements InboundConnector, OutboundConnector, HealthReporter {
 

--- a/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/base/PulsarContainer.java
+++ b/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/base/PulsarContainer.java
@@ -29,7 +29,6 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
         super.withStartupTimeout(Duration.ofSeconds(60));
         super.waitingFor(Wait.forLogMessage(".*Created namespace public/default.*", 1));
         super.withCommand("sh", "-c", runStarterScript());
-        super.withTmpFs(Collections.singletonMap("/pulsar/data", "rw"));
     }
 
     protected String runStarterScript() {

--- a/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/base/PulsarContainer.java
+++ b/smallrye-reactive-messaging-pulsar/src/test/java/io/smallrye/reactive/messaging/pulsar/base/PulsarContainer.java
@@ -2,7 +2,6 @@ package io.smallrye.reactive.messaging.pulsar.base;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Collections;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -13,7 +12,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 
 public class PulsarContainer extends GenericContainer<PulsarContainer> {
 
-    public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse("apachepulsar/pulsar:3.0.0");
+    public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse("apachepulsar/pulsar:3.2.2");
 
     public static final String STARTER_SCRIPT = "/run_pulsar.sh";
 


### PR DESCRIPTION
Didn't choose to deprecate `maxPendingMessages` as it is also a Pulsar producer config