### PR TITLE
Kafka 4.2 companion API updates

### DIFF
--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ClusterCompanion.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ClusterCompanion.java
@@ -31,10 +31,26 @@ public class ClusterCompanion {
     }
 
     /**
+     * Returns the controller node of the cluster.
+     * <p>
+     * Note: When the admin client is configured with {@code bootstrap.servers} (the default),
+     * this returns a random broker node, not the actual KRaft controller.
+     * When configured with {@code bootstrap.controllers}, it returns the current voter leader.
+     *
      * @return the controller {@link Node} of the cluster
      */
     public Node controller() {
         return toUni(() -> adminClient.describeCluster().controller()).await().atMost(kafkaApiTimeout);
+    }
+
+    /**
+     * @param includeFenced whether to include fenced brokers in the result
+     * @return the collection of {@link Node}s of the cluster, optionally including fenced brokers
+     */
+    public Collection<Node> nodes(boolean includeFenced) {
+        return toUni(() -> adminClient.describeCluster(new DescribeClusterOptions()
+                .includeFencedBrokers(includeFenced)).nodes())
+                .await().atMost(kafkaApiTimeout);
     }
 
     /**

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerBuilder.java
@@ -293,9 +293,23 @@ public class ConsumerBuilder<K, V> implements ConsumerRebalanceListener, Closeab
      *
      * @param offsetResetStrategy the offset reset strategy
      * @return this {@link ConsumerBuilder}
+     * @deprecated {@link OffsetResetStrategy} is deprecated for removal in Kafka 4.0+.
+     *             Use {@link #withOffsetReset(String)} instead with values like {@code "earliest"}, {@code "latest"},
+     *             {@code "none"}.
      */
+    @Deprecated(forRemoval = true)
     public ConsumerBuilder<K, V> withOffsetReset(OffsetResetStrategy offsetResetStrategy) {
         return withProp(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offsetResetStrategy.name().toLowerCase());
+    }
+
+    /**
+     * Add configuration property for {@code auto.offset.reset}
+     *
+     * @param offsetResetStrategy the offset reset strategy, e.g. {@code "earliest"}, {@code "latest"}, {@code "none"}
+     * @return this {@link ConsumerBuilder}
+     */
+    public ConsumerBuilder<K, V> withOffsetReset(String offsetResetStrategy) {
+        return withProp(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offsetResetStrategy);
     }
 
     /**

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerGroupsCompanion.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ConsumerGroupsCompanion.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.admin.MemberToRemove;
 import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupOptions;
 import org.apache.kafka.clients.admin.ShareGroupDescription;
 import org.apache.kafka.clients.admin.SharePartitionOffsetInfo;
+import org.apache.kafka.clients.admin.StreamsGroupDescription;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
@@ -50,8 +51,9 @@ public class ConsumerGroupsCompanion {
 
     /**
      * @return the list of consumer groups
+     * @deprecated Use {@link #listGroups()} instead which returns all group types.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public Collection<ConsumerGroupListing> list() {
         return toUni(() -> adminClient.listConsumerGroups().all())
                 .await().atMost(kafkaApiTimeout);
@@ -272,5 +274,46 @@ public class ConsumerGroupsCompanion {
     public void deleteOffsets(String groupId, List<TopicPartition> topicPartitions) {
         toUni(() -> adminClient.deleteConsumerGroupOffsets(groupId, new HashSet<>(topicPartitions)).all())
                 .await().atMost(kafkaApiTimeout);
+    }
+
+    /*
+     * STREAMS GROUPS (KIP-1071)
+     */
+
+    /**
+     * @param groupIds streams group ids
+     * @return the map of streams group descriptions by id
+     */
+    public Map<String, StreamsGroupDescription> describeStreamsGroups(String... groupIds) {
+        return toUni(() -> adminClient.describeStreamsGroups(Set.of(groupIds)).all())
+                .await().atMost(kafkaApiTimeout);
+    }
+
+    /**
+     * @param groupId streams group id
+     * @return the streams group description
+     */
+    public StreamsGroupDescription describeStreamsGroup(String groupId) {
+        return toUni(() -> adminClient.describeStreamsGroups(Set.of(groupId)).all())
+                .onItem().transform(result -> result.get(groupId))
+                .await().atMost(kafkaApiTimeout);
+    }
+
+    /**
+     * @param groupId streams group id
+     * @return the map of topic partitions to offset
+     */
+    public Map<TopicPartition, OffsetAndMetadata> streamsGroupOffsets(String groupId) {
+        return consumerStreamsGroupUni(groupId, null).await().atMost(kafkaApiTimeout);
+    }
+
+    /**
+     * @param groupId streams group id
+     * @param topicPartitions list of topic partitions
+     * @return the map of topic partitions to offset
+     */
+    public Map<TopicPartition, OffsetAndMetadata> streamsGroupOffsets(String groupId,
+            List<TopicPartition> topicPartitions) {
+        return consumerStreamsGroupUni(groupId, topicPartitions).await().atMost(kafkaApiTimeout);
     }
 }

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/KafkaCompanion.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/KafkaCompanion.java
@@ -25,7 +25,6 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaFuture;
@@ -208,7 +207,7 @@ public class KafkaCompanion implements AutoCloseable {
         config.put(GROUP_ID_CONFIG, "companion-" + UUID.randomUUID());
         config.put(CLIENT_ID_CONFIG, "companion-" + UUID.randomUUID());
         config.put(ENABLE_AUTO_COMMIT_CONFIG, Boolean.FALSE.toString());
-        config.put(AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.EARLIEST.toString().toLowerCase());
+        config.put(AUTO_OFFSET_RESET_CONFIG, "earliest");
         config.putAll(getCommonClientConfig());
         return config;
     }

