### PR TITLE
[Issue-2771] [Enhancement] Tries to inject Vertx instance from CDI using a qualifier

### DIFF
--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderLogging.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/i18n/ProviderLogging.java
@@ -143,4 +143,8 @@ public interface ProviderLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 242, value = "Resuming polling messages for channel %s, queue size %s <= %s")
     void resumingRequestingMessages(String channel, int size, int halfMaxQueueSize);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 244, value = "Trying to get Vertx instance using Identifier qualifier: %s.")
+    void vertxFromCDIQualifier(String cdiQualifier);
 }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/WeldTestBaseWithoutTails.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.se.SeContainerInitializer;
@@ -95,6 +97,25 @@ public class WeldTestBaseWithoutTails {
             }
         } else {
             throw new IllegalArgumentException("File " + file.getAbsolutePath() + " does not exist " + path);
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public static void installConfigFromProperties(Properties properties) {
+        releaseConfig();
+        File out = new File("target/test-classes/META-INF/microprofile-config.properties");
+        if (out.isFile()) {
+            out.delete();
+        }
+        out.getParentFile().mkdirs();
+        try (OutputStream outputStream = Files.newOutputStream(out.toPath())) {
+            properties.store(outputStream, null);
+            System.out.println("Installed configuration:");
+            List<String> list = Files.readAllLines(out.toPath());
+            list.forEach(System.out::println);
+            System.out.println("---------");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/VertxInstanceSelectTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/VertxInstanceSelectTest.java
@@ -1,0 +1,112 @@
+package io.smallrye.reactive.messaging.providers.connectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Extension;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.reactive.messaging.WeldTestBaseWithoutTails;
+import io.vertx.mutiny.core.Vertx;
+
+public class VertxInstanceSelectTest extends WeldTestBaseWithoutTails {
+
+    private static final Properties CONNECTOR_VERTX_CDI_IDENTIFIER_PROPERTIES = new Properties();
+    static {
+        CONNECTOR_VERTX_CDI_IDENTIFIER_PROPERTIES.setProperty("mp.messaging.connector.vertx.cdi.identifier", "vertx");
+    }
+
+    private static final Vertx vertxForCDI = Vertx.vertx();
+
+    // Test the case that 'mp.messaging.connector.vertx.cdi.identifier' is NOT specified and NO Vertx Bean exposed
+    // from CDI container. The vertx instance should be internal instance.
+    @Test
+    public void testNoVertxBeanNoIdentifier() {
+        initialize();
+        ExecutionHolder executionHolder = get(ExecutionHolder.class);
+        assertThat(executionHolder).isNotNull();
+        assertThat(executionHolder.vertx()).isNotNull();
+        assertThat(executionHolder.vertx()).isNotEqualTo(vertxForCDI);
+        assertThat(executionHolder.isInternalVertxInstance()).isTrue();
+    }
+
+    // Test the case that 'mp.messaging.connector.vertx.cdi.identifier' IS specified and NO Vertx Bean exposed
+    // from CDI container. The vertx instance should be internal instance.
+    @Test
+    public void testNoVertxBeanWithIdentifier() {
+        installConfigFromProperties(CONNECTOR_VERTX_CDI_IDENTIFIER_PROPERTIES);
+        initialize();
+        ExecutionHolder executionHolder = get(ExecutionHolder.class);
+        assertThat(executionHolder).isNotNull();
+        assertThat(executionHolder.vertx()).isNotNull();
+        assertThat(executionHolder.vertx()).isNotEqualTo(vertxForCDI);
+        assertThat(executionHolder.isInternalVertxInstance()).isTrue();
+    }
+
+    // Test the case that 'mp.messaging.connector.vertx.cdi.identifier' is NOT specified but has Vertx Bean exposed
+    // from CDI container using Default qualifier. The vertx instance should be vertxForCDI.
+    @Test
+    public void testWithVertxBeanDefaultNoIdentifier() {
+        addExtensionClass(VertxCDIDefaultExtension.class);
+        initialize();
+        ExecutionHolder executionHolder = get(ExecutionHolder.class);
+        assertThat(executionHolder).isNotNull();
+        assertThat(executionHolder.vertx()).isNotNull();
+        assertThat(executionHolder.vertx()).isEqualTo(vertxForCDI);
+        assertThat(executionHolder.isInternalVertxInstance()).isFalse();
+    }
+
+    // Test the case that 'mp.messaging.connector.vertx.cdi.identifier' IS specified but has Vertx Bean exposed
+    // from CDI container using Default qualifier. The vertx instance should be internal instance.
+    @Test
+    public void testWithVertxBeanDefaultWithIdentifier() {
+        installConfigFromProperties(CONNECTOR_VERTX_CDI_IDENTIFIER_PROPERTIES);
+        addExtensionClass(VertxCDIDefaultExtension.class);
+        initialize();
+        ExecutionHolder executionHolder = get(ExecutionHolder.class);
+        assertThat(executionHolder).isNotNull();
+        assertThat(executionHolder.vertx()).isNotNull();
+        assertThat(executionHolder.vertx()).isNotEqualTo(vertxForCDI);
+        assertThat(executionHolder.isInternalVertxInstance()).isTrue();
+    }
+
+    // Test the case that 'mp.messaging.connector.vertx.cdi.identifier' is specified and has Vertx Bean exposed
+    // from CDI container using the Identifier qualifier. The vertx instance should be vertxForCDI.
+    @Test
+    public void testWithVertxBeanIdentifierWithIdentifier() {
+        installConfigFromProperties(CONNECTOR_VERTX_CDI_IDENTIFIER_PROPERTIES);
+        addExtensionClass(VertxCDIIdentifierExtension.class);
+        initialize();
+        ExecutionHolder executionHolder = get(ExecutionHolder.class);
+        assertThat(executionHolder).isNotNull();
+        assertThat(executionHolder.vertx()).isNotNull();
+        assertThat(executionHolder.vertx()).isEqualTo(vertxForCDI);
+        assertThat(executionHolder.isInternalVertxInstance()).isFalse();
+    }
+
+    public static class VertxCDIDefaultExtension implements Extension {
+        public void registerVertxBean(@Observes AfterBeanDiscovery abd, BeanManager beanManager) {
+            abd.addBean()
+                    .beanClass(Vertx.class).types(Vertx.class)
+                    .addQualifiers(Any.Literal.INSTANCE, Default.Literal.INSTANCE)
+                    .createWith(cc -> vertxForCDI);
+        }
+    }
+
+    public static class VertxCDIIdentifierExtension implements Extension {
+        public void registerVertxBean(@Observes AfterBeanDiscovery abd, BeanManager beanManager) {
+            abd.addBean()
+                    .beanClass(Vertx.class).types(Vertx.class)
+                    .addQualifiers(Any.Literal.INSTANCE, Identifier.Literal.of("vertx"))
+                    .createWith(cc -> vertxForCDI);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2842 

This is the back port of https://github.com/smallrye/smallrye-reactive-messaging/pull/2772 to `4.24.x` branch for use in WildFly.