### PR TITLE
feat: allow creation of IncomingRabbitMQMetadata

### DIFF
--- a/documentation/src/main/docs/amqp/receiving-amqp-messages.md
+++ b/documentation/src/main/docs/amqp/receiving-amqp-messages.md
@@ -126,6 +126,9 @@ Messages coming from AMQP contains an instance of {{ javadoc('io.smallrye.reacti
 {{ insert('amqp/inbound/AmqpMetadataExample.java', 'code') }}
 ```
 
+If you need to create `IncomingAmqpMetadata` e.g. for testing purposes, create an `OutgoingAmqpMetadata` using its builder
+and convert it using {{ javadoc('io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata#toIncomingMetadata(String,boolean)') }}
+
 ## Acknowledgement
 
 When a Reactive Messaging `Message` associated with an AMQP Message is

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadata.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.rabbitmq.client.BasicProperties;
+import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.LongString;
 
 import io.vertx.codegen.annotations.Nullable;
@@ -20,8 +22,9 @@ import io.vertx.rabbitmq.RabbitMQMessage;
  */
 public class IncomingRabbitMQMetadata {
 
-    private final RabbitMQMessage message;
     private final Map<String, Object> headers;
+    private final BasicProperties properties;
+    private final Envelope envelope;
 
     /**
      * Constructor.
@@ -29,10 +32,15 @@ public class IncomingRabbitMQMetadata {
      * @param message the underlying {@link RabbitMQMessage}
      */
     IncomingRabbitMQMetadata(RabbitMQMessage message) {
-        this.message = message;
+        this(message.properties(), message.envelope());
+    }
+
+    IncomingRabbitMQMetadata(BasicProperties properties, Envelope envelope) {
+        this.properties = properties;
+        this.envelope = envelope;
 
         // Ensure the message headers are cast appropriately
-        final Map<String, Object> incomingHeaders = message.properties().getHeaders();
+        final Map<String, Object> incomingHeaders = properties.getHeaders();
         headers = (incomingHeaders != null) ? incomingHeaders.entrySet().stream()
                 .collect(HashMap::new, (m, e) -> m.put(e.getKey(), mapValue(e.getValue())), HashMap::putAll)
                 : new HashMap<>();
@@ -105,7 +113,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the content-type, which may be empty if no content-type was received
      */
     public Optional<String> getContentType() {
-        return Optional.ofNullable(message.properties().getContentType());
+        return Optional.ofNullable(properties.getContentType());
     }
 
     /**
@@ -119,7 +127,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the content-encoding, which may be empty if no content-encoding was received
      */
     public Optional<String> getContentEncoding() {
-        return Optional.ofNullable(message.properties().getContentEncoding());
+        return Optional.ofNullable(properties.getContentEncoding());
     }
 
     /**
@@ -130,7 +138,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the delivery-mode, which may be empty if no delivery-mode was received
      */
     public Optional<Integer> getDeliveryMode() {
-        return Optional.ofNullable(message.properties().getDeliveryMode());
+        return Optional.ofNullable(properties.getDeliveryMode());
     }
 
     /**
@@ -142,7 +150,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the priority, which may be empty if no priority was received
      */
     public Optional<Integer> getPriority() {
-        return Optional.ofNullable(message.properties().getPriority());
+        return Optional.ofNullable(properties.getPriority());
     }
 
     /**
@@ -153,7 +161,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the correlation-id, which may be empty if no correlation-id was received
      */
     public Optional<String> getCorrelationId() {
-        return Optional.ofNullable(message.properties().getCorrelationId());
+        return Optional.ofNullable(properties.getCorrelationId());
     }
 
     /**
@@ -164,7 +172,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the reply-to address, which may be empty if no reply-to was received
      */
     public Optional<String> getReplyTo() {
-        return Optional.ofNullable(message.properties().getReplyTo());
+        return Optional.ofNullable(properties.getReplyTo());
     }
 
     /**
@@ -175,7 +183,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the expiration, which may be empty if no expiration was received
      */
     public Optional<String> getExpiration() {
-        return Optional.ofNullable(message.properties().getExpiration());
+        return Optional.ofNullable(properties.getExpiration());
     }
 
     /**
@@ -189,7 +197,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the message-id, which may be empty if no message-id was received
      */
     public Optional<String> getMessageId() {
-        return Optional.ofNullable(message.properties().getMessageId());
+        return Optional.ofNullable(properties.getMessageId());
     }
 
     /**
@@ -202,7 +210,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the date and time, which may be empty if no timestamp was received
      */
     public Optional<ZonedDateTime> getTimestamp(final ZoneId zoneId) {
-        final Optional<Date> timestamp = Optional.ofNullable(message.properties().getTimestamp());
+        final Optional<Date> timestamp = Optional.ofNullable(properties.getTimestamp());
         return timestamp.map(t -> ZonedDateTime.ofInstant(t.toInstant(), zoneId));
     }
 
@@ -214,7 +222,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the type, which may be empty if no type was received
      */
     public Optional<String> getType() {
-        return Optional.ofNullable(message.properties().getType());
+        return Optional.ofNullable(properties.getType());
     }
 
     /**
@@ -226,7 +234,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the user-id, which may be empty if no user-id was received
      */
     public Optional<String> getUserId() {
-        return Optional.ofNullable(message.properties().getUserId());
+        return Optional.ofNullable(properties.getUserId());
     }
 
     /**
@@ -238,7 +246,7 @@ public class IncomingRabbitMQMetadata {
      * @return an {@link Optional} containing the app-id, which may be empty if no app-id was received
      */
     public Optional<String> getAppId() {
-        return Optional.ofNullable(message.properties().getAppId());
+        return Optional.ofNullable(properties.getAppId());
     }
 
     /**
@@ -254,7 +262,7 @@ public class IncomingRabbitMQMetadata {
      */
     @Deprecated
     public Optional<ZonedDateTime> getCreationTime(final ZoneId zoneId) {
-        final Optional<Date> timestamp = Optional.ofNullable(message.properties().getTimestamp());
+        final Optional<Date> timestamp = Optional.ofNullable(properties.getTimestamp());
         return timestamp.map(t -> ZonedDateTime.ofInstant(t.toInstant(), zoneId));
     }
 
@@ -272,7 +280,7 @@ public class IncomingRabbitMQMetadata {
      */
     @Deprecated
     public Optional<String> getId() {
-        return Optional.ofNullable(message.properties().getMessageId());
+        return Optional.ofNullable(properties.getMessageId());
     }
 
     /**
@@ -283,7 +291,7 @@ public class IncomingRabbitMQMetadata {
      * @return the name of the message's exchange.
      */
     public String getExchange() {
-        return message.envelope().getExchange();
+        return envelope.getExchange();
     }
 
     /**
@@ -294,7 +302,7 @@ public class IncomingRabbitMQMetadata {
      * @return the message's routing key.
      */
     public String getRoutingKey() {
-        return message.envelope().getRoutingKey();
+        return envelope.getRoutingKey();
     }
 
     /**
@@ -307,6 +315,6 @@ public class IncomingRabbitMQMetadata {
      * @return the message's redelivery flag.
      */
     public boolean isRedeliver() {
-        return message.envelope().isRedeliver();
+        return envelope.isRedeliver();
     }
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
@@ -1,8 +1,13 @@
 package io.smallrye.reactive.messaging.rabbitmq;
 
 import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.BasicProperties;
+import com.rabbitmq.client.Envelope;
 
 /**
  * Used to represent RabbitMQ metadata in on outgoing message.
@@ -313,4 +318,35 @@ public class OutgoingRabbitMQMetadata {
             return metadata;
         }
     }
+
+    /**
+     * Converts this OutgoingRabbitMQMetadata to an IncomingRabbitMQMetadata.
+     * This is mainly intended for use in unit tests that relies on incoming metadata.
+     *
+     * @param exchange the exchange
+     * @param isRedeliver if it was a redelivery
+     * @return this OutgoingRabbitMQMetadata converted to an IncomingRabbitMQMetadata
+     */
+    public IncomingRabbitMQMetadata toIncomingMetadata(String exchange, boolean isRedeliver) {
+        BasicProperties basicProperties = new AMQP.BasicProperties.Builder()
+                .userId(userId)
+                .appId(appId)
+                .headers(headers)
+                .contentType(contentType)
+                .contentEncoding(contentEncoding)
+                .correlationId(correlationId)
+                .deliveryMode(deliveryMode)
+                .expiration(expiration)
+                .priority(priority)
+                .messageId(messageId)
+                .replyTo(replyTo)
+                .timestamp(Date.from(timestamp.toInstant()))
+                .type(type)
+                .build();
+        // delivery tag is not accessed by IncomingRabbitMQMetadata, so just hardcode it to 0
+        Envelope envelope = new Envelope(0, isRedeliver, exchange, routingKey);
+
+        return new IncomingRabbitMQMetadata(basicProperties, envelope);
+    }
+
 }

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTest.java
@@ -8,10 +8,6 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import com.rabbitmq.client.BasicProperties;
-import com.rabbitmq.client.Envelope;
-
-import io.vertx.core.buffer.Buffer;
-import io.vertx.rabbitmq.RabbitMQMessage;
 
 public class IncomingRabbitMQMetadataTest {
 
@@ -21,47 +17,13 @@ public class IncomingRabbitMQMetadataTest {
         properties.put("header1", "value1");
         properties.put("header2", null);
 
-        DummyRabbitMQMessage message = new DummyRabbitMQMessage(new DummyBasicProperties(properties));
-
-        IncomingRabbitMQMetadata incomingRabbitMQMetadata = new IncomingRabbitMQMetadata(message);
+        IncomingRabbitMQMetadata incomingRabbitMQMetadata = new IncomingRabbitMQMetadata(new DummyBasicProperties(properties),
+                null);
 
         Assert.assertEquals("value1", incomingRabbitMQMetadata.getHeaders().get("header1"));
         Assert.assertTrue(incomingRabbitMQMetadata.getHeaders().containsKey("header2"));
         Assert.assertNull(incomingRabbitMQMetadata.getHeaders().get("header2"));
 
-    }
-
-    class DummyRabbitMQMessage implements RabbitMQMessage {
-        protected BasicProperties properties;
-
-        DummyRabbitMQMessage(BasicProperties properties) {
-            this.properties = properties;
-        }
-
-        @Override
-        public Buffer body() {
-            return Buffer.buffer();
-        }
-
-        @Override
-        public String consumerTag() {
-            return null;
-        }
-
-        @Override
-        public Envelope envelope() {
-            return null;
-        }
-
-        @Override
-        public BasicProperties properties() {
-            return this.properties;
-        }
-
-        @Override
-        public Integer messageCount() {
-            return null;
-        }
     }
 
     class DummyBasicProperties implements BasicProperties {

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMetadataTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQMetadataTest.java
@@ -126,6 +126,41 @@ public class RabbitMQMetadataTest {
         assertThat(props.getType()).isEqualTo("test-type");
     }
 
+    @Test
+    void testOutgoingToIncomingMetadata() {
+        ZonedDateTime timestamp = ZonedDateTime.now().truncatedTo(MILLIS);
+
+        OutgoingRabbitMQMetadata outgoingMetadata = OutgoingRabbitMQMetadata.builder()
+                .withUserId("test-user")
+                .withAppId("tests")
+                .withContentType("text/plain")
+                .withContentEncoding("utf8")
+                .withCorrelationId("req-123")
+                .withDeliveryMode(11)
+                .withExpiration("1000")
+                .withPriority(100)
+                .withMessageId("12345")
+                .withReplyTo("test-source")
+                .withTimestamp(timestamp)
+                .withType("test-type")
+                .build();
+
+        IncomingRabbitMQMetadata incomingRabbitMQMetadata = outgoingMetadata.toIncomingMetadata("exchange", true);
+
+        assertThat(incomingRabbitMQMetadata.getUserId()).isEqualTo(Optional.of("test-user"));
+        assertThat(incomingRabbitMQMetadata.getAppId()).isEqualTo(Optional.of("tests"));
+        assertThat(incomingRabbitMQMetadata.getContentType()).isEqualTo(Optional.of("text/plain"));
+        assertThat(incomingRabbitMQMetadata.getContentEncoding()).isEqualTo(Optional.of("utf8"));
+        assertThat(incomingRabbitMQMetadata.getCorrelationId()).isEqualTo(Optional.of("req-123"));
+        assertThat(incomingRabbitMQMetadata.getDeliveryMode()).isEqualTo(Optional.of(11));
+        assertThat(incomingRabbitMQMetadata.getExpiration()).isEqualTo(Optional.of("1000"));
+        assertThat(incomingRabbitMQMetadata.getPriority()).isEqualTo(Optional.of(100));
+        assertThat(incomingRabbitMQMetadata.getMessageId()).isEqualTo(Optional.of("12345"));
+        assertThat(incomingRabbitMQMetadata.getReplyTo()).isEqualTo(Optional.of("test-source"));
+        assertThat(incomingRabbitMQMetadata.getTimestamp(timestamp.getZone())).isEqualTo(Optional.of(timestamp));
+        assertThat(incomingRabbitMQMetadata.getType()).isEqualTo(Optional.of("test-type"));
+    }
+
     private static class TestInstrumenter extends RabbitMQOpenTelemetryInstrumenter {
 
         public TestInstrumenter(Instrumenter<RabbitMQTrace, Void> instrumenter) {


### PR DESCRIPTION
From OutgoingRabbitMQMetadata.

This is only a POC to see if this can get some traction, will probably need some polishing and unit tests, or perhaps a completely different approach.

Attempt at resolving #2945