### PR TITLE
Fix some Kafka flaky tests

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -162,7 +162,11 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
 
         if (!result.getItem1().isEmpty()) {
             // We are on the polling thread, we can use synchronous (blocking) commit
-            consumer.unwrap().commitSync(result.getItem1());
+            try {
+                consumer.unwrap().commitSync(result.getItem1());
+            } catch (Exception e) {
+                log.failedToCommit(result.getItem1(), e);
+            }
         }
 
         if (result.getItem2()) {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/health/ShareGroupSourceHealthCheckTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/health/ShareGroupSourceHealthCheckTest.java
@@ -92,6 +92,9 @@ public class ShareGroupSourceHealthCheckTest extends KafkaCompanionTestBase {
 
         await().until(() -> isStarted() && isReady() && isAlive());
 
+        companion.consumerGroups().waitForShareGroupAssignment(groupId)
+                .await().atMost(Duration.ofSeconds(20));
+
         companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, "key", i), 10);
 
         await().until(() -> received.size() >= 10);
@@ -122,6 +125,9 @@ public class ShareGroupSourceHealthCheckTest extends KafkaCompanionTestBase {
         channel.subscribe().with(received::add);
 
         await().until(() -> isStarted() && isReady() && isAlive());
+
+        companion.consumerGroups().waitForShareGroupAssignment(groupId)
+                .await().atMost(Duration.ofSeconds(20));
 
         companion.produceIntegers().usingGenerator(i -> new ProducerRecord<>(topic, "key", i), 10);
 

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/queues/SharedGroupConsumerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/queues/SharedGroupConsumerTest.java
@@ -70,8 +70,9 @@ public class SharedGroupConsumerTest extends KafkaCompanionTestBase {
     @Test
     public void testShareGroupSourceThroughConnector() {
         companion.topics().createAndWait(topic, 1);
+        String connectorGroupId = "share-group-connector-test-" + topic;
         KafkaMapBasedConfig config = kafkaConfig("mp.messaging.incoming.data")
-                .with("group.id", "share-group-connector-test-" + topic)
+                .with("group.id", connectorGroupId)
                 .with("value.deserializer", IntegerDeserializer.class.getName())
                 .with("topic", topic)
                 //                .with("max.poll.records", 40)
@@ -83,6 +84,9 @@ public class SharedGroupConsumerTest extends KafkaCompanionTestBase {
         runApplication(config, ShareGroupConsumerApp.class);
 
         await().until(this::isReady);
+
+        companion.consumerGroups().waitForShareGroupAssignment(connectorGroupId)
+                .await().atMost(Duration.ofSeconds(20));
 
         companion.produceIntegers()
                 .usingGenerator(i -> new ProducerRecord<>(topic, "" + i % 2, i), 50)
@@ -158,6 +162,9 @@ public class SharedGroupConsumerTest extends KafkaCompanionTestBase {
         app.subscribe();
 
         await().until(this::isReady);
+
+        companion.consumerGroups().waitForShareGroupAssignment(groupId)
+                .await().atMost(Duration.ofSeconds(20));
 
         companion.produceIntegers()
                 .usingGenerator(i -> new ProducerRecord<>(topic, "" + i % 2, i), 10)


### PR DESCRIPTION
- ShareGroupSourceHealthCheckTest
- SharedGroupConsumerTest
- PartitionsRevoked callback guard against commitSync failure for failures in BrokerRestartTest