### PR TITLE
Reset commit handler offset state on seek operations

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaCommitHandler.java
@@ -95,6 +95,17 @@ public interface KafkaCommitHandler {
     }
 
     /**
+     * Called when the consumer position for partitions has been changed by a seek operation.
+     * Implementations should reset any cached offset state for the given partitions so that
+     * commits resume correctly from the new position.
+     *
+     * @param partitions the partitions for which the consumer position was changed
+     */
+    default void partitionsSeeked(Collection<TopicPartition> partitions) {
+        // Do nothing by default.
+    }
+
+    /**
      * Handle message acknowledgment
      *
      * @param record incoming Kafka record

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaLatestCommit.java
@@ -2,6 +2,7 @@ package io.smallrye.reactive.messaging.kafka.commit;
 
 import static io.smallrye.reactive.messaging.kafka.i18n.KafkaLogging.log;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -79,5 +80,14 @@ public class KafkaLatestCommit extends ContextHolder implements KafkaCommitHandl
             }
         });
         return Uni.createFrom().voidItem().runSubscriptionOn(record::runOnMessageContext);
+    }
+
+    @Override
+    public void partitionsSeeked(Collection<TopicPartition> partitions) {
+        runOnContext(() -> {
+            for (TopicPartition tp : partitions) {
+                offsets.remove(tp);
+            }
+        });
     }
 }

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/commit/KafkaThrottledLatestProcessedCommit.java
@@ -447,6 +447,18 @@ public class KafkaThrottledLatestProcessedCommit extends ContextHolder implement
         }
     }
 
+    @Override
+    public void partitionsSeeked(Collection<TopicPartition> partitions) {
+        runOnContext(() -> {
+            for (TopicPartition tp : partitions) {
+                OffsetStore existing = offsetStores.remove(tp);
+                if (existing != null) {
+                    offsetStores.put(tp, new OffsetStore(tp, unprocessedRecordMaxAge, -1));
+                }
+            }
+        });
+    }
+
     private void cleanupPartitionOffsetStore() {
         for (TopicPartition partition : new HashSet<>(offsetStores.keySet())) {
             if (!assignments.contains(partition)) {

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/OrderedStreamHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/OrderedStreamHandler.java
@@ -154,6 +154,11 @@ public class OrderedStreamHandler extends ContextHolder implements KafkaCommitHa
         delegate.partitionsRevoked(partitions);
     }
 
+    @Override
+    public void partitionsSeeked(Collection<TopicPartition> partitions) {
+        delegate.partitionsSeeked(partitions);
+    }
+
     /**
      * Returns the underlying commit handler.
      */

--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/ReactiveKafkaConsumer.java
@@ -53,6 +53,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     private final Duration pollTimeout;
     private final String consumerGroup;
     private ConsumerRebalanceListener rebalanceListener;
+    private KafkaCommitHandler commitHandler;
 
     private final AtomicBoolean paused = new AtomicBoolean();
 
@@ -141,6 +142,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
 
     public void setRebalanceListener(KafkaConsumerRebalanceListener listener, KafkaCommitHandler commitHandler) {
         try {
+            this.commitHandler = commitHandler;
             rebalanceListener = RebalanceListeners.createRebalanceListener(this, consumerGroup,
                     listener, commitHandler);
         } catch (Exception e) {
@@ -559,7 +561,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     public Uni<Void> seek(TopicPartition partition, long offset) {
         return runOnPollingThread(c -> {
             c.seek(partition, offset);
-        });
+        }).invoke(() -> notifyCommitHandlerOfSeek(Collections.singleton(partition)));
     }
 
     @Override
@@ -567,7 +569,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     public Uni<Void> seek(TopicPartition partition, OffsetAndMetadata offsetAndMetadata) {
         return runOnPollingThread(c -> {
             c.seek(partition, offsetAndMetadata);
-        });
+        }).invoke(() -> notifyCommitHandlerOfSeek(Collections.singleton(partition)));
     }
 
     @Override
@@ -575,7 +577,7 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     public Uni<Void> seekToBeginning(Collection<TopicPartition> partitions) {
         return runOnPollingThread(c -> {
             c.seekToBeginning(partitions);
-        });
+        }).invoke(() -> notifyCommitHandlerOfSeek(partitions));
     }
 
     @Override
@@ -583,7 +585,13 @@ public class ReactiveKafkaConsumer<K, V> implements io.smallrye.reactive.messagi
     public Uni<Void> seekToEnd(Collection<TopicPartition> partitions) {
         return runOnPollingThread(c -> {
             c.seekToEnd(partitions);
-        });
+        }).invoke(() -> notifyCommitHandlerOfSeek(partitions));
+    }
+
+    private void notifyCommitHandlerOfSeek(Collection<TopicPartition> partitions) {
+        if (commitHandler != null && partitions != null && !partitions.isEmpty()) {
+            commitHandler.partitionsSeeked(partitions);
+        }
     }
 
     @Override

