### PR TITLE
Add configuration 'retain' property for outgoing MQTT message

### DIFF
--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttConnector.java
@@ -64,6 +64,7 @@ import io.vertx.mutiny.core.Vertx;
 @ConnectorAttribute(name = "merge", direction = OUTGOING, description = "Whether the connector should allow multiple upstreams", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "buffer-size", direction = INCOMING, description = "The size buffer of incoming messages waiting to be processed", type = "int", defaultValue = "128")
 @ConnectorAttribute(name = "unsubscribe-on-disconnection", direction = INCOMING_AND_OUTGOING, description = "This flag restore the old behavior to unsubscribe from the broken on disconnection", type = "boolean", defaultValue = "false")
+@ConnectorAttribute(name = "retain", direction = OUTGOING, description = "Whether the published message should be retained", type = "boolean", defaultValue = "false")
 public class MqttConnector implements InboundConnector, OutboundConnector, HealthReporter {
 
     static final String CONNECTOR_NAME = "smallrye-mqtt";

--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSink.java
@@ -32,6 +32,7 @@ public class MqttSink {
     private final String topic;
     private final int qos;
     private final boolean healthEnabled;
+    private final boolean retain;
 
     private final Flow.Subscriber<? extends Message<?>> sink;
 
@@ -48,6 +49,7 @@ public class MqttSink {
         topic = config.getTopic().orElse(channel);
         qos = config.getQos();
         healthEnabled = config.getHealthEnabled();
+        retain = config.getRetain();
 
         sink = MultiUtils.via(m -> m.onSubscription()
                 .call(() -> {
@@ -89,7 +91,7 @@ public class MqttSink {
             isRetain = mm.isRetain();
         } else {
             actualTopicToBeUsed = this.topic;
-            isRetain = false;
+            isRetain = this.retain;
             actualQoS = MqttQoS.valueOf(this.qos);
         }
 


### PR DESCRIPTION
Fixed issue #2663 

I did not find any documentation or example to update manually.
As far as I can see, the documentation gets updated automagically with the new connector attribute for outgoing messages.

Added a test to verify the send message contains the 'retain' property set to True, but cannot get this test to succeed.
It seems to go wrong somewhere in the Mqtt client code.
While debugging, I see the retain property is correctly set to true when the message is transformed into a `byte[]`.
But when reconstructing the message from `byte[]` the retain setting seems to have been lost and therefore the value is False instead of the expected True.

Any idea how to fix this? I'm clueless.