### PR TITLE
Kafka handle position and commit offset on seek operations

### DIFF
--- a/api/src/main/java/io/smallrye/reactive/messaging/PausableChannel.java
+++ b/api/src/main/java/io/smallrye/reactive/messaging/PausableChannel.java
@@ -21,4 +21,11 @@ public interface PausableChannel {
      * Resumes the channel.
      */
     void resume();
+
+    /**
+     * Clears the buffer of the channel, discarding any items that have been
+     * requested from upstream but not yet delivered to the consumer.
+     */
+    default void clearBuffer() {
+    }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/KafkaConsumerRebalanceListener.java
@@ -142,4 +142,23 @@ public interface KafkaConsumerRebalanceListener {
         onPartitionsRevoked(consumer, partitions);
     }
 
+    /**
+     * Called after the consumer position is explicitly changed via seek operations
+     * ({@link Consumer#seek}, {@link Consumer#seekToBeginning}, {@link Consumer#seekToEnd}).
+     * <p>
+     * This callback is invoked after the seek has taken effect. Calling
+     * {@link Consumer#position(org.apache.kafka.common.TopicPartition)} on the provided consumer
+     * will return the new position.
+     * <p>
+     * This allows listeners to reset any per-partition state that depends on the consumer's position.
+     * <p>
+     * <strong>IMPORTANT</strong>: The behavior must be blocking. Callback invoked from the polling thread.
+     *
+     * @param consumer the underlying Kafka consumer
+     * @param partitions the partitions that were seeked
+     */
+    default void onPartitionsSeeked(Consumer<?, ?> consumer, Collection<org.apache.kafka.common.TopicPartition> partitions) {
+
+    }
+
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
@@ -95,6 +95,16 @@ public interface KafkaCommitHandler {
     }
 
     /**
+     * Called when the consumer position is explicitly changed via seek operations,
+     * allowing handlers to reset per-partition tracking state.
+     *
+     * @param partitions seeked partitions
+     */
+    default void partitionsSeeked(Collection<TopicPartition> partitions) {
+        // Do nothing by default.
+    }
+
+    /**
      * Handle message acknowledgment
      *
      * @param record incoming Kafka record

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.kafka.commit;
 
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -34,7 +35,7 @@ import io.vertx.mutiny.core.Vertx;
  */
 public class KafkaLatestCommit extends ContextHolder implements KafkaCommitHandler {
 
-    private KafkaConsumer<?, ?> consumer;
+    private final KafkaConsumer<?, ?> consumer;
 
     /**
      * Stores the last offset for each topic/partition.
@@ -61,6 +62,16 @@ public class KafkaLatestCommit extends ContextHolder implements KafkaCommitHandl
         super(vertx, configuration.config()
                 .getOptionalValue(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, Integer.class).orElse(60000));
         this.consumer = consumer;
+    }
+
+    @Override
+    public void partitionsRevoked(Collection<TopicPartition> partitions) {
+        runOnContextAndAwait(() -> {
+            for (TopicPartition partition : partitions) {
+                offsets.remove(partition);
+            }
+            return null;
+        });
     }
 
     @Override

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
@@ -75,6 +75,11 @@ public class KafkaLatestCommit extends ContextHolder implements KafkaCommitHandl
     }
 
     @Override
+    public void partitionsSeeked(Collection<TopicPartition> partitions) {
+        partitionsRevoked(partitions);
+    }
+
+    @Override
     public <K, V> Uni<Void> handle(IncomingKafkaRecord<K, V> record) {
         runOnContext(() -> {
             Map<TopicPartition, OffsetAndMetadata> map = new HashMap<>();

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -56,6 +56,7 @@ import io.vertx.mutiny.core.Vertx;
 public class KafkaThrottledLatestProcessedCommit extends ContextHolder implements KafkaCommitHandler {
 
     private final Map<TopicPartition, OffsetStore> offsetStores = new HashMap<>();
+    private final Set<TopicPartition> seekedPartitions = new HashSet<>();
 
     private final String groupId;
     private final KafkaConsumer<?, ?> consumer;
@@ -146,6 +147,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
             Map<TopicPartition, OffsetAndMetadata> toCommit = new HashMap<>();
             for (TopicPartition partition : new HashSet<>(offsetStores.keySet())) {
                 if (!assignments.contains(partition)) { // revoked partition - remove and compute last commit
+                    seekedPartitions.remove(partition);
                     OffsetStore store = offsetStores.remove(partition);
                     if (store != null) {
 
@@ -172,6 +174,17 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
         if (result.getItem2()) {
             runOnContext(this::startFlushAndCheckHealthTimer);
         }
+    }
+
+    @Override
+    public void partitionsSeeked(Collection<TopicPartition> partitions) {
+        runOnContextAndAwait(() -> {
+            for (TopicPartition partition : partitions) {
+                offsetStores.remove(partition);
+                seekedPartitions.add(partition);
+            }
+            return null;
+        });
     }
 
     /**
@@ -209,15 +222,23 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
         OffsetStore offsetStore = offsetStores.get(recordsTopicPartition);
         Uni<OffsetStore> uni;
         if (offsetStore == null) {
-            uni = consumer.committed(recordsTopicPartition)
-                    .emitOn(this::runOnContext) // Switch back to event loop
-                    .onItem().transform(offsets -> {
-                        OffsetAndMetadata lastCommitted = offsets.get(recordsTopicPartition);
-                        OffsetStore store = new OffsetStore(recordsTopicPartition, unprocessedRecordMaxAge,
-                                lastCommitted == null ? -1 : lastCommitted.offset() - 1);
-                        offsetStores.put(recordsTopicPartition, store);
-                        return store;
-                    });
+            if (seekedPartitions.remove(recordsTopicPartition)) {
+                uni = Uni.createFrom().item(() -> {
+                    OffsetStore store = new OffsetStore(recordsTopicPartition, unprocessedRecordMaxAge, -1);
+                    offsetStores.put(recordsTopicPartition, store);
+                    return store;
+                }).emitOn(this::runOnContext);
+            } else {
+                uni = consumer.committed(recordsTopicPartition)
+                        .emitOn(this::runOnContext) // Switch back to event loop
+                        .onItem().transform(offsets -> {
+                            OffsetAndMetadata lastCommitted = offsets.get(recordsTopicPartition);
+                            OffsetStore store = new OffsetStore(recordsTopicPartition, unprocessedRecordMaxAge,
+                                    lastCommitted == null ? -1 : lastCommitted.offset() - 1);
+                            offsetStores.put(recordsTopicPartition, store);
+                            return store;
+                        });
+            }
         } else {
             uni = Uni.createFrom().item(offsetStore);
         }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -231,6 +231,7 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
             } else {
                 uni = consumer.committed(recordsTopicPartition)
                         .emitOn(this::runOnContext) // Switch back to event loop
+                        .onFailure().recoverWithItem(Collections::emptyMap)
                         .onItem().transform(offsets -> {
                             OffsetAndMetadata lastCommitted = offsets.get(recordsTopicPartition);
                             OffsetStore store = new OffsetStore(recordsTopicPartition, unprocessedRecordMaxAge,

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/OrderedStreamHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/OrderedStreamHandler.java
@@ -154,6 +154,11 @@ public class OrderedStreamHandler extends ContextHolder implements KafkaCommitHa
         delegate.partitionsRevoked(partitions);
     }
 
+    @Override
+    public void partitionsSeeked(Collection<TopicPartition> partitions) {
+        delegate.partitionsSeeked(partitions);
+    }
+
     /**
      * Returns the underlying commit handler.
      */

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
@@ -52,7 +52,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     private final RuntimeKafkaSourceConfiguration configuration;
     private final Duration pollTimeout;
     private final String consumerGroup;
-    private ConsumerRebalanceListener rebalanceListener;
+    private RebalanceListeners.WrappedConsumerRebalanceListener rebalanceListener;
 
     private final AtomicBoolean paused = new AtomicBoolean();
 
@@ -370,6 +370,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
                 c.seekToBeginning(Collections.singleton(tp));
             }
         }
