### PR TITLE
#2698 Fix: Pulsar pool message - Out of direct memory leak in PulsarNack

### DIFF
--- a/smallrye-reactive-messaging-pulsar/src/main/java/io/smallrye/reactive/messaging/pulsar/fault/PulsarNack.java
+++ b/smallrye-reactive-messaging-pulsar/src/main/java/io/smallrye/reactive/messaging/pulsar/fault/PulsarNack.java
@@ -45,6 +45,7 @@ public class PulsarNack implements PulsarFailureHandler {
         consumer.negativeAcknowledge(message.getMessageId());
         log.messageFailureNacked(channel, reason.getMessage());
         log.messageFailureFullCause(reason);
+        message.unwrap().release();
         return Uni.createFrom().voidItem()
                 .emitOn(message::runOnMessageContext);
     }


### PR DESCRIPTION
PulsarNackPoolMessagesTest>PulsarNackTest.testDeadLetterTopic is failing because of [Pulsar bug](https://github.com/apache/pulsar/issues/13269)