### PR TITLE
Add multi request to `KafkaRequestReply`

### DIFF
--- a/documentation/src/main/docs/kafka/request-reply.md
+++ b/documentation/src/main/docs/kafka/request-reply.md
@@ -65,6 +65,21 @@ Like the core Emitter's `send` methods, `request` method also can receive a `Mes
     The ingested reply type of the `KafkaRequestReply` is discovered at runtime,
     in order to configure a `MessageConveter` to be applied on the incoming message before returning the `Uni` result.
 
+## Requesting multiple replies
+
+You can use the `requestMulti` method to expect any number of replies represented by the `Multi` return type.
+
+For example this can be used to aggregate multiple replies to a single request.
+
+``` java
+{{ insert('kafka/outbound/KafkaRequestReplyMultiEmitter.java') }}
+```
+Like the other `request` you can also request `Message` types.
+
+!!! note
+    The channel attribute `reply.timeout` will be applied between each message, if reached the returned `Multi` will
+    fail.
+
 ## Scaling Request/Reply
 
 If multiple requestor instances are configured on the same outgoing topic, and the same reply topic,

--- a/documentation/src/main/java/kafka/outbound/KafkaRequestReplyMultiEmitter.java
+++ b/documentation/src/main/java/kafka/outbound/KafkaRequestReplyMultiEmitter.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.reactive.messaging.kafka.reply.KafkaRequestReply;
+
+@ApplicationScoped
+public class KafkaRequestReplyMultiEmitter {
+
+    @Inject
+    @Channel("my-request")
+    KafkaRequestReply<String, Integer> quoteRequest;
+
+    public Multi<Integer> requestQuote(String request) {
+        return quoteRequest.requestMulti(request).select().first(5);
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReply.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReply.java
@@ -9,6 +9,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.EmitterType;
 import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
@@ -126,6 +127,22 @@ public interface KafkaRequestReply<Req, Rep> extends EmitterType {
      * @return a Uni object representing the result of the send and receive operation
      */
     Uni<Message<Rep>> request(Message<Req> request);
+
+    /**
+     * Sends a request and receives responses.
+     *
+     * @param request the request object to be sent
+     * @return a Multi object representing the results of the send and receive operation
+     */
+    Multi<Rep> requestMulti(Req request);
+
+    /**
+     * Sends a request and receives responses.
+     *
+     * @param request the request object to be sent
+     * @return a Multi object representing the results of the send and receive operation
+     */
+    Multi<Message<Rep>> requestMulti(Message<Req> request);
 
     /**
      * Blocks until the consumer has been assigned all partitions for consumption.

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyTimeoutException.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyTimeoutException.java
@@ -1,0 +1,12 @@
+package io.smallrye.reactive.messaging.kafka.reply;
+
+/**
+ * Exception thrown when a reply is not received within the configured timeout.
+ */
+public class KafkaRequestReplyTimeoutException extends RuntimeException {
+
+    public KafkaRequestReplyTimeoutException(CorrelationId correlationId) {
+        super("Timeout waiting for a reply for request with correlation ID: " + correlationId);
+    }
+
+}

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/PendingReply.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/PendingReply.java
@@ -21,4 +21,14 @@ public interface PendingReply {
      * @return the recordMetadata of the request
      */
     RecordMetadata recordMetadata();
+
+    /**
+     * Complete the pending reply.
+     */
+    void complete();
+
+    /**
+     * @return whether the pending reply was terminated (with a completion or failure).
+     */
+    boolean isCancelled();
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyTest.java
@@ -5,6 +5,7 @@ import static io.smallrye.reactive.messaging.kafka.reply.KafkaRequestReply.DEFAU
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.smallrye.reactive.messaging.annotations.Blocking;
@@ -88,6 +90,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
 
         assertThat(companion.consumeStrings().fromTopics(replyTopic, 10).awaitCompletion())
                 .extracting(ConsumerRecord::value).containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -111,6 +114,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
         assertThat(companion.consumeStrings().fromTopics(replyTopic, 10).awaitCompletion())
                 .extracting(ConsumerRecord::value)
                 .containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -137,6 +141,70 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
         assertThat(companion.consumeStrings().fromTopics(replyTopic, 10).awaitCompletion())
                 .extracting(ConsumerRecord::value)
                 .containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
+    }
+
+    @Test
+    void testReplyMessageMulti() {
+        addBeans(ReplyServerMultipleReplies.class);
+        topic = companion.topics().createAndWait(topic, 3);
+        String replyTopic = topic + "-replies";
+        companion.topics().createAndWait(replyTopic, 3);
+
+        List<String> replies = new CopyOnWriteArrayList<>();
+
+        RequestReplyProducer app = runApplication(config(), RequestReplyProducer.class);
+        List<String> expected = new ArrayList<>();
+        int sent = 5;
+        for (int i = 0; i < sent; i++) {
+            app.requestReply().requestMulti(i)
+                    .subscribe()
+                    .with(replies::add);
+            for (int j = 0; j < ReplyServerMultipleReplies.REPLIES; j++) {
+                expected.add(i + ": " + j);
+            }
+        }
+        await().untilAsserted(() -> assertThat(replies).hasSize(ReplyServerMultipleReplies.REPLIES * sent));
+        assertThat(replies)
+                .containsAll(expected);
+
+        assertThat(companion.consumeStrings().fromTopics(replyTopic, ReplyServerMultipleReplies.REPLIES * sent).awaitCompletion())
+                .extracting(ConsumerRecord::value)
+                .containsAll(expected);
+
+        Map<CorrelationId, PendingReply> pendingReplies = app.requestReply().getPendingReplies();
+        assertThat(pendingReplies).allSatisfy((k, v) -> assertThat(v.isCancelled()).isFalse());
+        for (PendingReply pending : pendingReplies.values()) {
+            pending.complete();
+        }
+        assertThat(pendingReplies).allSatisfy((k, v) -> assertThat(v.isCancelled()).isTrue());
+        assertThat(app.requestReply().getPendingReplies())
+                .allSatisfy((k, v) -> assertThat(v.isCancelled()).isTrue());
+        await().untilAsserted(() -> assertThat(app.requestReply().getPendingReplies()).isEmpty());
+    }
+
+    @Test
+    void testReplyMessageMultiLimit() {
+        addBeans(ReplyServerMultipleReplies.class);
+        topic = companion.topics().createAndWait(topic, 3);
+        String replyTopic = topic + "-replies";
+        companion.topics().createAndWait(replyTopic, 3);
+
+        List<String> replies = new CopyOnWriteArrayList<>();
+
+        RequestReplyProducer app = runApplication(config(), RequestReplyProducer.class);
+        app.requestReply().requestMulti(0)
+                .select().first(5)
+                .subscribe()
+                .with(replies::add);
+        await().untilAsserted(() -> assertThat(replies).hasSize(5));
+        assertThat(replies)
+                .containsExactlyInAnyOrder("0: 0", "0: 1", "0: 2", "0: 3", "0: 4");
+
+        assertThat(companion.consumeStrings().fromTopics(replyTopic, 5).awaitCompletion())
+                .extracting(ConsumerRecord::value)
+                .containsExactlyInAnyOrder("0: 0", "0: 1", "0: 2", "0: 3", "0: 4");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -186,6 +254,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
         await().untilAsserted(() -> assertThat(replies).hasSize(10));
         assertThat(replies).extracting(ConsumerRecord::value)
                 .containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -213,6 +282,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
         assertThat(companion.consumeStrings().fromTopics(replyTopic, 10).awaitCompletion())
                 .allSatisfy(record -> assertThat(record.partition()).isEqualTo(2))
                 .extracting(ConsumerRecord::value).containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -245,6 +315,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
         assertThat(companion.consumerGroups().list()).extracting(ConsumerGroupListing::groupId)
                 .contains(replyTopicConsumer);
         await().untilAsserted(() -> assertThat(companion.consumerGroups().offsets(replyTopicConsumer)).isNotEmpty());
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -277,6 +348,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
         assertThat(companion.consumeStrings().fromTopics(replyTopic, 10).awaitCompletion())
                 .allSatisfy(record -> assertThat(record.partition()).isEqualTo(2))
                 .extracting(ConsumerRecord::value).containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -307,6 +379,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
         assertThat(companion.consumeStrings().fromTopics(replyTopic, 10).awaitCompletion())
                 .allSatisfy(record -> assertThat(record.partition()).isEqualTo(2))
                 .extracting(ConsumerRecord::value).containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -421,6 +494,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
 
         assertThat(companion.consumeStrings().fromTopics(replyTopic, 10).awaitCompletion())
                 .extracting(ConsumerRecord::value).containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -453,6 +527,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
                 .extracting(Throwable::getMessage)
                 .allSatisfy(message -> assertThat(message).containsAnyOf("0", "3", "6", "9")
                         .contains("Cannot reply to"));
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -477,6 +552,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
 
         assertThat(companion.consumeStrings().fromTopics(replyTopic, 10).awaitCompletion())
                 .extracting(ConsumerRecord::value).containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -536,6 +612,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
 
         assertThat(companion.consumeStrings().fromOffsets(Map.of(tp(replyTopic, 2), 10L), 10).awaitCompletion())
                 .extracting(ConsumerRecord::value).containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+        assertThat(app.requestReply().getPendingReplies()).isEmpty();
     }
 
     @Test
@@ -631,6 +708,26 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
                 return null;
             }
             return String.valueOf(payload);
+        }
+    }
+
+    @ApplicationScoped
+    public static class ReplyServerMultipleReplies {
+
+        public static final int REPLIES = 10;
+
+        @Incoming("req")
+        @Outgoing("rep")
+        Multi<String> process(Integer payload) {
+            if (payload == null) {
+                return null;
+            }
+            return Multi.createFrom().emitter(multiEmitter -> {
+                for (int i = 0; i < REPLIES; i++) {
+                    multiEmitter.emit(payload + ": " + i);
+                }
+                multiEmitter.complete();
+            });
         }
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyTest.java
@@ -628,7 +628,7 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
 
         app.requestReply().request(1)
                 .subscribe().withSubscriber(UniAssertSubscriber.create())
-                .awaitFailure().assertFailedWith(TimeoutException.class);
+                .awaitFailure().assertFailedWith(KafkaRequestReplyTimeoutException.class);
     }
 
     @Test


### PR DESCRIPTION
# Purpose
This PR adds a new request type to the `KafkaRequestReply` so that we can receive multiple replies to a request.
This  can be useful when you want to send a request, for which multiple consumer groups can answer, or a some service needs to answer with multiple messages. 
That was not supported with the  `Uni<Rep> request`.

# Implementation
This is a first idea to add the feature, in which the `KafkaRequestReplyImpl` is modified to use a `Multi` as a base for all operations instead of the `Uni`.
If you think this should be a separate, class or if you have any other idea, do not hesitate.

This adds two new methods `requestMulti` that returns a `Multi<Rep>`.
I had no idea, for the method names, and we can discuss a better one.
The `reply.timeout` is applied between each reply, and the `ReplyFailureHandler` is called for each reply, so one failure on a reply will fail the whole operation.
I didn't write the doc yet.

If you have any input feel free.