### PR TITLE
Revert "Bump io.smallrye:jandex-maven-plugin from 3.2.7 to 3.3.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <jackson.version>2.19.0</jackson.version>
     <yasson.version>2.0.3</yasson.version>
 
-    <jandex-maven-plugin.version>3.3.1</jandex-maven-plugin.version>
+    <jandex-maven-plugin.version>3.2.7</jandex-maven-plugin.version>
     <sundr-maven-plugin.version>0.200.4</sundr-maven-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
 


### PR DESCRIPTION
Reverts smallrye/smallrye-reactive-messaging#3031

Seeing a message from @Ladicek that this version also uses a new index, and so would prevent backporting to older Quarkus versions.