### PR TITLE
Fixes on Request/Reply for Kafka, AMQP and RabbitMQ

### DIFF
--- a/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/reply/AmqpRequestReplyImpl.java
+++ b/smallrye-reactive-messaging-amqp/src/main/java/io/smallrye/reactive/messaging/amqp/reply/AmqpRequestReplyImpl.java
@@ -32,6 +32,8 @@ import io.smallrye.reactive.messaging.providers.helpers.CDIUtils;
 import io.smallrye.reactive.messaging.providers.impl.Configs;
 import io.smallrye.reactive.messaging.providers.impl.OverrideConfig;
 import io.smallrye.reactive.messaging.providers.locals.ContextAwareMessage;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
 
 @Experimental("Experimental API")
 public class AmqpRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
@@ -128,6 +130,8 @@ public class AmqpRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
                 : replyToAddress;
         builder.withMessageId(correlationId.toString()).withReplyTo(replyTo);
         OutgoingAmqpMetadata outMetadata = builder.build();
+        // capture the caller context and emit replies on the same context
+        Context callerCtx = Vertx.currentContext();
         // Register pending reply before sending to avoid race where a fast reply
         // arrives before the pending reply is registered and gets silently dropped
         return Multi.createFrom().<Message<Rep>> emitter(emitter -> {
@@ -135,13 +139,9 @@ public class AmqpRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
                     new PendingReplyImpl<>(outMetadata,
                             (MultiEmitter<Message<Rep>>) emitter));
             sendMessage(request.addMetadata(outMetadata))
-                    .subscribe().with(
-                            unused -> subscription.get().request(1),
-                            failure -> {
-                                pendingReplies.remove(correlationId);
-                                emitter.fail(failure);
-                            });
+                    .subscribe().with(unused -> subscription.get().request(1), emitter::fail);
         })