--- a/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ShareConsumerBuilder.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/main/java/io/smallrye/reactive/messaging/kafka/companion/ShareConsumerBuilder.java
@@ -19,7 +19,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaShareConsumer;
-import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
+import org.apache.kafka.clients.consumer.internals.ShareAcquireMode;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.jboss.logging.Logger;
@@ -191,26 +191,39 @@ public class ShareConsumerBuilder<K, V> implements Closeable {
     /**
      * Add configuration property for {@code share.auto.offset.reset}
      *
-     * @param strategy the offset reset strategy
-     * @return this {@link ConsumerBuilder}
+     * @param offsetResetStrategy the offset reset strategy, e.g. {@code "earliest"}, {@code "latest"},
+     *        {@code "by_duration:PT1H"}
+     * @return this {@link ShareConsumerBuilder}
      */
-    public ShareConsumerBuilder<K, V> withOffsetReset(AutoOffsetResetStrategy strategy) {
-        String offsetResetStrategy = switch (strategy.type()) {
-            case LATEST, EARLIEST, NONE -> strategy.name();
-            case BY_DURATION -> strategy.name() + strategy.duration().map(Duration::toString).orElse("");
-        };
+    public ShareConsumerBuilder<K, V> withOffsetReset(String offsetResetStrategy) {
         return withProp("share.auto.offset.reset", offsetResetStrategy);
     }
 
     /**
      * Acknowledge explicitly records matching the given function with returned acknowledge type.
      *
-     * @param function the predicate to determine which records to acknowledge
+     * @param function the function to determine the acknowledge type for each record
      * @return this {@link ShareConsumerBuilder}
      */
     public ShareConsumerBuilder<K, V> withExplicitAck(Function<ConsumerRecord<K, V>, AcknowledgeType> function) {
         this.acknowledgeFunction = function;
         return withProp(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, "explicit");
+    }
+
+    /**
+     * Set the share acquire mode controlling fetch behavior (KIP-1206).
+     * <ul>
+     * <li>{@link ShareAcquireMode#BATCH_OPTIMIZED} - Soft limit, may exceed {@code max.poll.records} to align with batch
+     * boundaries (default).</li>
+     * <li>{@link ShareAcquireMode#RECORD_LIMIT} - Strict enforcement, acquires records only up to
+     * {@code max.poll.records}.</li>
+     * </ul>
+     *
+     * @param mode the share acquire mode
+     * @return this {@link ShareConsumerBuilder}
+     */
+    public ShareConsumerBuilder<K, V> withAcquireMode(ShareAcquireMode mode) {
+        return withProp("share.acquire.mode", mode.toString());
     }
 
     /**

--- a/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ShareGroupsTest.java
+++ b/smallrye-reactive-messaging-kafka-test-companion/src/test/java/io/smallrye/reactive/messaging/kafka/companion/ShareGroupsTest.java
@@ -13,7 +13,6 @@ import org.apache.kafka.clients.admin.ShareGroupDescription;
 import org.apache.kafka.clients.admin.ShareMemberDescription;
 import org.apache.kafka.clients.admin.SharePartitionOffsetInfo;
 import org.apache.kafka.clients.consumer.AcknowledgeType;
-import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
@@ -30,7 +29,7 @@ public class ShareGroupsTest extends KafkaCompanionTestBase {
         companion.consumerGroups().alterShareGroupConfig(groupId, "share.auto.offset.reset", "earliest");
         try (ConsumerTask<String, Integer> task = companion.shareConsumeIntegers()
                 .withGroupId(groupId)
-                .withOffsetReset(AutoOffsetResetStrategy.EARLIEST)
+                .withOffsetReset("earliest")
                 .fromTopics(topic)) {
 
             companion.consumerGroups().waitForShareGroupAssignment(groupId)
@@ -66,7 +65,7 @@ public class ShareGroupsTest extends KafkaCompanionTestBase {
         companion.consumerGroups().alterShareGroupConfig(groupId, "share.auto.offset.reset", "earliest");
         try (ConsumerTask<String, Integer> task = companion.shareConsumeIntegers()
                 .withGroupId(groupId)
-                .withOffsetReset(AutoOffsetResetStrategy.EARLIEST)
+                .withOffsetReset("earliest")
                 .fromTopics(topic)) {
 
             companion.consumerGroups().waitForShareGroupAssignment(groupId)
@@ -105,7 +104,7 @@ public class ShareGroupsTest extends KafkaCompanionTestBase {
         companion.consumerGroups().alterShareGroupConfig(groupId, "share.auto.offset.reset", "earliest");
         try (ConsumerTask<String, Integer> task = companion.shareConsumeIntegers()
                 .withGroupId(groupId)
-                .withOffsetReset(AutoOffsetResetStrategy.EARLIEST)
+                .withOffsetReset("earliest")
                 .fromTopics(topic)) {
 
             companion.consumerGroups().waitForShareGroupAssignment(groupId)
@@ -136,7 +135,7 @@ public class ShareGroupsTest extends KafkaCompanionTestBase {
         try (ConsumerTask<String, Integer> task = companion.shareConsumeIntegers()
                 .withGroupId(groupId)
                 .withClientId(clientId)
-                .withOffsetReset(AutoOffsetResetStrategy.EARLIEST)
+                .withOffsetReset("earliest")
                 .fromTopics(topic)) {
 
             companion.consumerGroups().waitForShareGroupAssignment(groupId)
@@ -167,7 +166,7 @@ public class ShareGroupsTest extends KafkaCompanionTestBase {
 
         // Consume 5 records with explicit-acknowledge
         ShareConsumerBuilder<String, Integer> builder = companion.shareConsumeIntegers()
-                .withOffsetReset(AutoOffsetResetStrategy.EARLIEST)
+                .withOffsetReset("earliest")
                 .withExplicitAck(r -> AcknowledgeType.ACCEPT);
         companion.consumerGroups().alterShareGroupConfig(builder.groupId(), "share.auto.offset.reset", "earliest");
         try (ConsumerTask<String, Integer> task = builder.fromTopics(topic, 5)) {


### PR DESCRIPTION
  - Deprecate ConsumerBuilder.withOffsetReset(OffsetResetStrategy), add String overload
  - Add ClusterCompanion.nodes(boolean) for fenced brokers (KIP-1073)
  - Add ShareConsumerBuilder.withAcquireMode (KIP-1206)
  - Add streams group APIs to ConsumerGroupsCompanion (KIP-1071)