### PR TITLE
Fix #2756 KafkaCompanion does not configure Serializer/Deserializer

### DIFF
--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
@@ -143,6 +143,11 @@ public class ConsumerBuilder<K, V> implements ConsumerRebalanceListener, Closeab
             Deserializer<K> keyDeser, Deserializer<V> valueDeser) {
         this.props = props;
         this.kafkaApiTimeout = kafkaApiTimeout;
+
+        // configure deserializers
+        keyDeser.configure(props, true);
+        valueDeser.configure(props, false);
+
         this.consumerCreator = p -> new KafkaConsumer<>(p, keyDeser, valueDeser);
     }
 

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ProducerBuilder.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ProducerBuilder.java
@@ -131,6 +131,11 @@ public class ProducerBuilder<K, V> implements Closeable {
             Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         this.props = props;
         this.kafkaApiTimeout = kafkaApiTimeout;
+
+        // configure serializers
+        keySerializer.configure(props, true);
+        valueSerializer.configure(props, false);
+
         this.producerCreator = p -> new KafkaProducer<>(p, keySerializer, valueSerializer);
     }
 

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/SerdesTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/SerdesTest.java
@@ -2,14 +2,52 @@ package io.smallrye.reactive.messaging.kafka.companion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.smallrye.reactive.messaging.kafka.companion.test.KafkaCompanionTestBase;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 import org.junit.jupiter.api.Test;
 
-import io.smallrye.reactive.messaging.kafka.companion.test.KafkaCompanionTestBase;
+import java.util.Map;
 
 public class SerdesTest extends KafkaCompanionTestBase {
+
+    @Test
+    void testRegisteredSerdeShouldBeConfigured() {
+        // Custom Serde which Serialize/Deserializer throw exception if not configured
+        companion.registerSerde(Person.class, new Serde<>() {
+            private PersonDeserializer personDeserializer = new PersonDeserializer();
+            private PersonSerializer personSerializer = new PersonSerializer();
+
+            @Override
+            public Serializer<Person> serializer() {
+                return personSerializer;
+            }
+
+            @Override
+            public Deserializer<Person> deserializer() {
+                return personDeserializer;
+            }
+
+            @Override
+            public void configure(Map<String, ?> configs, boolean isKey) {
+                // Configure the serializer and deserializer
+                personSerializer.configure(configs, isKey);
+                personDeserializer.configure(configs, isKey);
+            }
+        });
+
+        companion.produce(Person.class).fromRecords(
+                new ProducerRecord<>(topic, new Person("1", 30)),
+                new ProducerRecord<>(topic, new Person("2", 25)),
+                new ProducerRecord<>(topic, new Person("3", 18))).awaitCompletion();
+
+        ConsumerBuilder<String, Person> consumer = companion.consumeWithDeserializers(PersonDeserializer.class.getName());
+        ConsumerTask<String, Person> task = consumer.fromTopics(topic, 3).awaitCompletion();
+        assertThat(task.getRecords()).hasSize(3);
+    }
 
     @Test
     void testProduceRegisteredSerdeConsumeWithSerdeName() {
@@ -80,9 +118,20 @@ public class SerdesTest extends KafkaCompanionTestBase {
 
     public static class PersonSerializer implements Serializer<Person> {
 
+        private boolean isConfigured = false;
+
         @Override
         public byte[] serialize(String s, Person person) {
-            return (person.id + "|" + person.age).getBytes();
+            if (isConfigured) {
+                return (person.id + "|" + person.age).getBytes();
+            } else {
+                throw new SerializationException("Serializer not configured");
+            }
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+            isConfigured = true;
         }
     }
 
@@ -102,11 +151,21 @@ public class SerdesTest extends KafkaCompanionTestBase {
     }
 
     public static class PersonDeserializer implements Deserializer<Person> {
+        private boolean isConfigured = false;
 
         @Override
         public Person deserialize(String s, byte[] bytes) {
-            String[] split = new String(bytes).split("\\|");
-            return new Person(split[0], Integer.parseInt(split[1]));
+            if (isConfigured) {
+                String[] split = new String(bytes).split("\\|");
+                return new Person(split[0], Integer.parseInt(split[1]));
+            } else {
+                throw new SerializationException("Deserializer not configured");
+            }
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+            isConfigured = true;
         }
     }
 }


### PR DESCRIPTION
Updated SerdesTest and added test case to verify KafkaCompanion does not configure the (de)serializers.

Updated ConsumerBuilder and ProducerBuilder to fix the issue.