### PR TITLE
Remove defunct properties

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -136,7 +136,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>compile</scope>
-      <version>${version.junit5}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -467,12 +467,10 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
-      <version>${version.junit5}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>${version.junit5}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
In the new SmallRye parent, the `version.junit5` property has been discontinued. Using this property then leads to POM validation errors. However, it is not actually needed because the versions are managed in the parent, so just drop the usage of these properties.

This will allow the parent CI to include building this project, which should help avoid similar breakage in the future.