### PR TITLE
Fix documentation fallout

### DIFF
--- a/documentation/src/main/docs/amqp/receiving-amqp-messages.md
+++ b/documentation/src/main/docs/amqp/receiving-amqp-messages.md
@@ -126,9 +126,6 @@ Messages coming from AMQP contains an instance of {{ javadoc('io.smallrye.reacti
 {{ insert('amqp/inbound/AmqpMetadataExample.java', 'code') }}
 ```
 
-If you need to create `IncomingAmqpMetadata` e.g. for testing purposes, create an `OutgoingAmqpMetadata` using its builder
-and convert it using {{ javadoc('io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata#toIncomingMetadata(String,boolean)') }}
-
 ## Acknowledgement
 
 When a Reactive Messaging `Message` associated with an AMQP Message is

--- a/documentation/src/main/docs/rabbitmq/receiving-messages-from-rabbitmq.md
+++ b/documentation/src/main/docs/rabbitmq/receiving-messages-from-rabbitmq.md
@@ -148,6 +148,10 @@ the header:
 | Number               | `Number`         |
 | List                 | `java.util.List` |
 
+If you need to create `IncomingRabbitMQMetadata` e.g. for testing purposes,
+you can create an `{{ javadoc('io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata') }}`
+using its builder and convert it using `OutgoingRabbitMQMetadata.toIncomingMetadata(String, boolean)`
+
 ## Acknowledgement
 
 When a Reactive Messaging Message associated with a RabbitMQ Message is

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/OutgoingRabbitMQMetadata.java
@@ -321,7 +321,7 @@ public class OutgoingRabbitMQMetadata {
 
     /**
      * Converts this OutgoingRabbitMQMetadata to an IncomingRabbitMQMetadata.
-     * This is mainly intended for use in unit tests that relies on incoming metadata.
+     * This is mainly intended for use in unit tests that rely on incoming metadata.
      *
      * @param exchange the exchange
      * @param isRedeliver if it was a redelivery


### PR DESCRIPTION
I noticed that my original attempt to document the `OutgoingRabbitMQMetadata.toIncomingMetadata` method was in the wrong place.

Move it and reword it a bit and also fix a javadoc grammar error.