--- a/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
+++ b/smallrye-reactive-messaging-kafka/src/test/java/io/smallrye/reactive/messaging/kafka/commit/CommitStrategiesTest.java
@@ -459,6 +459,122 @@ public class CommitStrategiesTest extends WeldTestBase {
                 });
     }
 
+    @Test
+    void testLatestCommitStrategyAfterSeekToBeginning() {
+        String group = UUID.randomUUID().toString();
+        MapBasedConfig config = commonConfiguration()
+                .with("commit-strategy", "latest")
+                .with("lazy-client", true)
+                .with("client.id", UUID.randomUUID().toString());
+        source = createSource(group, config);
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getStream()
+                .subscribe().with(list::add);
+
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        Map<TopicPartition, Long> beginning = new HashMap<>();
+        beginning.put(tp0, 0L);
+        consumer.updateBeginningOffsets(beginning);
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(tp0));
+            for (int i = 0; i < 5; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k", "v" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 5);
+        for (Message<?> m : list) {
+            m.ack().toCompletableFuture().join();
+        }
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp0));
+            assertThat(committed.get(tp0).offset()).isEqualTo(5);
+        });
+
+        // Seek to beginning — must reset the commit handler's internal offset state
+        source.getConsumer().seekToBeginning(Collections.singletonList(tp0))
+                .await().atMost(Duration.ofSeconds(5));
+
+        list.clear();
+        consumer.schedulePollTask(() -> {
+            for (int i = 0; i < 5; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k", "v" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 5);
+
+        // Ack record at offset 2 — before the fix, no commit would happen because old watermark was 5
+        list.get(2).ack().toCompletableFuture().join();
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp0));
+            assertThat(committed.get(tp0).offset()).isEqualTo(3);
+        });
+    }
+
+    @Test
+    void testThrottledStrategyAfterSeekToBeginning() {
+        MapBasedConfig config = commonConfiguration()
+                .with("lazy-client", true)
+                .with("commit-strategy", "throttled")
+                .with("auto.commit.interval.ms", 100);
+        String group = UUID.randomUUID().toString();
+        source = createSource(group, config);
+        injectMockConsumer(source, consumer);
+
+        List<Message<?>> list = new ArrayList<>();
+        source.getStream()
+                .subscribe().with(list::add);
+
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+        consumer.updateBeginningOffsets(Collections.singletonMap(tp, 0L));
+
+        consumer.schedulePollTask(() -> {
+            consumer.rebalance(Collections.singletonList(tp));
+            source.getCommitHandler().partitionsAssigned(Collections.singletonList(tp));
+            for (int i = 0; i < 5; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k", "v" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 5);
+        for (Message<?> m : list) {
+            m.ack().toCompletableFuture().join();
+        }
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp));
+            assertThat(committed.get(tp)).isNotNull();
+            assertThat(committed.get(tp).offset()).isEqualTo(5);
+        });
+
+        // Seek to beginning — must reset the commit handler's internal offset state
+        source.getConsumer().seekToBeginning(Collections.singletonList(tp))
+                .await().atMost(Duration.ofSeconds(5));
+
+        list.clear();
+        consumer.schedulePollTask(() -> {
+            for (int i = 0; i < 5; i++) {
+                consumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k", "v" + i));
+            }
+        });
+
+        await().until(() -> list.size() == 5);
+
+        // Ack all records — before the fix, offsets 0-4 would be discarded as "outdated"
+        for (Message<?> m : list) {
+            m.ack().toCompletableFuture().join();
+        }
+
+        await().untilAsserted(() -> {
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Collections.singleton(tp));
+            assertThat(committed.get(tp)).isNotNull();
+            assertThat(committed.get(tp).offset()).isEqualTo(5);
+        });
+    }
+
     @ApplicationScoped
     @Identifier("mine")
     public static class NamedRebalanceListener implements KafkaConsumerRebalanceListener {


### PR DESCRIPTION
## Summary

Fixes #3455

- When `seekToBeginning`/`seekToEnd`/`seek` is called on a consumer, the `latest` and `throttled` commit handlers retained stale offset state, causing commits to be silently skipped until the old high watermark was re-reached.
- Adds a `partitionsSeeked` callback to `KafkaCommitHandler` (default no-op for backward compatibility) and notifies it from `ReactiveKafkaConsumer` after seek operations, so cached offset tracking is reset.

## Test plan

- [x] New test `testLatestCommitStrategyAfterSeekToBeginning` — verifies commits resume after seekToBeginning with `latest` strategy
- [x] New test `testThrottledStrategyAfterSeekToBeginning` — verifies commits resume after seekToBeginning with `throttled` strategy
- [x] Full `CommitStrategiesTest` suite passes (9 tests, 0 failures)