### PR TITLE
Fix empty JMSType for legacy connector

### DIFF
--- a/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/IncomingJmsMessage.java
+++ b/smallrye-reactive-messaging-jms/src/main/java/io/smallrye/reactive/messaging/jms/IncomingJmsMessage.java
@@ -36,7 +36,7 @@ public class IncomingJmsMessage<T> implements org.eclipse.microprofile.reactive.
             // ignore it
         }
         try {
-            this.clazz = cn != null ? load(cn) : null;
+            this.clazz = cn != null && !cn.isEmpty() ? load(cn) : null;
         } catch (ClassNotFoundException e) {
             throw ex.illegalStateUnableToLoadClass(e);
         }


### PR DESCRIPTION
This PR fix: https://github.com/smallrye/smallrye-reactive-messaging/issues/2625