### PR TITLE
RabbitMQ connection flow cleanup and lazy-client=false option

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolder.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolder.java
@@ -4,11 +4,9 @@ import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQExceptions.ex
 import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -23,7 +21,6 @@ public class ClientHolder {
     private final RabbitMQClient client;
 
     private final AtomicBoolean hasBeenConnected = new AtomicBoolean(false);
-    private final AtomicReference<CompletableFuture<RabbitMQClient>> ongoingConnection = new AtomicReference<>();
     private final Uni<RabbitMQClient> connection;
     private final Set<String> channels = ConcurrentHashMap.newKeySet();
 
@@ -81,30 +78,7 @@ public class ClientHolder {
 
     @CheckReturnValue
     public Uni<RabbitMQClient> getOrEstablishConnection() {
-        return Uni.createFrom().deferred(this::establishConnection);
-    }
-
-    private Uni<RabbitMQClient> establishConnection() {
-        CompletableFuture<RabbitMQClient> existing = ongoingConnection.get();
-        if (existing != null) {
-            if (!existing.isDone() || client.isConnected()) {
-                return Uni.createFrom().completionStage(existing);
-            }
-            ongoingConnection.compareAndSet(existing, null);
-        }
-
-        CompletableFuture<RabbitMQClient> placeholder = new CompletableFuture<>();
-        CompletableFuture<RabbitMQClient> current = ongoingConnection.compareAndExchange(null, placeholder);
-        if (current != null) {
-            return Uni.createFrom().completionStage(current);
-        }
-        connection.subscribe().with(placeholder::complete, placeholder::completeExceptionally);
-        placeholder.whenComplete((result, error) -> {
-            if (error != null) {
-                ongoingConnection.compareAndSet(placeholder, null);
-            }
-        });
-        return Uni.createFrom().completionStage(placeholder);
+        return connection;
     }
 
     public Set<String> channels() {

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -77,6 +77,9 @@ import io.vertx.rabbitmq.RabbitMQOptions;
 @ConnectorAttribute(name = "client-options-name", direction = INCOMING_AND_OUTGOING, description = "The name of the RabbitMQ Client Option bean used to customize the RabbitMQ client configuration", type = "string", alias = "rabbitmq-client-options-name")
 @ConnectorAttribute(name = "credentials-provider-name", direction = INCOMING_AND_OUTGOING, description = "The name of the RabbitMQ Credentials Provider bean used to provide dynamic credentials to the RabbitMQ client", type = "string", alias = "rabbitmq-credentials-provider-name")
 
+// Client
+@ConnectorAttribute(name = "lazy-client", type = "boolean", direction = INCOMING_AND_OUTGOING, description = "Whether the RabbitMQ client is created lazily or eagerly.", defaultValue = "true")
+
 // Health
 @ConnectorAttribute(name = "health-enabled", type = "boolean", direction = ConnectorAttribute.Direction.INCOMING_AND_OUTGOING, description = "Whether health reporting is enabled (default) or disabled", defaultValue = "true")
 @ConnectorAttribute(name = "health-readiness-enabled", type = "boolean", direction = ConnectorAttribute.Direction.INCOMING_AND_OUTGOING, description = "Whether readiness health reporting is enabled (default) or disabled", defaultValue = "true")

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
@@ -18,7 +18,6 @@ import com.rabbitmq.client.AMQP;
 import io.opentelemetry.api.OpenTelemetry;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.mutiny.tuples.Tuple2;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.providers.helpers.CDIUtils;
 import io.smallrye.reactive.messaging.providers.helpers.VertxContext;
@@ -65,11 +64,22 @@ public class IncomingRabbitMQChannel {
         final RabbitMQFailureHandler onNack = createFailureHandler(connector.failureHandlerFactories(), ic);
         final RabbitMQAckHandler onAck = createAckHandler(ic);
 
-        Multi<? extends Message<?>> multi = createConsumer(connector, ic)
-                .invoke(tuple -> client = tuple.getItem1().client())
-                // Translate all consumers into a merged stream of messages
+        ClientHolder holder = connector.getClientHolder(ic);
+        this.client = holder.client();
+        registerInfrastructureCallback(holder.client(), ic, connector);
+
+        if (!ic.getLazyClient()) {
+            Uni<Void> connection = holder.getOrEstablishConnection().replaceWithVoid();
+            if (ic.getSharedConnectionName().isPresent()) {
+                connection = connection.call(() -> declareInfrastructure(holder.client(), ic, connector));
+            }
+            connection.await().indefinitely();
+        }
+
+        Multi<? extends Message<?>> multi = holder.getOrEstablishConnection()
+                .flatMap(connection -> createConsumer(ic, connection))
                 .onItem().transformToMulti(
-                        tuple -> getStreamOfMessages(tuple.getItem2(), tuple.getItem1(), incomingContext, ic, onNack, onAck));
+                        consumer -> getStreamOfMessages(consumer, holder, incomingContext, ic, onNack, onAck));
 
         if (ic.getBroadcast()) {
             multi = multi.broadcast().toAllSubscribers();
@@ -113,29 +123,27 @@ public class IncomingRabbitMQChannel {
         return computeHealthReport(builder);
     }
 
-    private Uni<Tuple2<ClientHolder, RabbitMQConsumer>> createConsumer(RabbitMQConnector connector,
-            RabbitMQConnectorIncomingConfiguration ic) {
-        ClientHolder holder = connector.getClientHolder(ic);
-        final RabbitMQClient client = holder.client();
+    private Uni<Void> declareInfrastructure(RabbitMQClient client,
+            RabbitMQConnectorIncomingConfiguration ic, RabbitMQConnector connector) {
+        Uni<Void> uni;
+        if (ic.getMaxOutstandingMessages().isPresent()) {
+            uni = client.basicQos(ic.getMaxOutstandingMessages().get(), false);
+        } else {
+            uni = Uni.createFrom().voidItem();
+        }
+
+        Instance<Map<String, ?>> maps = connector.configMaps();
+        return uni
+                .call(() -> declareQueue(client, ic, maps))
+                .call(() -> RabbitMQClientHelper.configureDLQorDLX(client, ic, maps));
+    }
+
+    private void registerInfrastructureCallback(RabbitMQClient client,
+            RabbitMQConnectorIncomingConfiguration ic, RabbitMQConnector connector) {
         client.getDelegate().addConnectionEstablishedCallback(promise -> {
-
-            Uni<Void> uni;
-            if (ic.getMaxOutstandingMessages().isPresent()) {
-                uni = client.basicQos(ic.getMaxOutstandingMessages().get(), false);
-            } else {
-                uni = Uni.createFrom().nullItem();
-            }
-
-            Instance<Map<String, ?>> maps = connector.configMaps();
-            // Ensure we create the queues (and exchanges) from which messages will be read
-            uni
-                    .call(() -> declareQueue(client, ic, maps))
-                    .call(() -> RabbitMQClientHelper.configureDLQorDLX(client, ic, maps))
+            declareInfrastructure(client, ic, connector)
                     .subscribe().with(ignored -> promise.complete(), promise::fail);
         });
-
-        return holder.getOrEstablishConnection()
-                .flatMap(connection -> createConsumer(ic, connection).map(consumer -> Tuple2.of(holder, consumer)));
     }
 
     private RabbitMQFailureHandler createFailureHandler(Instance<RabbitMQFailureHandler.Factory> failureHandlerFactories,

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
@@ -5,6 +5,7 @@ import static io.smallrye.reactive.messaging.rabbitmq.i18n.RabbitMQLogging.log;
 import static io.smallrye.reactive.messaging.rabbitmq.internals.RabbitMQClientHelper.parseArguments;
 import static io.smallrye.reactive.messaging.rabbitmq.internals.RabbitMQClientHelper.serverQueueName;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicReference;
@@ -68,15 +69,16 @@ public class IncomingRabbitMQChannel {
         this.client = holder.client();
         registerInfrastructureCallback(holder.client(), ic, connector);
 
-        if (!ic.getLazyClient()) {
-            Uni<Void> connection = holder.getOrEstablishConnection().replaceWithVoid();
-            if (ic.getSharedConnectionName().isPresent()) {
-                connection = connection.call(() -> declareInfrastructure(holder.client(), ic, connector));
-            }
-            connection.await().indefinitely();
+        Uni<RabbitMQClient> connectionUni = holder.getOrEstablishConnection();
+        if (ic.getSharedConnectionName().isPresent()) {
+            connectionUni = connectionUni.call(() -> declareInfrastructure(holder.client(), ic, connector));
         }
 
-        Multi<? extends Message<?>> multi = holder.getOrEstablishConnection()
+        if (!ic.getLazyClient()) {
+            connectionUni.await().atMost(Duration.ofMillis(config.getConnectionTimeout()));
+        }
+
+        Multi<? extends Message<?>> multi = connectionUni
                 .flatMap(connection -> createConsumer(ic, connection))
                 .onItem().transformToMulti(
                         consumer -> getStreamOfMessages(consumer, holder, incomingContext, ic, onNack, onAck));

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/OutgoingRabbitMQChannel.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/OutgoingRabbitMQChannel.java
@@ -37,16 +37,17 @@ public class OutgoingRabbitMQChannel {
         final RabbitMQClient client = holder.client();
         registerExchangeCallback(client, oc, connector);
 
-        if (!oc.getLazyClient()) {
-            Uni<Void> connection = holder.getOrEstablishConnection().replaceWithVoid();
-            if (oc.getSharedConnectionName().isPresent()) {
-                connection = connection
-                        .call(() -> RabbitMQClientHelper.declareExchangeIfNeeded(client, oc, connector.configMaps()));
-            }
-            connection.await().indefinitely();
+        Uni<RabbitMQClient> connectionUni = holder.getOrEstablishConnection();
+        if (oc.getSharedConnectionName().isPresent()) {
+            connectionUni = connectionUni
+                    .call(() -> RabbitMQClientHelper.declareExchangeIfNeeded(client, oc, connector.configMaps()));
         }
 
-        final Uni<RabbitMQPublisher> getSender = holder.getOrEstablishConnection()
+        if (!oc.getLazyClient()) {
+            connectionUni.await().atMost(Duration.ofSeconds(config.getConnectionTimeout()));
+        }
+
+        final Uni<RabbitMQPublisher> getSender = connectionUni
                 .onItem()
                 .transformToUni(connection -> Uni.createFrom().item(RabbitMQPublisher.create(connector.vertx(), connection,
                         new RabbitMQPublisherOptions()

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/OutgoingRabbitMQChannel.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/OutgoingRabbitMQChannel.java
@@ -34,13 +34,17 @@ public class OutgoingRabbitMQChannel {
 
         this.config = oc;
         holder = connector.getClientHolder(oc);
-        // Create a client
         final RabbitMQClient client = holder.client();
-        client.getDelegate().addConnectionEstablishedCallback(promise -> {
-            // Ensure we create the exchange to which messages are to be sent
-            RabbitMQClientHelper.declareExchangeIfNeeded(client, oc, connector.configMaps())
-                    .subscribe().with((ignored) -> promise.complete(), promise::fail);
-        });
+        registerExchangeCallback(client, oc, connector);
+
+        if (!oc.getLazyClient()) {
+            Uni<Void> connection = holder.getOrEstablishConnection().replaceWithVoid();
+            if (oc.getSharedConnectionName().isPresent()) {
+                connection = connection
+                        .call(() -> RabbitMQClientHelper.declareExchangeIfNeeded(client, oc, connector.configMaps()));
+            }
+            connection.await().indefinitely();
+        }
 
         final Uni<RabbitMQPublisher> getSender = holder.getOrEstablishConnection()
                 .onItem()
@@ -105,6 +109,14 @@ public class OutgoingRabbitMQChannel {
         }
 
         return computeHealthReport(builder);
+    }
+
+    private void registerExchangeCallback(RabbitMQClient client,
+            RabbitMQConnectorOutgoingConfiguration oc, RabbitMQConnector connector) {
+        client.getDelegate().addConnectionEstablishedCallback(promise -> {
+            RabbitMQClientHelper.declareExchangeIfNeeded(client, oc, connector.configMaps())
+                    .subscribe().with(ignored -> promise.complete(), promise::fail);
+        });
     }
 
     public void terminate() {

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolderTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolderTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.rabbitmq.RabbitMQClient;
 import io.vertx.rabbitmq.RabbitMQOptions;
 
 public class ClientHolderTest extends RabbitMQBrokerTestBase {
@@ -32,22 +33,21 @@ public class ClientHolderTest extends RabbitMQBrokerTestBase {
     @Test
     public void testConcurrentGetOrEstablishConnection() throws InterruptedException {
         Vertx vertx = executionHolder.vertx();
-        io.vertx.mutiny.rabbitmq.RabbitMQClient client = io.vertx.mutiny.rabbitmq.RabbitMQClient
+        RabbitMQClient client = RabbitMQClient
                 .create(vertx, clientOptions());
         ClientHolder holder = new ClientHolder(client);
 
         int threadCount = 10;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         CountDownLatch startLatch = new CountDownLatch(1);
-        List<io.vertx.mutiny.rabbitmq.RabbitMQClient> connections = new CopyOnWriteArrayList<>();
+        List<RabbitMQClient> connections = new CopyOnWriteArrayList<>();
         List<Throwable> errors = new CopyOnWriteArrayList<>();
 
         for (int i = 0; i < threadCount; i++) {
             executor.submit(() -> {
                 try {
                     startLatch.await();
-                    io.vertx.mutiny.rabbitmq.RabbitMQClient conn = holder.getOrEstablishConnection()
-                            .await().atMost(Duration.ofSeconds(10));
+                    RabbitMQClient conn = holder.getOrEstablishConnection().await().atMost(Duration.ofSeconds(10));
                     connections.add(conn);
                 } catch (Throwable t) {
                     errors.add(t);
@@ -61,7 +61,7 @@ public class ClientHolderTest extends RabbitMQBrokerTestBase {
                 .untilAsserted(() -> assertThat(connections).hasSize(threadCount));
         assertThat(errors).isEmpty();
 
-        io.vertx.mutiny.rabbitmq.RabbitMQClient first = connections.get(0);
+        RabbitMQClient first = connections.get(0);
         assertThat(connections).allSatisfy(conn -> assertThat(conn).isSameAs(first));
         assertThat(client.isConnected()).isTrue();
 
@@ -73,17 +73,17 @@ public class ClientHolderTest extends RabbitMQBrokerTestBase {
     @Test
     public void testReconnectAfterDisconnection() {
         Vertx vertx = executionHolder.vertx();
-        io.vertx.mutiny.rabbitmq.RabbitMQClient client = io.vertx.mutiny.rabbitmq.RabbitMQClient
+        RabbitMQClient client = RabbitMQClient
                 .create(vertx, clientOptions());
         ClientHolder holder = new ClientHolder(client);
 
-        io.vertx.mutiny.rabbitmq.RabbitMQClient first = holder.getOrEstablishConnection()
+        RabbitMQClient first = holder.getOrEstablishConnection()
                 .await().atMost(Duration.ofSeconds(10));
         assertThat(first).isNotNull();
         assertThat(client.isConnected()).isTrue();
         assertThat(holder.hasBeenConnected()).isTrue();
 
-        io.vertx.mutiny.rabbitmq.RabbitMQClient cached = holder.getOrEstablishConnection()
+        RabbitMQClient cached = holder.getOrEstablishConnection()
                 .await().atMost(Duration.ofSeconds(10));
         assertThat(cached).isSameAs(first);
 
@@ -91,7 +91,7 @@ public class ClientHolderTest extends RabbitMQBrokerTestBase {
         await().atMost(Duration.ofSeconds(5))
                 .untilAsserted(() -> assertThat(client.isConnected()).isFalse());
 
-        io.vertx.mutiny.rabbitmq.RabbitMQClient reconnected = holder.getOrEstablishConnection()
+        RabbitMQClient reconnected = holder.getOrEstablishConnection()
                 .await().atMost(Duration.ofSeconds(10));
         assertThat(reconnected).isSameAs(first);
         assertThat(client.isConnected()).isTrue();
@@ -100,7 +100,7 @@ public class ClientHolderTest extends RabbitMQBrokerTestBase {
     @Test
     public void testConcurrentGetOrEstablishConnectionAfterDisconnect() throws InterruptedException {
         Vertx vertx = executionHolder.vertx();
-        io.vertx.mutiny.rabbitmq.RabbitMQClient client = io.vertx.mutiny.rabbitmq.RabbitMQClient
+        RabbitMQClient client = RabbitMQClient
                 .create(vertx, clientOptions());
         ClientHolder holder = new ClientHolder(client);
 
@@ -114,14 +114,14 @@ public class ClientHolderTest extends RabbitMQBrokerTestBase {
         int threadCount = 10;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         CountDownLatch startLatch = new CountDownLatch(1);
-        List<io.vertx.mutiny.rabbitmq.RabbitMQClient> connections = new CopyOnWriteArrayList<>();
+        List<RabbitMQClient> connections = new CopyOnWriteArrayList<>();
         List<Throwable> errors = new CopyOnWriteArrayList<>();
 
         for (int i = 0; i < threadCount; i++) {
             executor.submit(() -> {
                 try {
                     startLatch.await();
-                    io.vertx.mutiny.rabbitmq.RabbitMQClient conn = holder.getOrEstablishConnection()
+                    RabbitMQClient conn = holder.getOrEstablishConnection()
                             .await().atMost(Duration.ofSeconds(10));
                     connections.add(conn);
                 } catch (Throwable t) {

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolderTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/ClientHolderTest.java
@@ -1,0 +1,146 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.rabbitmq.RabbitMQOptions;
+
+public class ClientHolderTest extends RabbitMQBrokerTestBase {
+
+    private RabbitMQOptions clientOptions() {
+        return new RabbitMQOptions()
+                .setHost(host)
+                .setPort(port)
+                .setUser(username)
+                .setPassword(password)
+                .setAutomaticRecoveryOnInitialConnection(false)
+                .setReconnectAttempts(5)
+                .setReconnectInterval(1000);
+    }
+
+    @Test
+    public void testConcurrentGetOrEstablishConnection() throws InterruptedException {
+        Vertx vertx = executionHolder.vertx();
+        io.vertx.mutiny.rabbitmq.RabbitMQClient client = io.vertx.mutiny.rabbitmq.RabbitMQClient
+                .create(vertx, clientOptions());
+        ClientHolder holder = new ClientHolder(client);
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<io.vertx.mutiny.rabbitmq.RabbitMQClient> connections = new CopyOnWriteArrayList<>();
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    io.vertx.mutiny.rabbitmq.RabbitMQClient conn = holder.getOrEstablishConnection()
+                            .await().atMost(Duration.ofSeconds(10));
+                    connections.add(conn);
+                } catch (Throwable t) {
+                    errors.add(t);
+                }
+            });
+        }
+
+        startLatch.countDown();
+
+        await().atMost(Duration.ofSeconds(15))
+                .untilAsserted(() -> assertThat(connections).hasSize(threadCount));
+        assertThat(errors).isEmpty();
+
+        io.vertx.mutiny.rabbitmq.RabbitMQClient first = connections.get(0);
+        assertThat(connections).allSatisfy(conn -> assertThat(conn).isSameAs(first));
+        assertThat(client.isConnected()).isTrue();
+
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+        client.stop().await().atMost(Duration.ofSeconds(5));
+    }
+
+    @Test
+    public void testReconnectAfterDisconnection() {
+        Vertx vertx = executionHolder.vertx();
+        io.vertx.mutiny.rabbitmq.RabbitMQClient client = io.vertx.mutiny.rabbitmq.RabbitMQClient
+                .create(vertx, clientOptions());
+        ClientHolder holder = new ClientHolder(client);
+
+        io.vertx.mutiny.rabbitmq.RabbitMQClient first = holder.getOrEstablishConnection()
+                .await().atMost(Duration.ofSeconds(10));
+        assertThat(first).isNotNull();
+        assertThat(client.isConnected()).isTrue();
+        assertThat(holder.hasBeenConnected()).isTrue();
+
+        io.vertx.mutiny.rabbitmq.RabbitMQClient cached = holder.getOrEstablishConnection()
+                .await().atMost(Duration.ofSeconds(10));
+        assertThat(cached).isSameAs(first);
+
+        client.stop().await().atMost(Duration.ofSeconds(5));
+        await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(client.isConnected()).isFalse());
+
+        io.vertx.mutiny.rabbitmq.RabbitMQClient reconnected = holder.getOrEstablishConnection()
+                .await().atMost(Duration.ofSeconds(10));
+        assertThat(reconnected).isSameAs(first);
+        assertThat(client.isConnected()).isTrue();
+    }
+
+    @Test
+    public void testConcurrentGetOrEstablishConnectionAfterDisconnect() throws InterruptedException {
+        Vertx vertx = executionHolder.vertx();
+        io.vertx.mutiny.rabbitmq.RabbitMQClient client = io.vertx.mutiny.rabbitmq.RabbitMQClient
+                .create(vertx, clientOptions());
+        ClientHolder holder = new ClientHolder(client);
+
+        holder.getOrEstablishConnection().await().atMost(Duration.ofSeconds(10));
+        assertThat(client.isConnected()).isTrue();
+
+        client.stop().await().atMost(Duration.ofSeconds(5));
+        await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(client.isConnected()).isFalse());
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<io.vertx.mutiny.rabbitmq.RabbitMQClient> connections = new CopyOnWriteArrayList<>();
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    io.vertx.mutiny.rabbitmq.RabbitMQClient conn = holder.getOrEstablishConnection()
+                            .await().atMost(Duration.ofSeconds(10));
+                    connections.add(conn);
+                } catch (Throwable t) {
+                    errors.add(t);
+                }
+            });
+        }
+
+        startLatch.countDown();
+
+        await().atMost(Duration.ofSeconds(15))
+                .untilAsserted(() -> assertThat(connections).hasSize(threadCount));
+        assertThat(errors).isEmpty();
+
+        assertThat(connections).allSatisfy(conn -> assertThat(conn).isSameAs(client));
+        assertThat(client.isConnected()).isTrue();
+
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+        client.stop().await().atMost(Duration.ofSeconds(5));
+    }
+}

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -199,6 +199,36 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
         assertThat(binding2.getString("routing_key")).isEqualTo("urgent");
     }
 
+    /**
+     * Verifies that with eager client (default), incoming channel infrastructure
+     * (exchange, queue, bindings) is declared during container initialization.
+     */
+    @Test
+    void testEagerClientDeclaresInfrastructureAtStartup() throws Exception {
+        weld.addBeanClass(IncomingBean.class);
+
+        new MapBasedConfig()
+                .put("mp.messaging.incoming.data.exchange.name", exchangeName)
+                .put("mp.messaging.incoming.data.exchange.declare", true)
+                .put("mp.messaging.incoming.data.queue.name", queueName)
+                .put("mp.messaging.incoming.data.queue.declare", true)
+                .put("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
+                .put("mp.messaging.incoming.data.host", host)
+                .put("mp.messaging.incoming.data.port", port)
+                .put("mp.messaging.incoming.data.tracing.enabled", false)
+                .put("mp.messaging.incoming.data.lazy-client", false)
+                .put("rabbitmq-username", username)
+                .put("rabbitmq-password", password)
+                .put("rabbitmq-reconnect-attempts", 0)
+                .write();
+
+        container = weld.initialize();
+
+        // No await() needed — eager client blocks during construction
+        assertThat(usage.getExchange(exchangeName)).isNotNull();
+        assertThat(usage.getQueue(queueName)).isNotNull();
+    }
+
     @Test
     void testSharedConnectionIncomingAndOutgoingStartup() {
         final String routingKey = "shared";

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -200,7 +200,7 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
     }
 
     /**
-     * Verifies that with eager client (default), incoming channel infrastructure
+     * Verifies that with eager client, incoming channel infrastructure
      * (exchange, queue, bindings) is declared during container initialization.
      */
     @Test


### PR DESCRIPTION
`lazy-client=false` for eager client/queue-exchange creation