### PR TITLE
Release 5.0.0-beta0 - Take 2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: SmallRye Reactive Messaging
 release:
-    previous-version: 4.33.0
-    current-version: 4.34.0
+    previous-version: 4.34.0
+    current-version: 5.0.0-beta0
     next-version: 999-SNAPSHOT


### PR DESCRIPTION
First release failed because of the removed MQTT module still referenced in the docs and quickstarts.

https://github.com/smallrye/smallrye-reactive-messaging/actions/runs/23683968679