+        notifyCommitHandlerOfSeek(partitions);
         removeFromQueueRecordsFromTopicPartitions(partitions);
         c.resume(partitions);
     }
@@ -559,6 +560,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     public Uni<Void> seek(TopicPartition partition, long offset) {
         return runOnPollingThread(c -> {
             c.seek(partition, offset);
+            notifyCommitHandlerOfSeek(Collections.singleton(partition));
         });
     }
 
@@ -567,6 +569,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     public Uni<Void> seek(TopicPartition partition, OffsetAndMetadata offsetAndMetadata) {
         return runOnPollingThread(c -> {
             c.seek(partition, offsetAndMetadata);
+            notifyCommitHandlerOfSeek(Collections.singleton(partition));
         });
     }
 
@@ -575,6 +578,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     public Uni<Void> seekToBeginning(Collection<TopicPartition> partitions) {
         return runOnPollingThread(c -> {
             c.seekToBeginning(partitions);
+            notifyCommitHandlerOfSeek(partitions.isEmpty() ? c.assignment() : partitions);
         });
     }
 
@@ -583,7 +587,14 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     public Uni<Void> seekToEnd(Collection<TopicPartition> partitions) {
         return runOnPollingThread(c -> {
             c.seekToEnd(partitions);
+            notifyCommitHandlerOfSeek(partitions.isEmpty() ? c.assignment() : partitions);
         });
+    }
+
+    private void notifyCommitHandlerOfSeek(Collection<TopicPartition> partitions) {
+        if (rebalanceListener != null) {
+            rebalanceListener.onPartitionsSeeked(partitions);
+        }
     }
 
     @Override

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/RebalanceListeners.java
@@ -19,7 +19,7 @@ import io.smallrye.reactive.messaging.providers.i18n.ProviderLogging;
 
 public class RebalanceListeners {
 
-    static ConsumerRebalanceListener createRebalanceListener(
+    static WrappedConsumerRebalanceListener createRebalanceListener(
             ReactiveKafkaConsumer<?, ?> reactiveKafkaConsumer,
             String consumerGroup,
             KafkaConsumerRebalanceListener listener,
@@ -76,6 +76,14 @@ public class RebalanceListeners {
             } catch (RuntimeException e) {
                 log.reEnablingConsumerForGroup(consumerGroup);
                 throw e;
+            }
+        }
+
+        public void onPartitionsSeeked(Collection<TopicPartition> partitions) {
+            reactiveKafkaConsumer.removeFromQueueRecordsFromTopicPartitions(partitions);
+            commitHandler.partitionsSeeked(partitions);
+            if (listener != null) {
+                listener.onPartitionsSeeked(reactiveKafkaConsumer.unwrap(), partitions);
             }
         }
     }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -226,6 +226,114 @@ public class CommitStrategiesTest extends WeldTestBase {
     }
 
     @Test
+    void testLatestCommitStrategyWithSeek() {
+        String group = UUID.randomUUID().toString();
+        MapBasedConfig config = commonConfiguration()
+                .with("commit-strategy", "latest")
+                .with("lazy-client", true)
+                .with("client.id", UUID.randomUUID().toString());
+        source = createSource(group, config);
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getStream().subscribe().with(list::add);
+
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        Map<TopicPartition, Long> beginning = new HashMap<>();
+        beginning.put(tp0, 0L);
+        consumer.updateBeginningOffsets(beginning);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(tp0));
+            for (int i = 0; i < 5; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k", "v-" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 5);
+        list.forEach(m -> m.ack().toCompletableFuture().join());
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp0));
+            assertThat(committed.get(tp0).offset()).isEqualTo(5);
+        });
+
+        // Simulate seek via partitionsSeeked (as called by ReactiveKafkaConsumer.seek)
+        source.getCommitHandler().partitionsSeeked(Collections.singletonList(tp0));
+        consumer.schedulePollTask(() -> {
+            consumer.seek(tp0, 0);
+            for (int i = 0; i < 3; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k", "v-seek-" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 8);
+        for (int i = 5; i < 8; i++) {
+            list.get(i).ack().toCompletableFuture().join();
+        }
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp0));
+            assertThat(committed.get(tp0).offset()).isEqualTo(3);
+        });
+    }
+
+    @Test
+    void testThrottledStrategyWithSeek() {
+        MapBasedConfig config = commonConfiguration()
+                .with("lazy-client", true)
+                .with("commit-strategy", "throttled")
+                .with("auto.commit.interval.ms", 100);
+        String group = UUID.randomUUID().toString();
+        source = createSource(group, config);
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getStream().subscribe().with(list::add);
+
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        consumer.updateBeginningOffsets(Collections.singletonMap(tp0, 0L));
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(tp0));
+            source.getCommitHandler().partitionsAssigned(Collections.singletonList(tp0));
+            for (int i = 0; i < 5; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k", "v-" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 5);
+        list.forEach(m -> m.ack().toCompletableFuture().join());
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp0));
+            assertThat(committed.get(tp0)).isNotNull();
+            assertThat(committed.get(tp0).offset()).isEqualTo(5);
+        });
+
+        // Simulate seek via partitionsSeeked — must reset the OffsetStore
+        // so that records below the old lastProcessedOffset are tracked
+        source.getCommitHandler().partitionsSeeked(Collections.singletonList(tp0));
+        consumer.schedulePollTask(() -> {
+            consumer.seek(tp0, 0);
+            for (int i = 0; i < 3; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k", "v-seek-" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 8);
+        for (int i = 5; i < 8; i++) {
+            list.get(i).ack().toCompletableFuture().join();
+        }
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp0));
+            assertThat(committed.get(tp0)).isNotNull();
+            assertThat(committed.get(tp0).offset()).isEqualTo(3);
+        });
+    }
+
+    @Test
     void testThrottledStrategy() {
         MapBasedConfig config = commonConfiguration()
                 .with("lazy-client", true)

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -158,6 +158,74 @@ public class CommitStrategiesTest extends WeldTestBase {
     }
 
     @Test
+    void testLatestCommitStrategyWithPartitionsRevoked() {
+        String group = UUID.randomUUID().toString();
+        MapBasedConfig config = commonConfiguration()
+                .with("commit-strategy", "latest")
+                .with("lazy-client", true)
+                .with("client.id", UUID.randomUUID().toString());
+        source = createSource(group, config);
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getStream().subscribe().with(list::add);
+
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp1 = new TopicPartition(TOPIC, 1);
+        Map<TopicPartition, Long> beginning = new HashMap<>();
+        beginning.put(tp0, 0L);
+        beginning.put(tp1, 0L);
+        consumer.updateBeginningOffsets(beginning);
+
+        // Assign both partitions, process records on each
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Arrays.asList(tp0, tp1));
+            for (int i = 0; i < 5; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k", "v0-" + i));
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 1, i, "k", "v1-" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 10);
+        list.forEach(m -> m.ack().toCompletableFuture().join());
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer
+                    .committed(new HashSet<>(Arrays.asList(tp0, tp1)));
+            assertThat(committed.get(tp0).offset()).isEqualTo(5);
+            assertThat(committed.get(tp1).offset()).isEqualTo(5);
+        });
+
+        // Simulate partition revoke/re-assign: clear the commit handler's offsets map
+        // for tp1, then seek tp1 back to simulate resuming from a lower offset
+        // (e.g. after a consumer group offset reset or another consumer that committed
+        // a lower offset while it owned the partition).
+        source.getCommitHandler().partitionsRevoked(Collections.singletonList(tp1));
+        consumer.schedulePollTask(() -> {
+            consumer.seek(tp1, 0);
+            for (int i = 0; i < 3; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 1, i, "k", "v1-replay-" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 13);
+        for (int i = 10; i < 13; i++) {
+            list.get(i).ack().toCompletableFuture().join();
+        }
+
+        // With partitionsRevoked clearing the offsets map, the replayed records
+        // at offsets 0-2 trigger new commits and committed offset becomes 3.
+        // Without the fix, the stale offset (5) causes record.offset+1 <= 5
+        // for all replayed records, so no commits occur and offset stays at 5.
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer
+                    .committed(new HashSet<>(Arrays.asList(tp0, tp1)));
+            assertThat(committed.get(tp0).offset()).isEqualTo(5);
+            assertThat(committed.get(tp1).offset()).isEqualTo(3);
+        });
+    }
+
+    @Test
     void testThrottledStrategy() {
         MapBasedConfig config = commonConfiguration()
                 .with("lazy-client", true)

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/ConsumerSeekTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/ConsumerSeekTest.java
@@ -1,0 +1,287 @@
+package io.smallrye.reactive.messaging.kafka.commit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.common.annotation.Identifier;
+import io.smallrye.reactive.messaging.PausableChannel;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import io.smallrye.reactive.messaging.kafka.KafkaClientService;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
+import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
+import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
+
+public class ConsumerSeekTest extends KafkaCompanionTestBase {
+
+    private KafkaMapBasedConfig commonConfig(String group, String commitStrategy) {
+        KafkaMapBasedConfig config = kafkaConfig("mp.messaging.incoming.data");
+        config.put("group.id", group);
+        config.put("topic", topic);
+        config.put("value.deserializer", IntegerDeserializer.class.getName());
+        config.put("enable.auto.commit", "false");
+        config.put("auto.offset.reset", "earliest");
+        config.put("commit-strategy", commitStrategy);
+        config.put("pausable", true);
+        config.put("consumer-rebalance-listener.name", "seek-listener");
+        if ("throttled".equals(commitStrategy)) {
+            config.put("auto.commit.interval.ms", 100);
+        }
+        return config;
+    }
+
+    @Test
+    public void testSeekToBeginningWithLatestStrategy() {
+        String group = "test-seek-pausable-latest";
+
+        addBeans(SeekConsumerBean.class, SeekRebalanceListener.class);
+        runApplication(commonConfig(group, "latest"));
+
+        SeekConsumerBean bean = get(SeekConsumerBean.class);
+        SeekRebalanceListener listener = getBeanManager().createInstance()
+                .select(SeekRebalanceListener.class)
+                .select(Identifier.Literal.of("seek-listener"))
+                .get();
+
+        TopicPartition tp = new TopicPartition(topic, 0);
+
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, i), 10);
+
+        await().atMost(30, TimeUnit.SECONDS).until(() -> bean.getCount() >= 10);
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        bean.seekToBeginning(Collections.singleton(tp));
+
+        assertThat(listener.getSeekedPartitions()).contains(tp);
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .until(() -> bean.getCount() >= 20);
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, 10 + i), 10);
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(20L, offset.offset());
+                });
+    }
+
+    @Test
+    public void testSeekWithThrottledStrategy() {
+        String group = "test-seek-pausable-throttled";
+
+        addBeans(SeekConsumerBean.class, SeekRebalanceListener.class);
+        runApplication(commonConfig(group, "throttled"));
+
+        SeekConsumerBean bean = get(SeekConsumerBean.class);
+        SeekRebalanceListener listener = getBeanManager().createInstance()
+                .select(SeekRebalanceListener.class)
+                .select(Identifier.Literal.of("seek-listener"))
+                .get();
+
+        TopicPartition tp = new TopicPartition(topic, 0);
+
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, i), 10);
+
+        await().atMost(30, TimeUnit.SECONDS).until(() -> bean.getCount() >= 10);
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        bean.seekToBeginning(Collections.singleton(tp));
+
+        assertThat(listener.getSeekedPartitions()).contains(tp);
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .until(() -> bean.getCount() >= 20);
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, 10 + i), 10);
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(20L, offset.offset());
+                });
+    }
+
+    @Test
+    public void testSeekToBeginningWithOffsetResetInListener() {
+        String group = "test-seek-with-offset-reset";
+
+        addBeans(SeekConsumerBean.class, SeekAndResetOffsetListener.class);
+
+        KafkaMapBasedConfig config = kafkaConfig("mp.messaging.incoming.data");
+        config.put("group.id", group);
+        config.put("topic", topic);
+        config.put("value.deserializer", IntegerDeserializer.class.getName());
+        config.put("enable.auto.commit", "false");
+        config.put("auto.offset.reset", "earliest");
+        config.put("commit-strategy", "latest");
+        config.put("pausable", true);
+        config.put("consumer-rebalance-listener.name", "seek-and-reset-listener");
+
+        runApplication(config);
+
+        SeekConsumerBean bean = get(SeekConsumerBean.class);
+
+        TopicPartition tp = new TopicPartition(topic, 0);
+
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, i), 10);
+
+        await().atMost(30, TimeUnit.SECONDS).until(() -> bean.getCount() >= 10);
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        int countBeforeSeek = bean.getCount();
+
+        // The listener resets the committed offset to the seeked position
+        // in onPartitionsSeeked, so replayed records MUST be re-committed.
+        // Without partitionsSeeked clearing the commit handler state,
+        // the stale offset (10) would block all commits for records 0-9,
+        // and the committed offset would stay at 0.
+        bean.seekToBeginning(Collections.singleton(tp));
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .until(() -> bean.getCount() >= countBeforeSeek + 10);
+
+        // Committed offset must advance back to 10
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+    }
+
+    @ApplicationScoped
+    public static class SeekConsumerBean {
+
+        @Inject
+        @Channel("data")
+        PausableChannel pausable;
+
+        @Inject
+        KafkaClientService clientService;
+
+        private final List<Integer> received = new CopyOnWriteArrayList<>();
+        private final AtomicInteger wip = new AtomicInteger();
+
+        @Incoming("data")
+        @Blocking
+        public void consume(int payload) {
+            wip.incrementAndGet();
+            try {
+                received.add(payload);
+            } finally {
+                wip.decrementAndGet();
+            }
+        }
+
+        public void seekToBeginning(Collection<TopicPartition> partitions) {
+            pausable.pause();
+            await().until(() -> wip.get() == 0);
+            clientService.<String, Integer> getConsumer("data")
+                    .seekToBeginning(partitions).await().indefinitely();
+            pausable.clearBuffer();
+            pausable.resume();
+        }
+
+        public int getCount() {
+            return received.size();
+        }
+
+        public List<Integer> getReceived() {
+            return received;
+        }
+    }
+
+    @ApplicationScoped
+    @Identifier("seek-listener")
+    public static class SeekRebalanceListener implements KafkaConsumerRebalanceListener {
+
+        private final Set<TopicPartition> seekedPartitions = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+        @Override
+        public void onPartitionsSeeked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            seekedPartitions.addAll(partitions);
+        }
+
+        public Set<TopicPartition> getSeekedPartitions() {
+            return seekedPartitions;
+        }
+    }
+
+    @ApplicationScoped
+    @Identifier("seek-and-reset-listener")
+    public static class SeekAndResetOffsetListener implements KafkaConsumerRebalanceListener {
+
+        @Override
+        public void onPartitionsSeeked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+            for (TopicPartition tp : partitions) {
+                offsets.put(tp, new OffsetAndMetadata(consumer.position(tp)));
+            }
+            consumer.commitSync(offsets);
+        }
+    }
+}

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -30,6 +31,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
 import io.smallrye.reactive.messaging.kafka.KafkaRecord;
