### PR TITLE
Fix for flaky JMS disconnection test

### DIFF
--- a/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/support/ArtemisHolder.java
+++ b/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/support/ArtemisHolder.java
@@ -3,6 +3,7 @@ package io.smallrye.reactive.messaging.support;
 import java.nio.file.Paths;
 
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.apache.commons.io.FileUtils;
 
@@ -20,9 +21,19 @@ class ArtemisHolder {
         }
     }
 
+    void restart() {
+        try {
+            embedded = new EmbeddedActiveMQ();
+            embedded.start();
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not start embedded ActiveMQ server", e);
+        }
+    }
+
     void stop() {
         try {
             embedded.stop();
+            embedded = null;
         } catch (Exception e) {
             throw new IllegalStateException("Could not stop embedded ActiveMQ server", e);
         }

--- a/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/support/JmsTestBase.java
+++ b/smallrye-reactive-messaging-jms/src/test/java/io/smallrye/reactive/messaging/support/JmsTestBase.java
@@ -41,6 +41,10 @@ public class JmsTestBase {
         holder.stop();
     }
 
+    public void restartArtemis() {
+        holder.restart();
+    }
+
     @BeforeEach
     public void initializeWeld() {
         SmallRyeConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());


### PR DESCRIPTION
Restart the server without wiping the data.

This can cause duplicates in some cases, but saves the at-least-once property of the test.