### PR TITLE
Use Pattern also for shared subscription without wildcards

### DIFF
--- a/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
+++ b/smallrye-reactive-messaging-mqtt/src/main/java/io/smallrye/reactive/messaging/mqtt/MqttSource.java
@@ -49,7 +49,7 @@ public class MqttSource {
         MqttFailureHandler.Strategy strategy = MqttFailureHandler.Strategy.from(config.getFailureStrategy());
         MqttFailureHandler onNack = createFailureHandler(strategy, config.getChannel());
 
-        if (topic.contains("#") || topic.contains("+")) {
+        if (topic.contains("#") || topic.contains("+") || topic.startsWith("$share/")) {
             String replace = MqttTopicHelper.escapeTopicSpecialWord(MqttHelpers.rebuildMatchesWithSharedSubscription(topic))
                     .replace("+", "[^/]+")
                     .replace("#", ".+");


### PR DESCRIPTION
A regex Pattern is used for wildcard subscriptions to match topic's subscriptions (es: device/+/command) to topic's messages (es: device/SERIAL_1/command). 

The Pattern usage is also need for shared subscritions, when a topic's subscriptions (es: $share/group/cloud/notification) have to match with a topic's messages (es: cloud/notification).

