### PR TITLE
Kafka transactions support for Blocking execution

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/KafkaSource.java
@@ -369,7 +369,7 @@ public class KafkaSource<K, V> {
         if (records.size() == 1) {
             return records.get(0).onItem().transform(ignored -> batch);
         }
-        return Uni.combine().all().unis(records).combinedWith(ignored -> batch);
+        return Uni.combine().all().unis(records).with(ignored -> batch);
     }
 
     private KafkaFailureHandler createFailureHandler(Vertx vertx) {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/client/ReactiveKafkaConsumerTest.java
@@ -434,7 +434,7 @@ public class ReactiveKafkaConsumerTest extends ClientTestBase {
         // Verify rebalance
         await().until(() -> Uni.combine().all()
                 .unis(source.getConsumer().getAssignments(), source2.getConsumer().getAssignments())
-                .combinedWith((tp1, tp2) -> tp1.size() + tp2.size()).await().indefinitely() == partitions);
+                .with((tp1, tp2) -> tp1.size() + tp2.size()).await().indefinitely() == partitions);
         Set<TopicPartition> assignedToSource2 = source2.getConsumer().getAssignments().await().indefinitely();
 
         subscriber.request(100);

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/VertxContext.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/helpers/VertxContext.java
@@ -3,6 +3,7 @@ package io.smallrye.reactive.messaging.providers.helpers;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 import io.vertx.core.Context;
@@ -17,6 +18,14 @@ public class VertxContext {
 
     public static Context createNewDuplicatedContext() {
         return io.smallrye.common.vertx.VertxContext.createNewDuplicatedContext();
+    }
+
+    public static void executeBlocking(Context context, Runnable runnable) {
+        executeBlocking(context, runnable, true);
+    }
+
+    public static void executeBlocking(Context context, Runnable runnable, boolean ordered) {
+        context.executeBlocking(Executors.callable(runnable), ordered);
     }
 
     public static void runOnContext(Context context, Runnable runnable) {


### PR DESCRIPTION
Kafka Transactions captures and runs the emitter work on the caller context, whether it is event-loop or worker thread. 