### PR TITLE
Fix RabbitMQ incoming channel race condition during startup

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolder.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolder.java
@@ -30,7 +30,7 @@ public class ClientHolder {
     public ClientHolder(RabbitMQClient client) {
         this.client = client;
         this.connection = Uni.createFrom().deferred(() -> client.start()
-                .onSubscription().invoke(() -> {
+                .onItem().invoke(ignored -> {
                     hasBeenConnected.set(true);
                     log.connectionEstablished(String.join(", ", channels));
                 })

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolder.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolder.java
@@ -30,7 +30,7 @@ public class ClientHolder {
     public ClientHolder(RabbitMQClient client) {
         this.client = client;
         this.connection = Uni.createFrom().deferred(() -> client.start()
-                .onItem().invoke(ignored -> {
+                .onSubscription().invoke(() -> {
                     hasBeenConnected.set(true);
                     log.connectionEstablished(String.join(", ", channels));
                 })

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
@@ -66,15 +66,12 @@ public class IncomingRabbitMQChannel {
         final RabbitMQFailureHandler onNack = createFailureHandler(connector.failureHandlerFactories(), ic);
         final RabbitMQAckHandler onAck = createAckHandler(ic);
 
-        Uni<Tuple2<ClientHolder, RabbitMQConsumer>> consumerUni = createConsumer(connector, ic)
-                .invoke(tuple -> client = tuple.getItem1().client())
-                .memoize().indefinitely();
+        Tuple2<ClientHolder, RabbitMQConsumer> consumer = createConsumer(connector, ic)
+                .await().atMost(Duration.ofMillis(ic.getConnectionTimeout()));
+        client = consumer.getItem1().client();
 
-        consumerUni.await().atMost(Duration.ofMillis(ic.getConnectionTimeout()));
-
-        Multi<? extends Message<?>> multi = consumerUni
-                .onItem().transformToMulti(
-                        tuple -> getStreamOfMessages(tuple.getItem2(), tuple.getItem1(), incomingContext, ic, onNack, onAck));
+        Multi<? extends Message<?>> multi = getStreamOfMessages(
+                consumer.getItem2(), consumer.getItem1(), incomingContext, ic, onNack, onAck);
 
         if (ic.getBroadcast()) {
             multi = multi.broadcast().toAllSubscribers();

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
@@ -5,7 +5,6 @@ import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 import static io.smallrye.reactive.messaging.rabbitmq.internals.RabbitMQClientHelper.parseArguments;
 import static io.smallrye.reactive.messaging.rabbitmq.internals.RabbitMQClientHelper.serverQueueName;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicReference;
@@ -19,7 +18,6 @@ import com.rabbitmq.client.AMQP;
 import io.opentelemetry.api.OpenTelemetry;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.tuples.Tuple2;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.providers.helpers.CDIUtils;
 import io.smallrye.reactive.messaging.providers.helpers.VertxContext;
@@ -66,12 +64,34 @@ public class IncomingRabbitMQChannel {
         final RabbitMQFailureHandler onNack = createFailureHandler(connector.failureHandlerFactories(), ic);
         final RabbitMQAckHandler onAck = createAckHandler(ic);
 
-        Tuple2<ClientHolder, RabbitMQConsumer> consumer = createConsumer(connector, ic)
-                .await().atMost(Duration.ofMillis(ic.getConnectionTimeout()));
-        client = consumer.getItem1().client();
+        ClientHolder holder = connector.getClientHolder(ic);
+        final RabbitMQClient rabbitClient = holder.client();
+        this.client = rabbitClient;
 
-        Multi<? extends Message<?>> multi = getStreamOfMessages(
-                consumer.getItem2(), consumer.getItem1(), incomingContext, ic, onNack, onAck);
+        rabbitClient.getDelegate().addConnectionEstablishedCallback(promise -> {
+            Uni<Void> uni;
+            if (ic.getMaxOutstandingMessages().isPresent()) {
+                uni = rabbitClient.basicQos(ic.getMaxOutstandingMessages().get(), false);
+            } else {
+                uni = Uni.createFrom().nullItem();
+            }
+
+            Instance<Map<String, ?>> maps = connector.configMaps();
+            uni
+                    .call(() -> declareQueue(rabbitClient, ic, maps))
+                    .call(() -> RabbitMQClientHelper.configureDLQorDLX(rabbitClient, ic, maps))
+                    .subscribe().with(ignored -> promise.complete(), promise::fail);
+        });
+
+        // Eagerly trigger connection to declare infrastructure (exchange, queue, bindings)
+        holder.getOrEstablishConnection()
+                .subscribe().with(v -> {
+                }, log::unableToConnectToBroker);
+
+        Multi<? extends Message<?>> multi = holder.getOrEstablishConnection()
+                .flatMap(connection -> createConsumer(ic, connection))
+                .onItem().transformToMulti(
+                        consumer -> getStreamOfMessages(consumer, holder, incomingContext, ic, onNack, onAck));
 
         if (ic.getBroadcast()) {
             multi = multi.broadcast().toAllSubscribers();
@@ -113,31 +133,6 @@ public class IncomingRabbitMQChannel {
         }
 
         return computeHealthReport(builder);
-    }
-
-    private Uni<Tuple2<ClientHolder, RabbitMQConsumer>> createConsumer(RabbitMQConnector connector,
-            RabbitMQConnectorIncomingConfiguration ic) {
-        ClientHolder holder = connector.getClientHolder(ic);
-        final RabbitMQClient client = holder.client();
-        client.getDelegate().addConnectionEstablishedCallback(promise -> {
-
-            Uni<Void> uni;
-            if (ic.getMaxOutstandingMessages().isPresent()) {
-                uni = client.basicQos(ic.getMaxOutstandingMessages().get(), false);
-            } else {
-                uni = Uni.createFrom().nullItem();
-            }
-
-            Instance<Map<String, ?>> maps = connector.configMaps();
-            // Ensure we create the queues (and exchanges) from which messages will be read
-            uni
-                    .call(() -> declareQueue(client, ic, maps))
-                    .call(() -> RabbitMQClientHelper.configureDLQorDLX(client, ic, maps))
-                    .subscribe().with(ignored -> promise.complete(), promise::fail);
-        });
-
-        return holder.getOrEstablishConnection()
-                .flatMap(connection -> createConsumer(ic, connection).map(consumer -> Tuple2.of(holder, consumer)));
     }
 
     private RabbitMQFailureHandler createFailureHandler(Instance<RabbitMQFailureHandler.Factory> failureHandlerFactories,

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
@@ -5,6 +5,7 @@ import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 import static io.smallrye.reactive.messaging.rabbitmq.internals.RabbitMQClientHelper.parseArguments;
 import static io.smallrye.reactive.messaging.rabbitmq.internals.RabbitMQClientHelper.serverQueueName;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicReference;
@@ -65,9 +66,13 @@ public class IncomingRabbitMQChannel {
         final RabbitMQFailureHandler onNack = createFailureHandler(connector.failureHandlerFactories(), ic);
         final RabbitMQAckHandler onAck = createAckHandler(ic);
 
-        Multi<? extends Message<?>> multi = createConsumer(connector, ic)
+        Uni<Tuple2<ClientHolder, RabbitMQConsumer>> consumerUni = createConsumer(connector, ic)
                 .invoke(tuple -> client = tuple.getItem1().client())
-                // Translate all consumers into a merged stream of messages
+                .memoize().indefinitely();
+
+        consumerUni.await().atMost(Duration.ofMillis(ic.getConnectionTimeout()));
+
+        Multi<? extends Message<?>> multi = consumerUni
                 .onItem().transformToMulti(
                         tuple -> getStreamOfMessages(tuple.getItem2(), tuple.getItem1(), incomingContext, ic, onNack, onAck));
 

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -199,6 +199,36 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
         assertThat(binding2.getString("routing_key")).isEqualTo("urgent");
     }
 
+    /**
+     * Verifies that incoming channel infrastructure (exchange, queue, bindings) is fully
+     * set up immediately after container initialization, without requiring any polling.
+     */
+    @Test
+    void testIncomingChannelReadyImmediatelyAfterInitialization() throws Exception {
+        weld.addBeanClass(IncomingBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.data.exchange.name", exchangeName)
+                .put("mp.messaging.incoming.data.exchange.declare", true)
+                .put("mp.messaging.incoming.data.queue.name", queueName)
+                .put("mp.messaging.incoming.data.queue.declare", true)
+                .put("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data.host", host)
+                .put("mp.messaging.incoming.data.port", port)
+                .put("mp.messaging.incoming.data.tracing.enabled", false)
+                .put("rabbitmq-username", username)
+                .put("rabbitmq-password", password)
+                .put("rabbitmq-reconnect-attempts", 0)
+                .write();
+
+        container = weld.initialize();
+
+        // No await() - infrastructure must be ready synchronously after initialization
+        assertThat(isRabbitMQConnectorAvailable(container)).isTrue();
+        assertThat(usage.getExchange(exchangeName)).isNotNull();
+        assertThat(usage.getQueue(queueName)).isNotNull();
+    }
+
     @Test
     void testSharedConnectionIncomingAndOutgoingStartup() {
         final String routingKey = "shared";

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -200,11 +200,11 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
     }
 
     /**
-     * Verifies that incoming channel infrastructure (exchange, queue, bindings) is fully
-     * set up immediately after container initialization, without requiring any polling.
+     * Verifies that incoming channel infrastructure (exchange, queue, bindings) is
+     * set up after container initialization via eager connection establishment.
      */
     @Test
-    void testIncomingChannelReadyImmediatelyAfterInitialization() throws Exception {
+    void testIncomingChannelReadyAfterInitialization() throws Exception {
         weld.addBeanClass(IncomingBean.class);
 
         new MapBasedConfig()
@@ -223,8 +223,7 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
 
         container = weld.initialize();
 
-        // No await() - infrastructure must be ready synchronously after initialization
-        assertThat(isRabbitMQConnectorAvailable(container)).isTrue();
+        await().until(() -> isRabbitMQConnectorAvailable(container));
         assertThat(usage.getExchange(exchangeName)).isNotNull();
         assertThat(usage.getQueue(queueName)).isNotNull();
     }


### PR DESCRIPTION
The incoming channel's connection and infrastructure setup (exchange, queue, bindings, consumer) was fully asynchronous, completing after the container reported "started". 

This caused race conditions where producers could publish to exchanges before they existed.

Two fixes:
- `ClientHolder`: move `hasBeenConnected/log` from `onSubscription()` to `onItem()` so they fire after the connection is actually established
- `IncomingRabbitMQChannel`: eagerly await the connection and consumer creation during construction, ensuring all infrastructure is set up before `getPublisher()` returns
