### PR TITLE
Update the Mutiny bindings to 3.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <opentelemetry.instrumentation.version>2.5.0-alpha</opentelemetry.instrumentation.version>
     <opentelemetry-semconv.version>1.25.0-alpha</opentelemetry-semconv.version>
 
-    <smallrye-vertx-mutiny-clients.version>3.13.0</smallrye-vertx-mutiny-clients.version>
+    <smallrye-vertx-mutiny-clients.version>3.15.0</smallrye-vertx-mutiny-clients.version>
     <smallrye-reactive-converters.version>3.0.0</smallrye-reactive-converters.version>
     <mutiny-zero.version>1.1.0</mutiny-zero.version>
 


### PR DESCRIPTION
Thus, it's aligned with the Vert.x version (4.5.10)