### PR TITLE
Accept smallrye- as default connector name prefix for connector config

### DIFF
--- a/documentation/src/main/docs/concepts/connectors.md
+++ b/documentation/src/main/docs/concepts/connectors.md
@@ -145,6 +145,17 @@ mp.messaging.outgoing.data.acks=1
     the connector’s name and set the `connector` attribute for each channel
     managed by this connector.
 
+!!!tip "Connector names"
+    Connector managed by the SmallRye Reactive Messaging project are typically
+    prefixed with `smallrye-`. For example, the SmallRye Kafka Connector is
+    named `smallrye-kafka`. When using Smallrye connectors, you can omit the
+    prefix and just use `kafka` as the connector name:
+
+    ``` properties
+    mp.messaging.incoming.my-channel.connector=kafka
+    mp.messaging.connector.kafka.bootstrap.servers=localhost:9092
+    ```
+
 ## Connector attribute table
 
 In the connector documentation, you will find a table listing the

--- a/justfile
+++ b/justfile
@@ -29,6 +29,24 @@ update-pulsar-config-docs:
     @echo "📝 Updating Pulsar connector configuration docs"
     jbang .build/PulsarConfigDoc.java -d documentation/src/main/docs/pulsar/config
 
+# Build documentation
+build-docs:
+    #!/usr/bin/env bash
+    echo "📝 Building documentation"
+    ./mvnw -B -ntp clean compile -pl documentation
+    cd documentation
+    pipenv install
+    pipenv run mkdocs build
+
+# Serve documentation
+serve-docs:
+    #!/usr/bin/env bash
+    echo "📝 Building documentation"
+    ./mvnw -B -ntp clean compile -pl documentation
+    cd documentation
+    pipenv install
+    pipenv run mkdocs serve
+
 # Deploy documentation
 deploy-docs version:
     #!/usr/bin/env bash

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConfiguredChannelFactory.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/impl/ConfiguredChannelFactory.java
@@ -36,6 +36,7 @@ import io.smallrye.reactive.messaging.providers.helpers.MultiUtils;
 @ApplicationScoped
 public class ConfiguredChannelFactory implements ChannelRegistar {
 
+    public static final String SMALLRYE_PREFIX = "smallrye-";
     protected final Config config;
     protected final ChannelRegistry registry;
     private final ConnectorFactories factories;
@@ -202,6 +203,11 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
 
         InboundConnector inboundConnector = factories.getInboundConnectors().get(connector);
         if (inboundConnector == null) {
+            if (!connector.startsWith(SMALLRYE_PREFIX)) {
+                inboundConnector = factories.getInboundConnectors().get(SMALLRYE_PREFIX + connector);
+            }
+        }
+        if (inboundConnector == null) {
             throw ex.illegalArgumentUnknownConnector(name);
         }
 
@@ -219,6 +225,11 @@ public class ConfiguredChannelFactory implements ChannelRegistar {
         String connector = getConnectorAttribute(config);
 
         OutboundConnector outboundConnector = factories.getOutboundConnectors().get(connector);
+        if (outboundConnector == null) {
+            if (!connector.startsWith(SMALLRYE_PREFIX)) {
+                outboundConnector = factories.getOutboundConnectors().get(SMALLRYE_PREFIX + connector);
+            }
+        }
         if (outboundConnector == null) {
             throw ex.illegalArgumentUnknownConnector(name);
         }

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/ConnectorFactoryRegistrationTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/ConnectorFactoryRegistrationTest.java
@@ -24,7 +24,7 @@ public class ConnectorFactoryRegistrationTest extends WeldTestBase {
         assertThat(registry(container).getPublishers("dummy.source")).isNotEmpty();
         assertThat(registry(container).getSubscribers("dummy-sink")).isNotEmpty();
 
-        MyDummyConnector bean = container.select(MyDummyConnector.class, ConnectorLiteral.of("dummy")).get();
+        MyDummyConnector bean = container.select(MyDummyConnector.class, ConnectorLiteral.of("smallrye-dummy")).get();
         assertThat(bean.list()).containsExactly("8", "10", "12");
         assertThat(bean.gotCompletion()).isTrue();
         assertThat(bean.getConfigs()).hasSize(2).allSatisfy(config -> {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/EnabledConnectorTest.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/EnabledConnectorTest.java
@@ -25,7 +25,7 @@ public class EnabledConnectorTest extends WeldTestBase {
         assertThat(registry(container).getPublishers("dummy.source")).isNotEmpty();
         assertThat(registry(container).getSubscribers("dummy-sink")).isNotEmpty();
 
-        MyDummyConnector bean = container.select(MyDummyConnector.class, ConnectorLiteral.of("dummy")).get();
+        MyDummyConnector bean = container.select(MyDummyConnector.class, ConnectorLiteral.of("smallrye-dummy")).get();
         assertThat(bean.list()).containsExactly("8", "10", "12");
         assertThat(bean.gotCompletion()).isTrue();
         assertThat(bean.getConfigs()).hasSize(2).allSatisfy(config -> {

--- a/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/MyDummyConnector.java
+++ b/smallrye-reactive-messaging-provider/src/test/java/io/smallrye/reactive/messaging/providers/connectors/MyDummyConnector.java
@@ -19,7 +19,7 @@ import io.reactivex.Flowable;
 import io.smallrye.reactive.messaging.OutgoingMessageMetadata;
 
 @ApplicationScoped
-@Connector("dummy")
+@Connector("smallrye-dummy")
 public class MyDummyConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
     private final List<String> list = new CopyOnWriteArrayList<>();
     private final List<Config> configs = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
The channel attribute `connector` can omit the `smallrye-` prefix and still discover the right connector.