### PR TITLE
Release 5.0.0-beta2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: SmallRye Reactive Messaging
 release:
-    previous-version: 4.34.0
-    current-version: 4.35.0
+    previous-version: 4.35.0
+    current-version: 5.0.0-beta2
     next-version: 999-SNAPSHOT


### PR DESCRIPTION
Vert.x 5 migration branch (#3331) release on top of release [4.35.0](https://github.com/smallrye/smallrye-reactive-messaging/milestone/122)