@@ -351,5 +353,86 @@ public class KafkaCommitHandlerTest extends KafkaCompanionTestBase {
 
         await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() + messages2.size() >= 20000);
 
+    }
+
+    @Test
+    public void testSourceWithLatestAndRebalance() {
+        String group = "test-source-with-latest-commit-and-rebalance";
+        companion.topics().createAndWait(topic, 2);
+
+        MapBasedConfig config1 = newCommonConfigForSource()
+                .with("client.id", UUID.randomUUID().toString())
+                .with("group.id", group)
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .with("commit-strategy", "latest");
+
+        // Source 2 uses "ignore" — receives records but never commits offsets
+        MapBasedConfig config2 = newCommonConfigForSource()
+                .with("client.id", UUID.randomUUID().toString())
+                .with("group.id", group)
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .with("commit-strategy", "ignore");
+
+        source = createSource(group, config1);
+
+        List<Message<?>> messages1 = new CopyOnWriteArrayList<>();
+        source.getStream()
+                .onItem().call(m -> Uni.createFrom().completionStage(m.ack()))
+                .subscribe().with(messages1::add);
+
+        // Source 1 gets both partitions
+        await().until(() -> source.getConsumer().getAssignments().await().indefinitely().size() == 2);
+
+        TopicPartition tp0 = new TopicPartition(topic, 0);
+        TopicPartition tp1 = new TopicPartition(topic, 1);
+
+        // Batch 1: 100 records, all processed and committed by source 1
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, Integer.toString(i % 2), i), 100);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages1.size() >= 100);
+
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    Map<TopicPartition, OffsetAndMetadata> result = companion.consumerGroups().offsets(
+                            group, Arrays.asList(tp0, tp1));
+                    assertNotNull(result.get(tp0));
+                    assertNotNull(result.get(tp1));
+                    assertEquals(100, result.get(tp0).offset() + result.get(tp1).offset());
+                });
+
+        // Source 2 joins with "ignore" strategy — triggers rebalance, partitions split
+        KafkaSource<String, Integer> source2 = createSource(group, config2);
+        List<Message<?>> messages2 = new CopyOnWriteArrayList<>();
+        source2.getStream().subscribe().with(messages2::add);
+
+        await().until(() -> source2.getConsumer().getAssignments().await().indefinitely().size() == 1
+                && source.getConsumer().getAssignments().await().indefinitely().size() == 1);
+
+        // Batch 2: 100 records while source 2 is active
+        // Source 2 receives records on its partition but never commits
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, Integer.toString(i % 2), i), 100);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages2.size() >= 10);
+
+        // Close source 2 — triggers rebalance, source 1 gets both partitions back.
+        // Source 2 never committed, so for its partition the committed offset is still
+        // from batch 1. Source 1 replays batch-2 records on that partition.
+        source2.closeQuietly();
+
+        await().until(() -> source.getConsumer().getAssignments().await().indefinitely().size() == 2);
+
+        // Committed offsets must cover all 200 produced records.
+        // partitionsRevoked clears the stale offsets map so that replayed records
+        // are correctly committed after the partition is reassigned.
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    Map<TopicPartition, OffsetAndMetadata> result = companion.consumerGroups().offsets(
+                            group, Arrays.asList(tp0, tp1));
+                    assertNotNull(result.get(tp0));
+                    assertNotNull(result.get(tp1));
+                    assertEquals(200, result.get(tp0).offset() + result.get(tp1).offset());
+                });
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandlerTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -16,26 +17,36 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.common.annotation.Identifier;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.health.HealthReport;
 import io.smallrye.reactive.messaging.kafka.IncomingKafkaRecord;
