### PR TITLE
Add initial timeout property for `KafkaRequestReply` when using latest offset

### DIFF
--- a/documentation/src/main/docs/kafka/request-reply.md
+++ b/documentation/src/main/docs/kafka/request-reply.md
@@ -94,6 +94,7 @@ If `auto.offset.reset` is `latest`, at wiring time, before any request can take 
 finds partitions that the consumer needs to subscribe and waits for their assignment to the consumer.
 The timeout of the initial subscription can be adjusted with `reply.initial-assignment-timeout` which defaults to the `reply.timeout`.
 If this timeout fails, `KafkaRequestReply` will enter an invalid state which will require it to be restarted.
+If set to `-1`, the `KafkaRequestReply` will not wait for the initial assignment of the reply consumer to sent requests.
 
 On other occasions the `KafkaRequestReply#waitForAssignments` method can be used.
 

--- a/documentation/src/main/docs/kafka/request-reply.md
+++ b/documentation/src/main/docs/kafka/request-reply.md
@@ -89,9 +89,13 @@ A snapshot of the list of pending replies is available through the `KafkaRequest
 The requestor can be found in a position where a request is sent, and it's reply is already published to the reply topic,
 before the requestor starts and polls the consumer.
 In case the reply consumer is configured with `auto.offset.reset=latest`, which is the default value, this can lead to the requestor missing replies.
+
 If `auto.offset.reset` is `latest`, at wiring time, before any request can take place, the `KafkaRequestReply`
 finds partitions that the consumer needs to subscribe and waits for their assignment to the consumer.
-On other occasons the `KafkaRequestReply#waitForAssignments` method can be used.
+The timeout of the initial subscription can be adjusted with `reply.initial-assignment-timeout` which defaults to the `reply.timeout`.
+If this timeout fails, `KafkaRequestReply` will enter an invalid state which will require it to be restarted.
+
+On other occasions the `KafkaRequestReply#waitForAssignments` method can be used.
 
 ## Correlation Ids
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReply.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReply.java
@@ -76,6 +76,7 @@ public interface KafkaRequestReply<Req, Rep> extends EmitterType {
     /**
      * The config key for the initial assignment timeout.
      * This timeout is used at start when the {@code auto.offset.reset} is set to {@code latest}.
+     * The value {@code -1} disables waiting for initial assignment.
      */
     String REPLY_INITIAL_ASSIGNMENT_TIMEOUT_KEY = "reply.initial-assignment-timeout";
 

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReply.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReply.java
@@ -74,6 +74,12 @@ public interface KafkaRequestReply<Req, Rep> extends EmitterType {
     String REPLY_TIMEOUT_KEY = "reply.timeout";
 
     /**
+     * The config key for the initial assignment timeout.
+     * This timeout is used at start when the {@code auto.offset.reset} is set to {@code latest}.
+     */
+    String REPLY_INITIAL_ASSIGNMENT_TIMEOUT_KEY = "reply.initial-assignment-timeout";
+
+    /**
      * The config key for the correlation ID handler identifier.
      * <p>
      * This config is used to select a CDI-managed implementation of {@link CorrelationIdHandler}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyImpl.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyImpl.java
@@ -75,6 +75,7 @@ public class KafkaRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
     private final KafkaSource<Object, Rep> replySource;
     private final Set<TopicPartition> waitForPartitions;
     private final boolean gracefulShutdown;
+    private final Duration initialAssignmentTimeout;
     private Function<Message<Rep>, Message<Rep>> replyConverter;
 
     public KafkaRequestReplyImpl(EmitterConfiguration config,
@@ -103,6 +104,8 @@ public class KafkaRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
         this.replyTopic = consumerConfig.getTopic().orElse(null);
         this.replyPartition = connectorConfig.getOptionalValue(REPLY_PARTITION_KEY, Integer.class).orElse(-1);
         this.replyTimeout = Duration.ofMillis(connectorConfig.getOptionalValue(REPLY_TIMEOUT_KEY, Integer.class).orElse(5000));
+        this.initialAssignmentTimeout = Duration.ofMillis(connectorConfig
+                .getOptionalValue(REPLY_INITIAL_ASSIGNMENT_TIMEOUT_KEY, Integer.class).orElse((int) replyTimeout.toMillis()));
 
         this.autoOffsetReset = consumerConfig.getAutoOffsetReset();
         this.replyCorrelationIdHeader = connectorConfig.getOptionalValue(REPLY_CORRELATION_ID_HEADER_KEY, String.class)
@@ -151,8 +154,10 @@ public class KafkaRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
     @Override
     public Flow.Publisher<Message<? extends Req>> getPublisher() {
         return this.publisher
-                .plug(m -> "latest".equals(autoOffsetReset)
-                        ? m.onSubscription().call(() -> waitForAssignments().ifNoItem().after(replyTimeout).fail())
+                .plug(m -> "latest".equals(autoOffsetReset) ? m.onSubscription().call(() -> waitForAssignments()
+                        .ifNoItem()
+                        .after(initialAssignmentTimeout)
+                        .fail())
                         : m)
                 .onTermination().invoke(this::complete);
     }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyImpl.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyImpl.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -104,8 +105,10 @@ public class KafkaRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
         this.replyTopic = consumerConfig.getTopic().orElse(null);
         this.replyPartition = connectorConfig.getOptionalValue(REPLY_PARTITION_KEY, Integer.class).orElse(-1);
         this.replyTimeout = Duration.ofMillis(connectorConfig.getOptionalValue(REPLY_TIMEOUT_KEY, Integer.class).orElse(5000));
-        this.initialAssignmentTimeout = Duration.ofMillis(connectorConfig
-                .getOptionalValue(REPLY_INITIAL_ASSIGNMENT_TIMEOUT_KEY, Integer.class).orElse((int) replyTimeout.toMillis()));
+        int initialAssignmentTimeoutMillis = connectorConfig
+                .getOptionalValue(REPLY_INITIAL_ASSIGNMENT_TIMEOUT_KEY, Integer.class)
+                .orElse((int) replyTimeout.toMillis());
+        this.initialAssignmentTimeout = initialAssignmentTimeoutMillis < 0 ? null : Duration.ofMillis(initialAssignmentTimeoutMillis);
 
         this.autoOffsetReset = consumerConfig.getAutoOffsetReset();
         this.replyCorrelationIdHeader = connectorConfig.getOptionalValue(REPLY_CORRELATION_ID_HEADER_KEY, String.class)
@@ -154,10 +157,11 @@ public class KafkaRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
     @Override
     public Flow.Publisher<Message<? extends Req>> getPublisher() {
         return this.publisher
-                .plug(m -> "latest".equals(autoOffsetReset) ? m.onSubscription().call(() -> waitForAssignments()
-                        .ifNoItem()
-                        .after(initialAssignmentTimeout)
-                        .fail())
+                .plug(m -> initialAssignmentTimeout != null && "latest".equals(autoOffsetReset)
+                        ? m.onSubscription().call(() -> waitForAssignments()
+                                .ifNoItem()
+                                .after(initialAssignmentTimeout)
+                                .fail())
                         : m)
                 .onTermination().invoke(this::complete);
     }


### PR DESCRIPTION
This PR alleviates some a part of the issue of #2714 notably the fact that at start the `KafkaRequestReply` uses the same timeout to wait for assignments and to await replies when using the `latest` offset.

I didn't have any idea just named the property `reply.initial-assignment-timeout` you can propose a more suitable one if you think of one.