### PR TITLE
Improvements to post-processing ack management

### DIFF
--- a/documentation/src/main/docs/concepts/signatures.md
+++ b/documentation/src/main/docs/concepts/signatures.md
@@ -55,14 +55,14 @@ and available acknowledgement strategies (when applicable).
 | `@Outgoing @Incoming Flow.Processor<I, O> method()`                       | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
 | `@Outgoing @Incoming ProcessorBuilder<Message<I>, Message<O>> method()`   | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
 | `@Outgoing @Incoming ProcessorBuilder<I, O> method()`                     | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
-| `@Outgoing @Incoming Publisher<Message<O>> method(Message<I> msg)`        | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Publisher<O> method(I payload)`                      | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
-| `@Outgoing @Incoming Multi<Message<O>> method(Message<I> msg)`            | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Multi<O> method(I payload)`                          | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
-| `@Outgoing @Incoming Flow.Publisher<Message<O>> method(Message<I> msg)`   | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Flow.Publisher<O> method(I payload)`                 | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
-| `@Outgoing @Incoming PublisherBuilder<Message<O>> method(Message<I> msg)` | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming PublisherBuilder<O> method(I payload)`               | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | automatic            |
+| `@Outgoing @Incoming Publisher<Message<O>> method(Message<I> msg)`        | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming Publisher<O> method(I payload)`                      | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE | automatic            |
+| `@Outgoing @Incoming Multi<Message<O>> method(Message<I> msg)`            | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming Multi<O> method(I payload)`                          | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE | automatic            |
+| `@Outgoing @Incoming Flow.Publisher<Message<O>> method(Message<I> msg)`   | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming Flow.Publisher<O> method(I payload)`                 | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE | automatic            |
+| `@Outgoing @Incoming PublisherBuilder<Message<O>> method(Message<I> msg)` | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
+| `@Outgoing @Incoming PublisherBuilder<O> method(I payload)`               | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE | automatic            |
 
 ## Method signatures to manipulate streams
 

--- a/documentation/src/main/docs/concepts/signatures.md
+++ b/documentation/src/main/docs/concepts/signatures.md
@@ -41,28 +41,41 @@ and available acknowledgement strategies (when applicable).
 
 ## Method signatures to process data
 
-| Signature                                                                 | Invocation time                                  | Supported Acknowledgement Strategies    | Metadata Propagation |
-|---------------------------------------------------------------------------|--------------------------------------------------|-----------------------------------------|----------------------|
-| `@Outgoing @Incoming Message<O> method(Message<I> msg)`                   | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING          | manual               |
-| `@Outgoing @Incoming O method(I payload)`                                 | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING | automatic            |
-| `@Outgoing @Incoming CompletionStage<Message<O>> method(Message<I> msg)`  | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING          | manual               |
-| `@Outgoing @Incoming CompletionStage<O> method(I payload)`                | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING | automatic            |
-| `@Outgoing @Incoming Uni<Message<O>> method(Message<I> msg)`              | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING          | manual               |
-| `@Outgoing @Incoming Uni<O> method(I payload)`                            | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING | automatic            |
-| `@Outgoing @Incoming Processor<Message<I>, Message<O>> method()`          | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Processor<I, O> method()`                            | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
-| `@Outgoing @Incoming Flow.Processor<Message<I>, Message<O>> method()`     | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Flow.Processor<I, O> method()`                       | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
-| `@Outgoing @Incoming ProcessorBuilder<Message<I>, Message<O>> method()`   | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming ProcessorBuilder<I, O> method()`                     | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                  | not supported        |
-| `@Outgoing @Incoming Publisher<Message<O>> method(Message<I> msg)`        | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Publisher<O> method(I payload)`                      | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE | automatic            |
-| `@Outgoing @Incoming Multi<Message<O>> method(Message<I> msg)`            | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Multi<O> method(I payload)`                          | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE | automatic            |
-| `@Outgoing @Incoming Flow.Publisher<Message<O>> method(Message<I> msg)`   | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming Flow.Publisher<O> method(I payload)`                 | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE | automatic            |
-| `@Outgoing @Incoming PublisherBuilder<Message<O>> method(Message<I> msg)` | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE          | manual               |
-| `@Outgoing @Incoming PublisherBuilder<O> method(I payload)`               | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE | automatic            |
+| Signature                                                                 | Invocation time                                  | Supported Acknowledgement Strategies                            | Metadata Propagation |
+|---------------------------------------------------------------------------|--------------------------------------------------|-----------------------------------------------------------------|----------------------|
+| `@Outgoing @Incoming Message<O> method(Message<I> msg)`                   | Called for every incoming message (sequentially) | POST_PROCESSING (Smallrye only), *MANUAL*, NONE, PRE_PROCESSING | manual               |
+| `@Outgoing @Incoming Message<O> method(I payload)`                        | Called for every incoming message (sequentially) | *POST_PROCESSING* (Smallrye only), NONE, PRE_PROCESSING         | automatic            |
+| `@Outgoing @Incoming O method(I payload)`                                 | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING                         | automatic            |
+| `@Outgoing @Incoming CompletionStage<Message<O>> method(Message<I> msg)`  | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING                                  | manual               |
+| `@Outgoing @Incoming CompletionStage<O> method(I payload)`                | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING                         | automatic            |
+| `@Outgoing @Incoming CompletionStage<Message<O>> method(I payload)`       | Called for every incoming payload (sequentially) | *POST_PROCESSING* (Smallrye only), NONE, PRE_PROCESSING         | automatic            |
+| `@Outgoing @Incoming Uni<Message<O>> method(Message<I> msg)`              | Called for every incoming message (sequentially) | *MANUAL*, NONE, PRE_PROCESSING                                  | manual               |
+| `@Outgoing @Incoming Uni<Message<O>> method(I payload)`                   | Called for every incoming payload (sequentially) | *POST_PROCESSING* (Smallrye only), NONE, PRE_PROCESSING         | automatic            |
+| `@Outgoing @Incoming Uni<O> method(I payload)`                            | Called for every incoming payload (sequentially) | *POST_PROCESSING*, NONE, PRE_PROCESSING                         | automatic            |
+| `@Outgoing @Incoming Processor<Message<I>, Message<O>> method()`          | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE                                  | manual               |
+| `@Outgoing @Incoming Processor<I, O> method()`                            | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                                          | not supported        |
+| `@Outgoing @Incoming Flow.Processor<Message<I>, Message<O>> method()`     | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE                                  | manual               |
+| `@Outgoing @Incoming Flow.Processor<I, O> method()`                       | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                                          | not supported        |
+| `@Outgoing @Incoming ProcessorBuilder<Message<I>, Message<O>> method()`   | Called once at *assembly* time                   | *MANUAL*, PRE_PROCESSING, NONE                                  | manual               |
+| `@Outgoing @Incoming ProcessorBuilder<I, O> method()`                     | Called once at *assembly* time                   | *PRE_PROCESSING*, NONE                                          | not supported        |
+| `@Outgoing @Incoming Publisher<Message<O>> method(Message<I> msg)`        | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE                                  | manual               |
+| `@Outgoing @Incoming Publisher<O> method(I payload)`                      | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE                         | automatic            |
+| `@Outgoing @Incoming Multi<Message<O>> method(Message<I> msg)`            | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE                                  | manual               |
+| `@Outgoing @Incoming Multi<O> method(I payload)`                          | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE                         | automatic            |
+| `@Outgoing @Incoming Flow.Publisher<Message<O>> method(Message<I> msg)`   | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE                                  | manual               |
+| `@Outgoing @Incoming Flow.Publisher<O> method(I payload)`                 | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE                         | automatic            |
+| `@Outgoing @Incoming PublisherBuilder<Message<O>> method(Message<I> msg)` | Called for every incoming message (sequentially) | *MANUAL*, PRE_PROCESSING, NONE                                  | manual               |
+| `@Outgoing @Incoming PublisherBuilder<O> method(I payload)`               | Called for every incoming payload (sequentially) | *PRE_PROCESSING*, POST_PROCESSING, NONE                         | automatic            |
+
+Note that in additional to the MicroProfile Reactive Messaging specification,
+SmallRye Reactive Messaging supports the post-processing acknowledgment handling with automatic metadata propagation for the following signatures:
+
+- `@Outgoing @Incoming Message<O> method(I payload)`
+- `@Outgoing @Incoming CompletionStage<Message<O>> method(I payload)`
+- `@Outgoing @Incoming Uni<Message<O>> method(I payload)`
+- `@Outgoing @Incoming Message<O> method(Message<I> payload)` : For this signature, the post-processing acknowledgment handling is limited.
+  It covers cases for nacking incoming messages on caught exceptions at the method body, acking incoming messages when outgoing message is skipped by returning `null`, and chaining acknowlegment from outgoing message to the incoming.
+  However, if the incoming message has already been (n)acked, you will experience duplicate (n)acks.
 
 ## Method signatures to manipulate streams
 

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MediatorConfigurationSupport.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/MediatorConfigurationSupport.java
@@ -422,7 +422,10 @@ public class MediatorConfigurationSupport {
 
         if (production == MediatorConfiguration.Production.INDIVIDUAL_MESSAGE
                 && acknowledgment == Acknowledgment.Strategy.POST_PROCESSING) {
-            throw ex.illegalStateForValidateProcessor(methodAsString);
+            // relax here the validation for the post-processing acknowledgment
+            if (consumption == MediatorConfiguration.Consumption.MESSAGE) {
+                log.postProcessingNotFullySupported(methodAsString);
+            }
         }
 
         return new ValidationOutput(production, consumption, useBuilderTypes, useReactiveStreams, payloadType);

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/ProcessorMediator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/ProcessorMediator.java
@@ -26,6 +26,7 @@ import io.smallrye.reactive.messaging.Shape;
 import io.smallrye.reactive.messaging.providers.helpers.AcknowledgementCoordinator;
 import io.smallrye.reactive.messaging.providers.helpers.ClassUtils;
 import io.smallrye.reactive.messaging.providers.helpers.MultiUtils;
+import io.smallrye.reactive.messaging.providers.i18n.ProviderLogging;
 import mutiny.zero.flow.adapters.AdaptersToFlow;
 
 @SuppressWarnings("ReactiveStreamsUnusedPublisher")
@@ -147,19 +148,19 @@ public class ProcessorMediator extends AbstractMediator {
                 processMethodReturningIndividualPayloadAndConsumingIndividualItem();
                 break;
             case COMPLETION_STAGE_OF_MESSAGE:
-                // Case 11
+                // Case 12
                 processMethodReturningACompletionStageOfMessageAndConsumingIndividualItem();
                 break;
             case COMPLETION_STAGE_OF_PAYLOAD:
-                // Case 12
+                // Case 11
                 processMethodReturningACompletionStageOfPayloadAndConsumingIndividualItem();
                 break;
             case UNI_OF_MESSAGE:
-                // Case 11 - Uni variant
+                // Case 12 - Uni variant
                 processMethodReturningAUniOfMessageAndConsumingIndividualItem();
                 break;
             case UNI_OF_PAYLOAD:
-                // Case 12 - Uni variant
+                // Case 11 - Uni variant
                 processMethodReturningAUniOfPayloadAndConsumingIndividualItem();
                 break;
             default:
@@ -167,6 +168,9 @@ public class ProcessorMediator extends AbstractMediator {
         }
     }
 
+    /**
+     * {@code PublisherBuilder<Message<O>> method(Message<I> msg)}
+     */
     @SuppressWarnings("unchecked")
     private void processMethodReturningAPublisherBuilderOfMessageAndConsumingMessages() {
         this.mapper = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
@@ -174,6 +178,9 @@ public class ProcessorMediator extends AbstractMediator {
                         msg -> AdaptersToFlow.publisher(((PublisherBuilder<Message<?>>) invoke(msg)).buildRs()));
     }
 
+    /**
+     * {@code PublisherBuilder<Message<O>> method(Message<I> msg)}
+     */
     @SuppressWarnings("unchecked")
     private void processMethodReturningAReactiveStreamsPublisherOfMessageAndConsumingMessages() {
         this.mapper = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
@@ -181,12 +188,18 @@ public class ProcessorMediator extends AbstractMediator {
                         msg -> AdaptersToFlow.publisher((Publisher<Message<?>>) invoke(msg)));
     }
 
+    /**
+     * {@code Flow.Publisher<Message<O>> method(Message<I> msg)}
+     */
     @SuppressWarnings("unchecked")
     private void processMethodReturningAPublisherOfMessageAndConsumingMessages() {
         this.mapper = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
                 .onItem().transformToMultiAndConcatenate(msg -> (Flow.Publisher<Message<?>>) invoke(msg));
     }
 
+    /**
+     * {@code ProcessorBuilder<Message<I>, Message<O>> method()}
+     */
     private void processMethodReturningAProcessorBuilderOfMessages() {
         ProcessorBuilder<Message<?>, Message<?>> builder = Objects.requireNonNull(invoke(),
                 msg.methodReturnedNull(configuration.methodAsString()));
@@ -197,6 +210,9 @@ public class ProcessorMediator extends AbstractMediator {
         };
     }
 
+    /**
+     * {@code Processor<Message<I>, Message<O>> method()}
+     */
     private void processMethodReturningAReactiveStreamsProcessorOfMessages() {
         Processor<Message<?>, Message<?>> result = Objects.requireNonNull(invoke(),
                 msg.methodReturnedNull(configuration.methodAsString()));
@@ -207,6 +223,9 @@ public class ProcessorMediator extends AbstractMediator {
         };
     }
 
+    /**
+     * {@code Flow.Processor<Message<I>, Message<O>> method()}
+     */
     private void processMethodReturningAProcessorOfMessages() {
         Flow.Processor<Message<?>, Message<?>> result = Objects.requireNonNull(invoke(),
                 msg.methodReturnedNull(configuration.methodAsString()));
@@ -217,6 +236,9 @@ public class ProcessorMediator extends AbstractMediator {
         };
     }
 
+    /**
+     * {@code ProcessorBuilder<O> method()}
+     */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private void processMethodReturningAProcessorBuilderOfPayloads() {
         ProcessorBuilder returnedProcessorBuilder = invoke();
@@ -230,6 +252,9 @@ public class ProcessorMediator extends AbstractMediator {
         };
     }
 
+    /**
+     * {@code Processor<I, O> method()}
+     */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private void processMethodReturningAReactiveStreamsProcessorOfPayloads() {
         Processor returnedProcessor = invoke();
@@ -242,6 +267,9 @@ public class ProcessorMediator extends AbstractMediator {
         };
     }
 
+    /**
+     * {@code Flow.Processor<I, O> method()}
+     */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private void processMethodReturningAProcessorOfPayloads() {
         Flow.Processor returnedProcessor = invoke();
@@ -254,6 +282,9 @@ public class ProcessorMediator extends AbstractMediator {
         };
     }
 
+    /**
+     * {@code PublisherBuilder<O> method(I payload)}
+     */
     private void processMethodReturningAPublisherBuilderOfPayloadsAndConsumingPayloads() {
         this.mapper = upstream -> {
             Multi<? extends Message<?>> multi = MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration);
@@ -278,6 +309,9 @@ public class ProcessorMediator extends AbstractMediator {
         };
     }
 
+    /**
+     * {@code Publisher<O> method(I payload)}
+     */
     private void processMethodReturningAReactiveStreamsPublisherOfPayloadsAndConsumingPayloads() {
         this.mapper = upstream -> {
             Multi<? extends Message<?>> multi = MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration);
@@ -302,6 +336,9 @@ public class ProcessorMediator extends AbstractMediator {
         };
     }
 
+    /**
+     * {@code Flow.Publisher<O> method(I payload)}
+     */
     private void processMethodReturningAPublisherOfPayloadsAndConsumingPayloads() {
         this.mapper = upstream -> {
             Multi<? extends Message<?>> multi = MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration);
@@ -327,6 +364,10 @@ public class ProcessorMediator extends AbstractMediator {
         };
     }
 
+    /**
+     * {@code Message<O> method(Message<I> msg)}
+     * {@code Message<O> method(I payload)}
+     */
     private void processMethodReturningIndividualMessageAndConsumingIndividualItem() {
         // Item can be a message or a payload
         if (configuration.isBlocking()) {
@@ -337,7 +378,7 @@ public class ProcessorMediator extends AbstractMediator {
                             .onItem()
                             .transformToMultiAndConcatenate(message -> invokeBlocking(message, getArguments(message))
                                     .onItemOrFailure()
-                                    .transformToUni((o, t) -> this.handlePostInvocationWithMessage((Message<?>) o, t))
+                                    .transformToUni((o, t) -> handlePostInvocationWithMessage(message, (Message<?>) o, t))
                                     .onItem().transformToMulti(this::handleSkip));
                 };
             } else {
@@ -346,7 +387,7 @@ public class ProcessorMediator extends AbstractMediator {
                     return multi
                             .onItem().transformToMulti(message -> invokeBlocking(message, getArguments(message))
                                     .onItemOrFailure()
-                                    .transformToUni((o, t) -> this.handlePostInvocationWithMessage((Message<?>) o, t))
+                                    .transformToUni((o, t) -> handlePostInvocationWithMessage(message, (Message<?>) o, t))
                                     .onItem().transformToMulti(this::handleSkip))
                             .merge(maxConcurrency());
                 };
@@ -359,16 +400,16 @@ public class ProcessorMediator extends AbstractMediator {
                         .onItem().transformToMultiAndConcatenate(
                                 message -> invokeOnMessageContext(message, getArguments(message))
                                         .onItem().transform(o -> (Message<?>) o)
-                                        .onItemOrFailure().transformToUni(this::handlePostInvocationWithMessage)
+                                        .onItemOrFailure()
+                                        .transformToUni((r, f) -> handlePostInvocationWithMessage(message, r, f))
                                         .onItem().transformToMulti(this::handleSkip));
             };
         }
     }
 
-    private boolean isPostAck() {
-        return configuration.getAcknowledgment() == Acknowledgment.Strategy.POST_PROCESSING;
-    }
-
+    /**
+     * {@code O method(I payload)}
+     */
     private void processMethodReturningIndividualPayloadAndConsumingIndividualItem() {
         // Item can be message or payload.
         if (configuration.isBlocking()) {
@@ -441,36 +482,62 @@ public class ProcessorMediator extends AbstractMediator {
         }
     }
 
-    private Uni<? extends Message<Object>> handlePostInvocationWithMessage(Message<?> res,
-            Throwable fail) {
+    private Uni<? extends Message<Object>> handlePostInvocationWithMessage(Message<?> in, Message<?> res, Throwable fail) {
         if (fail != null) {
-            throw ex.processingException(getMethodAsString(), fail);
+            if (isPostAck()) {
+                // Here we nack the incoming, but maybe the message has already been (n)acked
+                return Uni.createFrom()
+                        .completionStage(in.nack(fail).thenApply(x -> null));
+            } else {
+                throw ex.processingException(getMethodAsString(), fail);
+            }
         } else if (res != null) {
+            if (isPostAck()) {
+                // Here we chain the outgoing message to the incoming, but maybe the message has already been (n)acked
+                return Uni.createFrom().item((Message<Object>) res.withAckWithMetadata(m -> res.ack(m).thenCompose(x -> in.ack(m)))
+                        .withNackWithMetadata((t, m) -> res.nack(t, m).thenCompose(x -> in.nack(t, m))));
+            }
+
             return Uni.createFrom().item((Message<Object>) res);
         } else {
             // the method returned null, the message is not forwarded
+            if (isPostAck()) {
+                // Here we ack the incoming message, but maybe the message has already been (n)acked
+                return Uni.createFrom().completionStage(in.ack().thenApply(x -> null));
+            }
             return Uni.createFrom().nullItem();
         }
     }
 
+    /**
+     * {@code CompletionStage<Message<O>> method(I payload)}
+     */
     private void processMethodReturningACompletionStageOfMessageAndConsumingIndividualItem() {
         this.mapper = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
                 .onItem().transformToMultiAndConcatenate(
                         message -> invokeOnMessageContext(message, getArguments(message))
                                 .onItem().transformToUni(cs -> Uni.createFrom().completionStage((CompletionStage<?>) cs))
-                                .onItemOrFailure().transformToUni((r, f) -> handlePostInvocationWithMessage((Message<?>) r, f))
+                                .onItemOrFailure()
+                                .transformToUni((r, f) -> handlePostInvocationWithMessage(message, (Message<?>) r, f))
                                 .onItem().transformToMulti(this::handleSkip));
     }
 
+    /**
+     * {@code Uni<Message<O>> method(I payload)}
+     */
     private void processMethodReturningAUniOfMessageAndConsumingIndividualItem() {
         this.mapper = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
                 .onItem().transformToMultiAndConcatenate(
                         message -> invokeOnMessageContext(message, getArguments(message))
                                 .onItem().transformToUni(u -> (Uni<?>) u)
-                                .onItemOrFailure().transformToUni((r, f) -> handlePostInvocationWithMessage((Message<?>) r, f))
+                                .onItemOrFailure()
+                                .transformToUni((r, f) -> handlePostInvocationWithMessage(message, (Message<?>) r, f))
                                 .onItem().transformToMulti(this::handleSkip));
     }
 
+    /**
+     * {@code CompletionStage<O> method(I payload)}
+     */
     private void processMethodReturningACompletionStageOfPayloadAndConsumingIndividualItem() {
         this.mapper = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
                 .onItem().transformToMultiAndConcatenate(
@@ -480,6 +547,9 @@ public class ProcessorMediator extends AbstractMediator {
                                 .onItem().transformToMulti(this::handleSkip));
     }
 
+    /**
+     * {@code Uni<O> method(I payload)}
+     */
     private void processMethodReturningAUniOfPayloadAndConsumingIndividualItem() {
         this.mapper = upstream -> MultiUtils.handlePreProcessingAcknowledgement(upstream, configuration)
                 .onItem().transformToMultiAndConcatenate(
@@ -502,4 +572,9 @@ public class ProcessorMediator extends AbstractMediator {
                 || ClassUtils.isAssignable(returnType, Processor.class)
                 || ClassUtils.isAssignable(returnType, ProcessorBuilder.class);
     }
+
+    private boolean isPostAck() {
+        return configuration.getAcknowledgment() == Acknowledgment.Strategy.POST_PROCESSING;
+    }
+
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderLogging.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderLogging.java
@@ -143,4 +143,8 @@ public interface ProviderLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 242, value = "Resuming polling messages for channel %s, queue size %s <= %s")
     void resumingRequestingMessages(String channel, int size, int halfMaxQueueSize);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 243, value = "Processing method '%s' annotated with @Acknowledgement(POST_PROCESSING), but may not be compatible with post-processing acknowledgement management. You may experience duplicate (negative-)acknowledgement of messages.")
+    void postProcessingNotFullySupported(String methodAsString);
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ProcessorShapeReturningPublisherTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/ProcessorShapeReturningPublisherTest.java
@@ -2,12 +2,17 @@ package io.smallrye.reactive.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.reactive.messaging.beans.BeanProducingAPublisherBuilderOfMessagesAndConsumingIndividualMessage;
 import io.smallrye.reactive.messaging.beans.BeanProducingAPublisherBuilderOfPayloadsAndConsumingIndividualPayload;
+import io.smallrye.reactive.messaging.beans.BeanProducingAPublisherBuilderOfPayloadsAndConsumingIndividualPayloadWithProcessingError;
 import io.smallrye.reactive.messaging.beans.BeanProducingAPublisherOfMessagesAndConsumingIndividualMessage;
 import io.smallrye.reactive.messaging.beans.BeanProducingAPublisherOfPayloadsAndConsumingIndividualPayload;
+import io.smallrye.reactive.messaging.beans.BeanProducingAPublisherOfPayloadsAndConsumingIndividualPayloadWithProcessingError;
 
 public class ProcessorShapeReturningPublisherTest extends WeldTestBase {
 
@@ -28,11 +33,31 @@ public class ProcessorShapeReturningPublisherTest extends WeldTestBase {
     }
 
     @Test
+    public void BeanProducingAPublisherOfPayloadsAndConsumingIndividualPayloadWithProcessingError() {
+        addBeanClass(BeanProducingAPublisherOfPayloadsAndConsumingIndividualPayloadWithProcessingError.class);
+        initialize();
+        MyCollector collector = container.select(MyCollector.class).get();
+        assertThat(collector.payloads()).isEqualTo(IntStream.rangeClosed(1, 5)
+                .map(i -> i * 2)
+                .flatMap(i -> IntStream.of(i, i)).boxed()
+                .map(Object::toString).collect(Collectors.toList()));
+    }
+
+    @Test
     public void testBeanProducingAPublisherBuilderOfPayloadsAndConsumingIndividualPayload() {
         addBeanClass(BeanProducingAPublisherBuilderOfPayloadsAndConsumingIndividualPayload.class);
         initialize();
         MyCollector collector = container.select(MyCollector.class).get();
         assertThat(collector.payloads()).isEqualTo(EXPECTED);
+    }
+
+    @Test
+    public void testBeanProducingAPublisherBuilderOfPayloadsAndConsumingIndividualPayloadWithProcessingError() {
+        addBeanClass(BeanProducingAPublisherBuilderOfPayloadsAndConsumingIndividualPayloadWithProcessingError.class);
+        initialize();
+        MyCollector collector = container.select(MyCollector.class).get();
+        assertThat(collector.payloads()).isEqualTo(IntStream.rangeClosed(1, 6).flatMap(i -> IntStream.of(i, i)).boxed()
+                .map(Object::toString).collect(Collectors.toList()));
     }
 
     @Test

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/acknowledgement/AsynchronousPayloadProcessorAckTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/acknowledgement/AsynchronousPayloadProcessorAckTest.java
@@ -43,6 +43,40 @@ public class AsynchronousPayloadProcessorAckTest extends WeldTestBaseWithoutTail
     }
 
     @Test
+    public void testThatMessagesAreAckedAfterSuccessfulProcessingOfPayloadReturningCompletionStageOfMessage() throws InterruptedException {
+        addBeanClass(SuccessfulPayloadProcessorCompletionStageOfMessage.class);
+        initialize();
+        Emitter<String> emitter = get(EmitterBean.class).emitter();
+        Sink sink = get(Sink.class);
+
+        Set<String> acked = new ConcurrentHashSet<>();
+        Set<String> nacked = new ConcurrentHashSet<>();
+
+        run(acked, nacked, emitter);
+
+        await().until(() -> sink.list().size() == 10);
+        assertThat(acked).hasSize(10);
+        assertThat(nacked).hasSize(0);
+    }
+
+    @Test
+    public void testThatMessagesAreAckedAfterSuccessfulProcessingOfPayloadReturningUniOfMessage() throws InterruptedException {
+        addBeanClass(SuccessfulPayloadProcessorUniOfMessage.class);
+        initialize();
+        Emitter<String> emitter = get(EmitterBean.class).emitter();
+        Sink sink = get(Sink.class);
+
+        Set<String> acked = new ConcurrentHashSet<>();
+        Set<String> nacked = new ConcurrentHashSet<>();
+
+        run(acked, nacked, emitter);
+
+        await().until(() -> sink.list().size() == 10);
+        assertThat(acked).hasSize(10);
+        assertThat(nacked).hasSize(0);
+    }
+
+    @Test
     public void testThatMessagesAreAckedAfterSuccessfulProcessingOfPayloadUni() throws InterruptedException {
         addBeanClass(SuccessfulPayloadProcessorUni.class);
         initialize();
@@ -157,6 +191,29 @@ public class AsynchronousPayloadProcessorAckTest extends WeldTestBaseWithoutTail
         @Outgoing("out")
         public Uni<String> process(String s) {
             return Uni.createFrom().completionStage(CompletableFuture.supplyAsync(s::toUpperCase));
+        }
+
+    }
+
+
+    @ApplicationScoped
+    public static class SuccessfulPayloadProcessorCompletionStageOfMessage {
+
+        @Incoming("data")
+        @Outgoing("out")
+        public CompletionStage<Message<String>> process(String s) {
+            return CompletableFuture.supplyAsync(() -> Message.of(s.toUpperCase()));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class SuccessfulPayloadProcessorUniOfMessage {
+
+        @Incoming("data")
+        @Outgoing("out")
+        public Uni<Message<String>> process(String s) {
+            return Uni.createFrom().completionStage(CompletableFuture.supplyAsync(() -> Message.of(s.toUpperCase())));
         }
 
     }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingAPublisherBuilderOfPayloadsAndConsumingIndividualPayloadWithProcessingError.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingAPublisherBuilderOfPayloadsAndConsumingIndividualPayloadWithProcessingError.java
@@ -1,0 +1,29 @@
+package io.smallrye.reactive.messaging.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+
+import io.reactivex.Flowable;
+
+@ApplicationScoped
+public class BeanProducingAPublisherBuilderOfPayloadsAndConsumingIndividualPayloadWithProcessingError {
+
+    @Incoming("count")
+    @Outgoing("sink")
+    @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
+    public PublisherBuilder<String> process(Integer payload) {
+        if (payload > 5) {
+            throw new IllegalArgumentException("boom");
+        }
+        return ReactiveStreams.of(payload)
+                .map(i -> i + 1)
+                .flatMapRsPublisher(i -> Flowable.just(i, i))
+                .map(i -> Integer.toString(i));
+    }
+
+}

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingAPublisherOfPayloadsAndConsumingIndividualPayloadWithProcessingError.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/beans/BeanProducingAPublisherOfPayloadsAndConsumingIndividualPayloadWithProcessingError.java
@@ -1,0 +1,30 @@
+package io.smallrye.reactive.messaging.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.Publisher;
+
+import io.reactivex.Flowable;
+
+@ApplicationScoped
+public class BeanProducingAPublisherOfPayloadsAndConsumingIndividualPayloadWithProcessingError {
+
+    @Incoming("count")
+    @Outgoing("sink")
+    @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
+    public Publisher<String> process(Integer payload) {
+        if (payload % 2 == 0) {
+            throw new IllegalArgumentException("boom");
+        }
+        return ReactiveStreams.of(payload)
+                .map(i -> i + 1)
+                .flatMapRsPublisher(i -> Flowable.just(i, i))
+                .map(i -> Integer.toString(i))
+                .buildRs();
+    }
+
+}


### PR DESCRIPTION
In addition to closing  #2732 and #2733 we introduce post-processsing acknowledgement support for the following signatures : 
- `@Outgoing @Incoming Message<O> method(I payload)`
- `@Outgoing @Incoming CompletionStage<Message<O>> method(I payload)`
- `@Outgoing @Incoming Uni<Message<O>> method(I payload)`
- `@Outgoing @Incoming Message<O> method(Message<I> payload)` 

For the last one, if acknowledgments are already handled in the method, there will be duplicate (n)acks.