+import io.smallrye.reactive.messaging.kafka.KafkaClientService;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumer;
+import io.smallrye.reactive.messaging.kafka.KafkaConsumerRebalanceListener;
 import io.smallrye.reactive.messaging.kafka.KafkaRecord;
 import io.smallrye.reactive.messaging.kafka.base.KafkaCompanionTestBase;
+import io.smallrye.reactive.messaging.kafka.base.KafkaMapBasedConfig;
 import io.smallrye.reactive.messaging.kafka.impl.KafkaSource;
 import io.smallrye.reactive.messaging.test.common.config.MapBasedConfig;
 
@@ -434,5 +445,311 @@ public class KafkaCommitHandlerTest extends KafkaCompanionTestBase {
                     assertNotNull(result.get(tp1));
                     assertEquals(200, result.get(tp0).offset() + result.get(tp1).offset());
                 });
+    }
+
+    @Test
+    public void testSourceWithLatestAndSeekToBeginning() {
+        String group = "test-source-with-latest-and-seek";
+
+        MapBasedConfig config = newCommonConfigForSource()
+                .with("client.id", UUID.randomUUID().toString())
+                .with("group.id", group)
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .with("commit-strategy", "latest");
+
+        source = createSource(group, config);
+
+        List<Message<?>> messages = new CopyOnWriteArrayList<>();
+        source.getStream()
+                .onItem().call(m -> Uni.createFrom().completionStage(m.ack()))
+                .subscribe().with(messages::add);
+
+        TopicPartition tp = new TopicPartition(topic, 0);
+
+        // Produce and consume 10 records
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, i), 10);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
+
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        int countBeforeSeek = messages.size();
+
+        // Seek to beginning through the consumer API — full path:
+        // ReactiveKafkaConsumer → WrappedConsumerRebalanceListener.onPartitionsSeeked
+        // → buffer clear + commitHandler.partitionsSeeked
+        source.getConsumer().seekToBeginning(Collections.singleton(tp))
+                .await().indefinitely();
+
+        // Records should be re-delivered from offset 0
+        await().atMost(2, TimeUnit.MINUTES)
+                .until(() -> messages.size() >= countBeforeSeek + 10);
+
+        // After seek + replay, committed offset must still be correct
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        // Produce 10 more records (offsets 10-19)
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, 10 + i), 10);
+
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(20L, offset.offset());
+                });
+    }
+
+    @Test
+    public void testSourceWithThrottledAndSeek() {
+        String group = "test-source-with-throttled-and-seek";
+
+        MapBasedConfig config = newCommonConfigForSource()
+                .with("client.id", UUID.randomUUID().toString())
+                .with("group.id", group)
+                .with("value.deserializer", IntegerDeserializer.class.getName())
+                .with("commit-strategy", "throttled")
+                .with(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 100);
+
+        source = createSource(group, config);
+
+        List<Message<?>> messages = new CopyOnWriteArrayList<>();
+        source.getStream()
+                .onItem().call(m -> Uni.createFrom().completionStage(m.ack()))
+                .subscribe().with(messages::add);
+
+        TopicPartition tp = new TopicPartition(topic, 0);
+
+        // Produce and consume 10 records
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, i), 10);
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> messages.size() >= 10);
+
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        int countBeforeSeek = messages.size();
+
+        // Seek to offset 0 through the consumer API
+        source.getConsumer().seek(tp, 0).await().indefinitely();
+
+        // Records re-delivered from offset 0
+        await().atMost(2, TimeUnit.MINUTES)
+                .until(() -> messages.size() >= countBeforeSeek + 10);
+
+        // After seek + replay, committed offset must still be correct
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        // Produce 10 more records
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, 10 + i), 10);
+
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(20L, offset.offset());
+                });
+    }
+
+    @Test
+    public void testSeekToBeginningWithApplicationScopedBean() {
+        String group = "test-app-seek-to-beginning";
+
+        addBeans(SeekConsumerBean.class, SeekTrackingRebalanceListener.class);
+
+        KafkaMapBasedConfig config = kafkaConfig("mp.messaging.incoming.data");
+        config.put("group.id", group);
+        config.put("topic", topic);
+        config.put("value.deserializer", IntegerDeserializer.class.getName());
+        config.put("auto.offset.reset", "earliest");
+        config.put("commit-strategy", "latest");
+        config.put("consumer-rebalance-listener.name", "seek-tracking-listener");
+
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, i), 10);
+
+        runApplication(config);
+
+        SeekConsumerBean bean = get(SeekConsumerBean.class);
+        SeekTrackingRebalanceListener listener = getBeanManager().createInstance()
+                .select(SeekTrackingRebalanceListener.class)
+                .select(Identifier.Literal.of("seek-tracking-listener"))
+                .get();
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.getCount() >= 10);
+
+        TopicPartition tp = new TopicPartition(topic, 0);
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        // Seek to beginning via KafkaClientService — exercises the full CDI path
+        KafkaClientService clientService = get(KafkaClientService.class);
+        KafkaConsumer<String, Integer> consumer = clientService.getConsumer("data");
+        assertNotNull(consumer);
+
+        int countBeforeSeek = bean.getCount();
+
+        consumer.seekToBeginning(Collections.singleton(tp)).await().indefinitely();
+
+        // Verify onPartitionsSeeked was called on the user's rebalance listener
+        await().atMost(10, TimeUnit.SECONDS)
+                .until(() -> listener.getSeekedPartitions().contains(tp));
+
+        // Records should be re-delivered from offset 0
+        await().atMost(2, TimeUnit.MINUTES)
+                .until(() -> bean.getCount() >= countBeforeSeek + 10);
+
+        // After seek + replay, committed offset must still be correct
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        // Produce more records and verify committed offset covers everything
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, 10 + i), 10);
+
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(20L, offset.offset());
+                });
+    }
+
+    @Test
+    public void testSeekWithApplicationScopedBeanAndThrottledStrategy() {
+        String group = "test-app-seek-throttled";
+
+        addBeans(SeekConsumerBean.class, SeekTrackingRebalanceListener.class);
+
+        KafkaMapBasedConfig config = kafkaConfig("mp.messaging.incoming.data");
+        config.put("group.id", group);
+        config.put("topic", topic);
+        config.put("value.deserializer", IntegerDeserializer.class.getName());
+        config.put("auto.offset.reset", "earliest");
+        config.put("commit-strategy", "throttled");
+        config.put("auto.commit.interval.ms", 100);
+        config.put("consumer-rebalance-listener.name", "seek-tracking-listener");
+
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, i), 10);
+
+        runApplication(config);
+
+        SeekConsumerBean bean = get(SeekConsumerBean.class);
+        SeekTrackingRebalanceListener listener = getBeanManager().createInstance()
+                .select(SeekTrackingRebalanceListener.class)
+                .select(Identifier.Literal.of("seek-tracking-listener"))
+                .get();
+
+        await().atMost(2, TimeUnit.MINUTES).until(() -> bean.getCount() >= 10);
+
+        TopicPartition tp = new TopicPartition(topic, 0);
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        KafkaClientService clientService = get(KafkaClientService.class);
+        KafkaConsumer<String, Integer> consumer = clientService.getConsumer("data");
+        assertNotNull(consumer);
+
+        int countBeforeSeek = bean.getCount();
+
+        // Seek to offset 0 via consumer API — full path through throttled handler
+        consumer.seek(tp, 0).await().indefinitely();
+
+        // Verify onPartitionsSeeked was called
+        await().atMost(10, TimeUnit.SECONDS)
+                .until(() -> listener.getSeekedPartitions().contains(tp));
+
+        // Records re-delivered from offset 0
+        await().atMost(2, TimeUnit.MINUTES)
+                .until(() -> bean.getCount() >= countBeforeSeek + 10);
+
+        // After seek + replay, committed offset must still be correct
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(10L, offset.offset());
+                });
+
+        // Produce more records and verify committed offset advances
+        companion.produceIntegers()
+                .usingGenerator(i -> new ProducerRecord<>(topic, 10 + i), 10);
+
+        await().atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> {
+                    OffsetAndMetadata offset = companion.consumerGroups().offsets(group, tp);
+                    assertNotNull(offset);
+                    assertEquals(20L, offset.offset());
+                });
+    }
+
+    @ApplicationScoped
+    public static class SeekConsumerBean {
+
+        private final List<Integer> received = new CopyOnWriteArrayList<>();
+
+        @Incoming("data")
+        public void consume(int payload) {
+            received.add(payload);
+        }
+
+        public int getCount() {
+            return received.size();
+        }
+
+        public List<Integer> getReceived() {
+            return received;
+        }
+    }
+
+    @ApplicationScoped
+    @Identifier("seek-tracking-listener")
+    public static class SeekTrackingRebalanceListener implements KafkaConsumerRebalanceListener {
+
+        private final Set<TopicPartition> seekedPartitions = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+        @Override
+        public void onPartitionsSeeked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            seekedPartitions.addAll(partitions);
+        }
+
+        public Set<TopicPartition> getSeekedPartitions() {
+            return seekedPartitions;
+        }
     }
 }

--- a/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/PausableChannelDecorator.java
+++ b/smallrye-reactive-messaging-provider/src/main/java/io/smallrye/reactive/messaging/providers/extension/PausableChannelDecorator.java
@@ -91,6 +91,11 @@ public class PausableChannelDecorator implements PublisherDecorator, SubscriberD
         public void resume() {
             pauser.resume();
         }
+
+        @Override
+        public void clearBuffer() {
+            pauser.clearBuffer();
+        }
     }
 
 }


### PR DESCRIPTION
- Latest commit strategy: clear offsets on partition revocation
- Added clearBuffer to the PausableChannel interface
- Added `onPartitionsSeeked` callback to `KafkaConsumerRebalanceListener` and `partitionsSeeked` to KafkaCommitHandler interface. On seek operations, the Kafka consumer clears the poller buffer and calls `partitionsSeeked` on commit handlers.