### PR TITLE
Kafka transactions tests improvements

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/i18n/KafkaLogging.java
@@ -396,4 +396,8 @@ public interface KafkaLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 18294, value = "Configuration 'throttled.ordered' is deprecated. Use 'ordered' instead, which works with any commit strategy.")
     void throttledOrderedDeprecated();
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 18295, value = "Evicting broken pooled producer from channel %s with transactional.id %s")
+    void pooledProducerEvicted(String channel, Object transactionalId);
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/PooledKafkaProducer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/PooledKafkaProducer.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.kafka.impl;
 
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
+import static io.smallrye.reactive.messaging.kafka.transactions.KafkaTransactionsImpl.isFatalError;
 
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +34,7 @@ import io.smallrye.reactive.messaging.kafka.KafkaConnectorOutgoingConfiguration;
 import io.smallrye.reactive.messaging.kafka.KafkaProducer;
 import io.smallrye.reactive.messaging.kafka.SerializationFailureHandler;
 import io.smallrye.reactive.messaging.kafka.i18n.KafkaExceptions;
+import io.smallrye.reactive.messaging.kafka.transactions.KafkaTransactionsImpl;
 
 public class PooledKafkaProducer<K, V> implements KafkaProducer<K, V> {
 
@@ -151,6 +153,24 @@ public class PooledKafkaProducer<K, V> implements KafkaProducer<K, V> {
 
     private void releaseProducer(ReactiveKafkaProducer<K, V> p) {
         availableProducers.offer(p);
+    }
+
+    // Workaround for KAFKA-19177: broker-side transaction timeout causes the producer to enter
+    // FATAL_ERROR state from which it cannot recover. The Kafka client fix (reclassifying
+    // INVALID_TXN_STATE as abortable in EndTxn responses, per KIP-588) is not yet released.
+    // Until then, we evict the broken producer so the pool creates a fresh replacement.
+    private void evictProducer(ReactiveKafkaProducer<K, V> p) {
+        allProducers.remove(p);
+        availableProducers.remove(p);
+        log.pooledProducerEvicted(channel, p.configuration().get(ProducerConfig.TRANSACTIONAL_ID_CONFIG));
+    }
+
+    private void releaseOrEvict(ReactiveKafkaProducer<K, V> p, Throwable t) {
+        if (isFatalError(t)) {
+            evictProducer(p);
+        } else {
+            releaseProducer(p);
+        }
     }
 
     private ReactiveKafkaProducer<K, V> createProducer(int index) {
@@ -322,13 +342,18 @@ public class PooledKafkaProducer<K, V> implements KafkaProducer<K, V> {
         @Override
         @CheckReturnValue
         public Uni<Void> beginTransaction() {
-            return acquire().beginTransaction()
-                    .onFailure().invoke(() -> {
-                        ReactiveKafkaProducer<K, V> released = producer.getAndSet(null);
-                        if (released != null) {
-                            releaseProducer(released);
-                        }
-                    });
+            return Uni.createFrom().voidItem()
+                    .chain(() -> {
+                        ReactiveKafkaProducer<K, V> p = acquire();
+                        return p.beginTransaction()
+                                .onFailure().invoke(t -> {
+                                    producer.compareAndSet(p, null);
+                                    releaseOrEvict(p, t);
+                                });
+                    })
+                    // If the acquired producer is in a fatal error state (e.g. broker-side transaction timeout),
+                    // evict it and retry once to acquire a fresh producer from the pool.
+                    .onFailure(KafkaTransactionsImpl::isFatalError).retry().atMost(1);
         }
 
         synchronized ReactiveKafkaProducer<K, V> acquire() {
@@ -368,9 +393,11 @@ public class PooledKafkaProducer<K, V> implements KafkaProducer<K, V> {
                 return Uni.createFrom().voidItem();
             }
             try {
-                return p.commitTransaction().eventually(() -> releaseProducer(p));
+                return p.commitTransaction()
+                        .invoke(() -> releaseProducer(p))
+                        .onFailure().invoke(t -> releaseOrEvict(p, t));
             } catch (Exception e) {
-                releaseProducer(p);
+                releaseOrEvict(p, e);
                 throw e;
             }
         }
@@ -383,9 +410,11 @@ public class PooledKafkaProducer<K, V> implements KafkaProducer<K, V> {
                 return Uni.createFrom().voidItem();
             }
             try {
-                return p.abortTransaction().eventually(() -> releaseProducer(p));
+                return p.abortTransaction()
+                        .invoke(() -> releaseProducer(p))
+                        .onFailure().invoke(t -> releaseOrEvict(p, t));
             } catch (Exception e) {
-                releaseProducer(p);
+                releaseOrEvict(p, e);
                 throw e;
             }
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/transactions/KafkaTransactionsImpl.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/transactions/KafkaTransactionsImpl.java
@@ -15,6 +15,9 @@ import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.InvalidTxnStateException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TransactionAbortedException;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
@@ -51,6 +54,23 @@ public class KafkaTransactionsImpl<T> extends MutinyEmitterImpl<T> implements Ka
         this.clientService = clientService;
         this.producer = clientService.getProducer(config.name());
         this.transactionTimeout = resolveTransactionTimeout(producer.configuration());
+    }
+
+    public static boolean isFatalError(Throwable t) {
+        if (t instanceof ProducerFencedException || t instanceof InvalidProducerEpochException
+                || t instanceof InvalidTxnStateException) {
+            return true;
+        }
+        // InvalidTxnStateException may also appear wrapped in the cause chain
+        // (e.g. KafkaException -> TransactionAbortableException -> InvalidTxnStateException)
+        Throwable cause = t.getCause();
+        while (cause != null) {
+            if (cause instanceof InvalidTxnStateException) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 
     private static Duration resolveTransactionTimeout(Map<String, ?> config) {
@@ -330,7 +350,12 @@ public class KafkaTransactionsImpl<T> extends MutinyEmitterImpl<T> implements Ka
                     // commit or rollback the transaction
                     .call(() -> abort ? abort() : commit().onFailure().recoverWithUni(throwable -> {
                         KafkaLogging.log.transactionCommitFailed(throwable);
-                        return abort();
+                        return abort().onItemOrFailure().transformToUni((v, f) -> {
+                            if (isFatalError(throwable)) {
+                                return Uni.createFrom().failure(throwable);
+                            }
+                            return Uni.createFrom().voidItem();
+                        });
                     }))
                     // finally, call after commit or after abort callbacks
                     .onFailure().recoverWithUni(throwable -> afterAbort.apply(throwable))

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/ExactlyOnceProcessingTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/ExactlyOnceProcessingTest.java
@@ -246,8 +246,8 @@ public class ExactlyOnceProcessingTest extends KafkaCompanionTestBase {
                 .withProp(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1")
                 .fromTopics(inTopic);
 
-        // Let the rebalance settle, then remove the intruder so our processor reclaims all partitions
-        Thread.sleep(8000);
+        // Wait for the rebalance to complete (intruder gets assigned partitions and polls records)
+        await().atMost(Duration.ofSeconds(30)).until(() -> intruder.count() > 0);
         intruder.close();
 
         // All records should eventually be processed despite the rebalance

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/ExactlyOnceProcessingTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/ExactlyOnceProcessingTest.java
@@ -7,6 +7,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -84,6 +86,32 @@ public class ExactlyOnceProcessingTest extends KafkaCompanionTestBase {
             return processed;
         }
 
+    }
+
+    @Test
+    void testWithTransactionAndAckSingleRecord() {
+        inTopic = companion.topics().createAndWait(Uuid.randomUuid().toString(), 1);
+        outTopic = companion.topics().createAndWait(Uuid.randomUuid().toString(), 1);
+        int numberOfRecords = 10;
+        MapBasedConfig config = new MapBasedConfig(producerConfig());
+        config.putAll(consumerConfig());
+        WithTransactionAndAckProcessor application = runApplication(config, WithTransactionAndAckProcessor.class);
+
+        companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(inTopic, i), numberOfRecords);
+
+        ConsumerTask<String, Integer> records = companion.consumeIntegers()
+                .withProp(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
+                .fromTopics(outTopic, numberOfRecords)
+                .awaitCompletion(Duration.ofMinutes(1));
+
+        assertThat(records.getRecords())
+                .extracting(ConsumerRecord::value)
+                .containsAll(IntStream.range(0, numberOfRecords).boxed().collect(Collectors.toList()))
+                .doesNotHaveDuplicates();
+
+        assertThat(application.getProcessed())
+                .containsAll(IntStream.range(0, numberOfRecords).boxed().collect(Collectors.toList()))
+                .doesNotHaveDuplicates();
     }
 
     @Test
@@ -190,6 +218,107 @@ public class ExactlyOnceProcessingTest extends KafkaCompanionTestBase {
                 .with("max.poll.records", "100")
                 .with("auto.offset.reset", "earliest")
                 .with("value.deserializer", IntegerDeserializer.class.getName());
+    }
+
+    @Test
+    @Tag(TestTags.SLOW)
+    void testExactlyOnceProcessorWithRebalanceDuringTransaction() throws InterruptedException {
+        inTopic = companion.topics().createAndWait(Uuid.randomUuid().toString(), 3);
+        outTopic = companion.topics().createAndWait(Uuid.randomUuid().toString(), 3);
+        int numberOfRecords = 20;
+        MapBasedConfig config = new MapBasedConfig(producerConfig());
+        config.putAll(consumerConfig()
+                .with("max.poll.records", "1")
+                .with("session.timeout.ms", "6000")
+                .with("heartbeat.interval.ms", "2000"));
+        RebalanceExactlyOnceProcessor application = runApplication(config, RebalanceExactlyOnceProcessor.class);
+
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(inTopic, i % 3, "k" + i, i), numberOfRecords);
+
+        // Wait until processing is underway
+        assertThat(application.awaitProcessingStarted(30, TimeUnit.SECONDS)).isTrue();
+
+        // Join a second consumer to the same group to trigger a rebalance
+        // while transactions are in-flight (each record takes 1s to process)
+        ConsumerTask<String, Integer> intruder = companion.consumeIntegers()
+                .withGroupId("my-consumer")
+                .withProp(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1")
+                .fromTopics(inTopic);
+
+        // Let the rebalance settle, then remove the intruder so our processor reclaims all partitions
+        Thread.sleep(8000);
+        intruder.close();
+
+        // All records should eventually be processed despite the rebalance
+        await().atMost(Duration.ofMinutes(2)).untilAsserted(() -> {
+            assertThat(application.getProcessed())
+                    .containsAll(IntStream.range(0, numberOfRecords).boxed().collect(Collectors.toList()));
+        });
+
+        // Output should contain all records with no duplicates
+        ConsumerTask<String, Integer> records = companion.consumeIntegers()
+                .withProp(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
+                .fromTopics(outTopic, numberOfRecords)
+                .awaitCompletion(Duration.ofMinutes(1));
+
+        assertThat(records.getRecords())
+                .extracting(ConsumerRecord::value)
+                .containsAll(IntStream.range(0, numberOfRecords).boxed().collect(Collectors.toList()))
+                .doesNotHaveDuplicates();
+    }
+
+    @ApplicationScoped
+    public static class RebalanceExactlyOnceProcessor {
+
+        @Inject
+        @Channel("transactional-producer")
+        KafkaTransactions<Integer> transaction;
+
+        private final CountDownLatch processingStarted = new CountDownLatch(1);
+        private final List<Integer> processed = new CopyOnWriteArrayList<>();
+
+        @Incoming("exactly-once-consumer")
+        Uni<Void> process(KafkaRecord<String, Integer> record) {
+            return transaction.withTransaction(record, emitter -> {
+                processingStarted.countDown();
+                emitter.send(KafkaRecord.of(record.getKey(), record.getPayload()));
+                return Uni.createFrom().voidItem()
+                        .onItem().delayIt().by(Duration.ofSeconds(1))
+                        .invoke(() -> processed.add(record.getPayload()));
+            }).onFailure().recoverWithUni(t -> Uni.createFrom().completionStage(record.nack(t)));
+        }
+
+        public boolean awaitProcessingStarted(long timeout, TimeUnit unit) throws InterruptedException {
+            return processingStarted.await(timeout, unit);
+        }
+
+        public List<Integer> getProcessed() {
+            return processed;
+        }
+    }
+
+    @ApplicationScoped
+    public static class WithTransactionAndAckProcessor {
+
+        @Inject
+        @Channel("transactional-producer")
+        KafkaTransactions<Integer> transaction;
+
+        List<Integer> processed = new CopyOnWriteArrayList<>();
+
+        @Incoming("exactly-once-consumer")
+        Uni<Void> process(KafkaRecord<String, Integer> record) {
+            return transaction.withTransactionAndAck(record, emitter -> {
+                emitter.send(KafkaRecord.of(record.getKey(), record.getPayload()));
+                processed.add(record.getPayload());
+                return Uni.createFrom().voidItem();
+            });
+        }
+
+        public List<Integer> getProcessed() {
+            return processed;
+        }
     }
 
     @ApplicationScoped

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/PerPartitionExactlyOnceProcessingTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/PerPartitionExactlyOnceProcessingTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.reactive.messaging.kafka.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
@@ -428,6 +429,44 @@ public class PerPartitionExactlyOnceProcessingTest extends KafkaCompanionTestBas
                 .doesNotHaveDuplicates();
     }
 
+    @Test
+    void testPoolExhausted() {
+        outTopic = companion.topics().createAndWait(topic, 3);
+        // max-pool-size=1 means only one concurrent transaction is allowed
+        MapBasedConfig config = new MapBasedConfig(producerConfig()
+                .with("pooled-producer.max-pool-size", 1));
+        PoolExhaustionApp app = runApplication(config, PoolExhaustionApp.class);
+
+        // First transaction holds a producer, second should fail with pool exhausted
+        assertThatThrownBy(() -> app.runConcurrentTransactions().await().atMost(Duration.ofSeconds(10)))
+                .hasMessageContaining("pool");
+    }
+
+    @Test
+    void testInitialPoolSizeCreatesProducersAtStartup() {
+        outTopic = companion.topics().createAndWait(topic, 3);
+        MapBasedConfig config = new MapBasedConfig(producerConfig()
+                .with("pooled-producer.initial-pool-size", 3)
+                .with("pooled-producer.max-pool-size", 5));
+        runApplication(config, WithTransactionNoMessageApp.class);
+
+        KafkaClientService clientService = get(KafkaClientService.class);
+        KafkaProducer<?, ?> producer = clientService.getProducer("transactional-producer");
+        assertThat(producer).isInstanceOf(PooledKafkaProducer.class);
+
+        PooledKafkaProducer<?, ?> pooledProducer = (PooledKafkaProducer<?, ?>) producer;
+        assertThat(pooledProducer.getProducers())
+                .as("initial-pool-size=3 should pre-create 3 producers")
+                .hasSize(3);
+
+        // Each should have a distinct transactional.id
+        Set<String> txIds = pooledProducer.getProducers().stream()
+                .map(p -> (String) p.configuration().get(ProducerConfig.TRANSACTIONAL_ID_CONFIG))
+                .collect(Collectors.toSet());
+        assertThat(txIds).hasSize(3);
+        txIds.forEach(id -> assertThat(id).startsWith("tx-producer-"));
+    }
+
     private KafkaMapBasedConfig producerConfig() {
         return kafkaConfig("mp.messaging.outgoing.transactional-producer")
                 .with("topic", outTopic)
@@ -484,6 +523,29 @@ public class PerPartitionExactlyOnceProcessingTest extends KafkaCompanionTestBas
                 emitter.send(1);
                 return Uni.createFrom().voidItem();
             });
+        }
+    }
+
+    @ApplicationScoped
+    public static class PoolExhaustionApp {
+
+        @Inject
+        @Channel("transactional-producer")
+        KafkaTransactions<Integer> transaction;
+
+        Uni<Void> runConcurrentTransactions() {
+            // First transaction holds the only pooled producer with a delay
+            Uni<Void> tx1 = transaction.withTransaction(emitter -> {
+                emitter.send(1);
+                return Uni.createFrom().voidItem()
+                        .onItem().delayIt().by(Duration.ofSeconds(5));
+            });
+            // Second transaction should fail because pool is exhausted (max-pool-size=1)
+            Uni<Void> tx2 = transaction.withTransaction(emitter -> {
+                emitter.send(2);
+                return Uni.createFrom().voidItem();
+            });
+            return Uni.join().all(tx1, tx2).andCollectFailures().replaceWithVoid();
         }
     }
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/PerPartitionExactlyOnceProcessingTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/PerPartitionExactlyOnceProcessingTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.Uni;
@@ -36,6 +37,7 @@ import io.smallrye.reactive.messaging.kafka.KafkaClientService;
 import io.smallrye.reactive.messaging.kafka.KafkaProducer;
 import io.smallrye.reactive.messaging.kafka.KafkaRecord;
 import io.smallrye.reactive.messaging.kafka.KafkaRecordBatch;
+import io.smallrye.reactive.messaging.kafka.TestTags;
 import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordBatchMetadata;
 import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata;
 import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
@@ -173,7 +175,7 @@ public class PerPartitionExactlyOnceProcessingTest extends KafkaCompanionTestBas
                 .withOffsetReset(OffsetResetStrategy.EARLIEST)
                 .withProp(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
                 .fromTopics(outTopic, numberOfRecords)
-                .awaitCompletion(Duration.ofSeconds(20));
+                .awaitCompletion(Duration.ofSeconds(30));
 
         assertThat(records.getRecords())
                 .extracting(ConsumerRecord::value)
@@ -207,7 +209,7 @@ public class PerPartitionExactlyOnceProcessingTest extends KafkaCompanionTestBas
                 .withOffsetReset(OffsetResetStrategy.EARLIEST)
                 .withProp(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
                 .fromTopics(outTopic, numberOfRecords)
-                .awaitCompletion(Duration.ofSeconds(20));
+                .awaitCompletion(Duration.ofSeconds(30));
 
         assertThat(records.getRecords())
                 .extracting(ConsumerRecord::value)
@@ -430,6 +432,28 @@ public class PerPartitionExactlyOnceProcessingTest extends KafkaCompanionTestBas
     }
 
     @Test
+    @Tag(TestTags.SLOW)
+    void testPooledProducerRecoveryAfterBrokerTimeout() {
+        outTopic = companion.topics().createAndWait(topic, 1);
+        MapBasedConfig config = new MapBasedConfig(producerConfig()
+                .with("transaction.timeout.ms", 2000));
+        PooledTimeoutRecoveryApp app = runApplication(config, PooledTimeoutRecoveryApp.class);
+
+        // First transaction: broker times out and aborts, producer enters fatal error state
+        assertThatThrownBy(() -> app.produceSlowly(15_000).await().atMost(Duration.ofSeconds(30)))
+                .isNotNull();
+
+        // The broken producer should be evicted from the pool.
+        // A subsequent transaction should get a fresh producer and succeed.
+        app.produceQuickly(5).await().atMost(Duration.ofSeconds(30));
+
+        companion.consumeIntegers()
+                .withProp(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
+                .fromTopics(outTopic, 5)
+                .awaitCompletion(Duration.ofMinutes(1));
+    }
+
+    @Test
     void testPoolExhausted() {
         outTopic = companion.topics().createAndWait(topic, 3);
         // max-pool-size=1 means only one concurrent transaction is allowed
@@ -509,6 +533,31 @@ public class PerPartitionExactlyOnceProcessingTest extends KafkaCompanionTestBas
                 .with("max.poll.records", "100")
                 .with("auto.offset.reset", "earliest")
                 .with("value.deserializer", IntegerDeserializer.class.getName());
+    }
+
+    @ApplicationScoped
+    public static class PooledTimeoutRecoveryApp {
+
+        @Inject
+        @Channel("transactional-producer")
+        KafkaTransactions<Integer> transaction;
+
+        Uni<Void> produceSlowly(long delayMillis) {
+            return transaction.withTransaction(emitter -> {
+                emitter.send(KafkaRecord.of("key", 1));
+                return Uni.createFrom().voidItem()
+                        .onItem().delayIt().by(Duration.ofMillis(delayMillis));
+            });
+        }
+
+        Uni<Void> produceQuickly(int count) {
+            return transaction.withTransaction(emitter -> {
+                for (int i = 0; i < count; i++) {
+                    emitter.send(KafkaRecord.of("key", i));
+                }
+                return Uni.createFrom().voidItem();
+            });
+        }
     }
 
     @ApplicationScoped

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/TransactionalProducerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/TransactionalProducerTest.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.TransactionAbortedException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -22,12 +23,14 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.assertj.core.api.Assertions;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.kafka.KafkaRecord;
+import io.smallrye.reactive.messaging.kafka.TestTags;
 import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
 import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
 import io.smallrye.reactive.messaging.kafka.base.PerfTestUtils;
@@ -509,5 +512,150 @@ public class TransactionalProducerTest extends KafkaCompanionTestBase {
         public KafkaTransactions<byte[]> transaction() {
             return transaction;
         }
+    }
+
+    private KafkaMapBasedConfig shortTimeoutConfig() {
+        return config().put("transaction.timeout.ms", 2000);
+    }
+
+    @Test
+    @Tag(TestTags.SLOW)
+    void testTransactionTimedOutByBroker() {
+        topic = companion.topics().createAndWait(topic, 1);
+        SlowTransactionalProducer application = runApplication(shortTimeoutConfig(), SlowTransactionalProducer.class);
+
+        // Delay must exceed the broker's transaction abort cleanup interval (~10s)
+        // so the broker detects the timeout and aborts the transaction before commit.
+        assertThatThrownBy(() -> application.produceSlowly(15_000).await().atMost(Duration.ofSeconds(30)))
+                .hasRootCauseInstanceOf(KafkaException.class);
+        assertThat(application.transaction().isTransactionInProgress()).isFalse();
+
+        // No records should be visible to a read_committed consumer
+        companion.consumeIntegers()
+                .withProp(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
+                .fromTopics(topic, 1)
+                .awaitNoRecords(Duration.ofSeconds(3));
+    }
+
+    @Test
+    @Tag(TestTags.SLOW)
+    void testTransactionTimedOutByBrokerBlocking() {
+        topic = companion.topics().createAndWait(topic, 1);
+        SlowTransactionalProducer application = runApplication(shortTimeoutConfig(), SlowTransactionalProducer.class);
+
+        assertThatThrownBy(() -> application.produceSlowlyBlocking(15_000))
+                .hasRootCauseInstanceOf(KafkaException.class);
+        assertThat(application.transaction().isTransactionInProgress()).isFalse();
+
+        companion.consumeIntegers()
+                .withProp(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
+                .fromTopics(topic, 1)
+                .awaitNoRecords(Duration.ofSeconds(3));
+    }
+
+    @ApplicationScoped
+    public static class SlowTransactionalProducer {
+
+        @Inject
+        @Channel("transactional-producer")
+        KafkaTransactions<Integer> transaction;
+
+        Uni<Void> produceSlowly(long delayMillis) {
+            return transaction.withTransaction(emitter -> {
+                emitter.send(KafkaRecord.of("key", 1));
+                return Uni.createFrom().voidItem()
+                        .onItem().delayIt().by(Duration.ofMillis(delayMillis));
+            });
+        }
+
+        void produceSlowlyBlocking(long delayMillis) {
+            transaction.withTransactionAndAwait(emitter -> {
+                emitter.send(KafkaRecord.of("key", 1));
+                return Uni.createFrom().voidItem()
+                        .onItem().delayIt().by(Duration.ofMillis(delayMillis));
+            });
+        }
+
+        Uni<Void> produceQuickly(int count) {
+            return transaction.withTransaction(emitter -> {
+                for (int i = 0; i < count; i++) {
+                    emitter.send(KafkaRecord.of("key", i));
+                }
+                return Uni.createFrom().voidItem();
+            });
+        }
+
+        public KafkaTransactions<Integer> transaction() {
+            return transaction;
+        }
+    }
+
+    @Test
+    void testEmptyTransaction() {
+        topic = companion.topics().createAndWait(topic, 1);
+        EmptyTransactionalProducer application = runApplication(config(), EmptyTransactionalProducer.class);
+
+        // A transaction that does work but sends no records should commit successfully
+        String result = application.doWorkWithoutSending().await().atMost(Duration.ofSeconds(10));
+        assertThat(result).isEqualTo("done");
+        assertThat(application.transaction().isTransactionInProgress()).isFalse();
+
+        // No records should appear
+        companion.consumeIntegers()
+                .withProp(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
+                .fromTopics(topic, 1)
+                .awaitNoRecords(Duration.ofSeconds(3));
+    }
+
+    @Test
+    void testEmptyTransactionBlocking() {
+        topic = companion.topics().createAndWait(topic, 1);
+        EmptyTransactionalProducer application = runApplication(config(), EmptyTransactionalProducer.class);
+
+        String result = application.doWorkWithoutSendingBlocking();
+        assertThat(result).isEqualTo("done");
+        assertThat(application.transaction().isTransactionInProgress()).isFalse();
+    }
+
+    @ApplicationScoped
+    public static class EmptyTransactionalProducer {
+
+        @Inject
+        @Channel("transactional-producer")
+        KafkaTransactions<Integer> transaction;
+
+        Uni<String> doWorkWithoutSending() {
+            return transaction.withTransaction(emitter -> {
+                // Do some work but don't send any records
+                return Uni.createFrom().item("done");
+            });
+        }
+
+        String doWorkWithoutSendingBlocking() {
+            return transaction.withTransactionAndAwait(emitter -> {
+                return Uni.createFrom().item("done");
+            });
+        }
+
+        public KafkaTransactions<Integer> transaction() {
+            return transaction;
+        }
+    }
+
+    @Test
+    @Tag(TestTags.SLOW)
+    void testProducerNotReusableAfterBrokerTimeout() {
+        topic = companion.topics().createAndWait(topic, 1);
+        SlowTransactionalProducer application = runApplication(shortTimeoutConfig(), SlowTransactionalProducer.class);
+
+        // First transaction: times out, broker aborts it
+        assertThatThrownBy(() -> application.produceSlowly(15_000).await().atMost(Duration.ofSeconds(30)))
+                .hasRootCauseInstanceOf(KafkaException.class);
+        assertThat(application.transaction().isTransactionInProgress()).isFalse();
+
+        // After a broker-side timeout abort, the Kafka producer enters a permanent error state.
+        // Subsequent transactions on the same producer will fail.
+        assertThatThrownBy(() -> application.produceQuickly(5).await().atMost(Duration.ofSeconds(10)))
+                .isInstanceOf(KafkaException.class);
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/TransactionalProducerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/transactions/TransactionalProducerTest.java
@@ -14,6 +14,7 @@ import jakarta.inject.Inject;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.InvalidTxnStateException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.TransactionAbortedException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -527,7 +528,7 @@ public class TransactionalProducerTest extends KafkaCompanionTestBase {
         // Delay must exceed the broker's transaction abort cleanup interval (~10s)
         // so the broker detects the timeout and aborts the transaction before commit.
         assertThatThrownBy(() -> application.produceSlowly(15_000).await().atMost(Duration.ofSeconds(30)))
-                .hasRootCauseInstanceOf(KafkaException.class);
+                .isInstanceOf(InvalidTxnStateException.class);
         assertThat(application.transaction().isTransactionInProgress()).isFalse();
 
         // No records should be visible to a read_committed consumer
@@ -544,7 +545,7 @@ public class TransactionalProducerTest extends KafkaCompanionTestBase {
         SlowTransactionalProducer application = runApplication(shortTimeoutConfig(), SlowTransactionalProducer.class);
 
         assertThatThrownBy(() -> application.produceSlowlyBlocking(15_000))
-                .hasRootCauseInstanceOf(KafkaException.class);
+                .isInstanceOf(InvalidTxnStateException.class);
         assertThat(application.transaction().isTransactionInProgress()).isFalse();
 
         companion.consumeIntegers()
@@ -650,7 +651,7 @@ public class TransactionalProducerTest extends KafkaCompanionTestBase {
 
         // First transaction: times out, broker aborts it
         assertThatThrownBy(() -> application.produceSlowly(15_000).await().atMost(Duration.ofSeconds(30)))
-                .hasRootCauseInstanceOf(KafkaException.class);
+                .isInstanceOf(InvalidTxnStateException.class);
         assertThat(application.transaction().isTransactionInProgress()).isFalse();
 
         // After a broker-side timeout abort, the Kafka producer enters a permanent error state.


### PR DESCRIPTION
More tests for Kafka transactions and a workaround for timed-out transactional producers