+                .plug(m -> callerCtx != null ? m.emitOn(callerCtx::runOnContext) : m)
                 .ifNoItem().after(replyTimeout)
                 .failWith(() -> new AmqpRequestReplyTimeoutException(correlationId))
                 .onItem().transformToUniAndConcatenate(m -> {

--- a/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/reply/AmqpRequestReplyEmitterTest.java
+++ b/smallrye-reactive-messaging-amqp/src/test/java/io/smallrye/reactive/messaging/amqp/reply/AmqpRequestReplyEmitterTest.java
@@ -8,6 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -33,6 +36,8 @@ import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 import io.smallrye.reactive.messaging.test.common.config.SmallRyeConfigTestUtil;
 import io.vertx.mutiny.amqp.AmqpMessage;
 import io.vertx.mutiny.amqp.AmqpReceiver;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
 
 public class AmqpRequestReplyEmitterTest extends AmqpBrokerTestBase {
 
@@ -121,6 +126,39 @@ public class AmqpRequestReplyEmitterTest extends AmqpBrokerTestBase {
                 .untilAsserted(() -> assertThat(replies).hasSize(10));
         assertThat(replies).containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
         assertThat(producer.requestReply().getPendingReplies()).isEmpty();
+    }
+
+    @Test
+    public void testReplyCallerContextPropagation() throws InterruptedException {
+        startReplyServer();
+
+        Weld weld = new Weld();
+        weld.addBeanClasses(RequestReplyProducer.class);
+        config().write();
+        container = initializeContainer(weld);
+
+        RequestReplyProducer producer = container.getBeanManager().createInstance()
+                .select(RequestReplyProducer.class).get();
+        await().until(() -> isAmqpConnectorReady(container));
+
+        AtomicReference<Context> replyContext = new AtomicReference<>();
+        AtomicReference<String> replyLocalValue = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        String expectedValue = "test-context-value";
+
+        executionHolder.vertx().getDelegate().getOrCreateContext().runOnContext(v -> {
+            Vertx.currentContext().putLocal("test-key", expectedValue);
+            producer.requestReply().request(42)
+                    .subscribe().with(reply -> {
+                        replyContext.set(Vertx.currentContext());
+                        replyLocalValue.set(Vertx.currentContext().getLocal("test-key"));
+                        latch.countDown();
+                    });
+        });
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(replyLocalValue.get()).isEqualTo(expectedValue);
+        assertThat(replyContext.get()).isNotNull();
     }
 
     @Test

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyImpl.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyImpl.java
@@ -53,6 +53,7 @@ import io.smallrye.reactive.messaging.providers.extension.MutinyEmitterImpl;
 import io.smallrye.reactive.messaging.providers.helpers.CDIUtils;
 import io.smallrye.reactive.messaging.providers.impl.Configs;
 import io.smallrye.reactive.messaging.providers.locals.ContextAwareMessage;
+import io.vertx.mutiny.core.Context;
 import io.vertx.mutiny.core.Vertx;
 
 @TechPreview("Tech Preview API")
@@ -227,16 +228,20 @@ public class KafkaRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
             builder.addHeaders(new RecordHeader(replyPartitionHeader, partition));
         }
         OutgoingMessageMetadata<RecordMetadata> outMetadata = new OutgoingMessageMetadata<>();
-        return sendMessage(request.addMetadata(builder.build()).addMetadata(outMetadata))
-                .invoke(() -> subscription.get().request(1))
-                .onItem()
-                .transformToMulti(unused -> Multi.createFrom().<Message<Rep>> emitter(emitter -> {
-                    pendingReplies.put(correlationId,
-                            new PendingReplyImpl<>(outMetadata.getResult(),
-                                    replyTopic,
-                                    replyPartition,
-                                    (MultiEmitter<Message<Rep>>) emitter));
-                }))
+        // capture the caller context and emit replies on the same context
+        Context callerCtx = Vertx.currentContext();
+        // Register pending reply before sending to avoid race where a fast reply
+        // arrives before the pending reply is registered and gets silently dropped
+        return Multi.createFrom().<Message<Rep>> emitter(emitter -> {
+            pendingReplies.put(correlationId,
+                    new PendingReplyImpl<>(outMetadata.getResult(),
+                            replyTopic,
+                            replyPartition,
+                            (MultiEmitter<Message<Rep>>) emitter));
+            sendMessage(request.addMetadata(builder.build()).addMetadata(outMetadata))
+                    .subscribe().with(unused -> subscription.get().request(1), emitter::fail);
+        })
+                .plug(m -> callerCtx != null ? m.emitOn(callerCtx::runOnContext) : m)
                 .ifNoItem().after(replyTimeout).failWith(() -> new KafkaRequestReplyTimeoutException(correlationId))
                 .onItem().transformToUniAndConcatenate(m -> {
                     if (replyFailureHandler != null) {

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/reply/KafkaRequestReplyTest.java
@@ -10,6 +10,9 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -47,6 +50,8 @@ import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
 import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
 import io.smallrye.reactive.messaging.kafka.converters.ConsumerRecordConverter;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
 
 public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
 
@@ -94,6 +99,35 @@ public class KafkaRequestReplyTest extends KafkaCompanionTestBase {
         assertThat(companion.consumeStrings().fromTopics(replyTopic, 10).awaitCompletion())
                 .extracting(ConsumerRecord::value).containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
         assertThat(app.requestReply().getPendingReplies()).isEmpty();
+    }
+
+    @Test
+    void testReplyCallerContextPropagation() throws InterruptedException {
+        addBeans(ReplyServer.class);
+        topic = companion.topics().createAndWait(topic, 3);
+        String replyTopic = topic + "-replies";
+        companion.topics().createAndWait(replyTopic, 3);
+
+        RequestReplyProducer app = runApplication(config(), RequestReplyProducer.class);
+
+        AtomicReference<Context> replyContext = new AtomicReference<>();
+        AtomicReference<String> replyLocalValue = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        String expectedValue = "test-context-value";
+
+        vertx.getDelegate().getOrCreateContext().runOnContext(v -> {
+            Vertx.currentContext().putLocal("test-key", expectedValue);
+            app.requestReply().request(42)
+                    .subscribe().with(reply -> {
+                        replyContext.set(Vertx.currentContext());
+                        replyLocalValue.set(Vertx.currentContext().getLocal("test-key"));
+                        latch.countDown();
+                    });
+        });
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(replyLocalValue.get()).isEqualTo(expectedValue);
+        assertThat(replyContext.get()).isNotNull();
     }
 
     @Test

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/reply/RabbitMQRequestReplyImpl.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/reply/RabbitMQRequestReplyImpl.java
@@ -32,6 +32,8 @@ import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
 import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorCommonConfiguration;
 import io.smallrye.reactive.messaging.rabbitmq.internals.RabbitMQClientHelper;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
 
 @Experimental("Experimental API")
 public class RabbitMQRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
@@ -124,14 +126,18 @@ public class RabbitMQRequestReplyImpl<Req, Rep> extends MutinyEmitterImpl<Req>
         CorrelationId correlationId = correlationIdHandler.generate(request);
         builder.withCorrelationId(correlationId.toString()).withReplyTo(REPLY_TO);
         OutgoingRabbitMQMetadata outMetadata = builder.build();
-        return sendMessage(request.addMetadata(outMetadata))
-                .invoke(() -> subscription.get().request(1))
-                .onItem()
-                .transformToMulti(unused -> Multi.createFrom().<Message<Rep>> emitter(emitter -> {
-                    pendingReplies.put(correlationId,
-                            new PendingReplyImpl<>(outMetadata,
-                                    (MultiEmitter<Message<Rep>>) emitter));
-                }))
+        // capture the caller context and emit replies on the same context
+        Context callerCtx = Vertx.currentContext();
+        // Register pending reply before sending to avoid race where a fast reply
+        // arrives before the pending reply is registered and gets silently dropped
+        return Multi.createFrom().<Message<Rep>> emitter(emitter -> {
+            pendingReplies.put(correlationId,
+                    new PendingReplyImpl<>(outMetadata,
+                            (MultiEmitter<Message<Rep>>) emitter));
+            sendMessage(request.addMetadata(outMetadata))
+                    .subscribe().with(unused -> subscription.get().request(1), emitter::fail);
+        })
+                .plug(m -> callerCtx != null ? m.emitOn(callerCtx::runOnContext) : m)
                 .ifNoItem().after(replyTimeout)
                 .failWith(() -> new RabbitMQRequestReplyTimeoutException(correlationId))
                 .onItem().transformToUniAndConcatenate(m -> {

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/reply/RabbitMQRequestReplyTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/reply/RabbitMQRequestReplyTest.java
@@ -9,6 +9,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -28,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.smallrye.reactive.messaging.providers.connectors.ExecutionHolder;
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage;
 import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata;
 import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata.Builder;
@@ -36,6 +40,8 @@ import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnector;
 import io.smallrye.reactive.messaging.rabbitmq.converter.ByteArrayMessageConverter;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 import io.smallrye.reactive.messaging.test.common.config.SmallRyeConfigTestUtil;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
 
 class RabbitMQRequestReplyTest extends RabbitMQBrokerTestBase {
 
@@ -90,6 +96,41 @@ class RabbitMQRequestReplyTest extends RabbitMQBrokerTestBase {
         await().atMost(java.time.Duration.ofSeconds(5)).untilAsserted(() -> assertThat(replies).hasSize(10));
         assertThat(replies).containsExactlyInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
         assertThat(producer.requestReply().getPendingReplies()).isEmpty();
+    }
+
+    @Test
+    public void testReplyCallerContextPropagation() throws InterruptedException {
+        String exchange = "test-exchange";
+        String requestAddress = "requests";
+        weld.addBeanClasses(RequestReplyProducer.class, ReplyServer.class);
+        config(exchange, requestAddress).write();
+        SmallRyeConfigTestUtil.installConfig();
+        container = weld.initialize();
+
+        RequestReplyProducer producer = container.getBeanManager().createInstance()
+                .select(RequestReplyProducer.class).get();
+        await().until(() -> isRabbitMQConnectorAvailable(container));
+
+        AtomicReference<Context> replyContext = new AtomicReference<>();
+        AtomicReference<String> replyLocalValue = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        String expectedValue = "test-context-value";
+
+        ExecutionHolder executionHolder = container.getBeanManager()
+                .createInstance().select(ExecutionHolder.class).get();
+        executionHolder.vertx().getDelegate().getOrCreateContext().runOnContext(v -> {
+            Vertx.currentContext().putLocal("test-key", expectedValue);
+            producer.requestReply().request(42)
+                    .subscribe().with(reply -> {
+                        replyContext.set(Vertx.currentContext());
+                        replyLocalValue.set(Vertx.currentContext().getLocal("test-key"));
+                        latch.countDown();
+                    });
+        });
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(replyLocalValue.get()).isEqualTo(expectedValue);
+        assertThat(replyContext.get()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
Capture the caller's Vert.x duplicated context and dispatch replies on it, so that context locals (e.g. OTel tracing context) are available when chaining operations after receiving a reply.

Also, apply the same pattern used in AMQP, that is, registering a pending reply _before_ sending the message. This avoids race conditions between send confirm and pending reply.