### PR TITLE
Fix using tracing.attribute-headers in RabbitMQTraceAttributesExtractor

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/IncomingRabbitMQChannel.java
@@ -53,7 +53,7 @@ public class IncomingRabbitMQChannel {
             RabbitMQConnectorIncomingConfiguration ic, Instance<OpenTelemetry> openTelemetryInstance) {
         if (ic.getTracingEnabled()) {
             instrumenter = RabbitMQOpenTelemetryInstrumenter
-                    .createForConnector(openTelemetryInstance);
+                    .createForConnector(openTelemetryInstance, ic);
         } else {
             instrumenter = null;
         }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/RabbitMQMessageSender.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/internals/RabbitMQMessageSender.java
@@ -74,7 +74,7 @@ public class RabbitMQMessageSender implements Processor<Message<?>, Message<?>>,
         }
 
         if (oc.getTracingEnabled()) {
-            instrumenter = RabbitMQOpenTelemetryInstrumenter.createForSender(openTelemetryInstance);
+            instrumenter = RabbitMQOpenTelemetryInstrumenter.createForSender(openTelemetryInstance, configuration);
         } else {
             instrumenter = null;
         }

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQOpenTelemetryInstrumenter.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQOpenTelemetryInstrumenter.java
@@ -1,7 +1,10 @@
 package io.smallrye.reactive.messaging.rabbitmq.tracing;
 
+import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorCommonConfiguration;
 import jakarta.enterprise.inject.Instance;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -20,18 +23,23 @@ public class RabbitMQOpenTelemetryInstrumenter {
         this.instrumenter = instrumenter;
     }
 
-    public static RabbitMQOpenTelemetryInstrumenter createForSender(Instance<OpenTelemetry> openTelemetryInstance) {
-        return create(TracingUtils.getOpenTelemetry(openTelemetryInstance), true);
+    public static RabbitMQOpenTelemetryInstrumenter createForSender(Instance<OpenTelemetry> openTelemetryInstance,
+            RabbitMQConnectorCommonConfiguration config) {
+        return create(TracingUtils.getOpenTelemetry(openTelemetryInstance), true, config);
     }
 
-    public static RabbitMQOpenTelemetryInstrumenter createForConnector(Instance<OpenTelemetry> openTelemetryInstance) {
-        return create(TracingUtils.getOpenTelemetry(openTelemetryInstance), false);
+    public static RabbitMQOpenTelemetryInstrumenter createForConnector(Instance<OpenTelemetry> openTelemetryInstance,
+            RabbitMQConnectorCommonConfiguration config) {
+        return create(TracingUtils.getOpenTelemetry(openTelemetryInstance), false, config);
     }
 
-    private static RabbitMQOpenTelemetryInstrumenter create(OpenTelemetry openTelemetry, boolean sender) {
+    private static RabbitMQOpenTelemetryInstrumenter create(OpenTelemetry openTelemetry, boolean sender,
+            RabbitMQConnectorCommonConfiguration config) {
         MessageOperation messageOperation = sender ? MessageOperation.PUBLISH : MessageOperation.RECEIVE;
 
-        RabbitMQTraceAttributesExtractor rabbitMQAttributesExtractor = new RabbitMQTraceAttributesExtractor();
+        RabbitMQTraceAttributesExtractor rabbitMQAttributesExtractor = new RabbitMQTraceAttributesExtractor(
+                Arrays.stream(config.getTracingAttributeHeaders().split(","))
+                        .map(String::trim).collect(Collectors.toSet()));
         MessagingAttributesGetter<RabbitMQTrace, Void> messagingAttributesGetter = rabbitMQAttributesExtractor
                 .getMessagingAttributesGetter();
         InstrumenterBuilder<RabbitMQTrace, Void> builder = Instrumenter.builder(openTelemetry,

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQTraceAttributesExtractor.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQTraceAttributesExtractor.java
@@ -9,11 +9,15 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import java.util.Map;
+import java.util.Set;
 
 public class RabbitMQTraceAttributesExtractor implements AttributesExtractor<RabbitMQTrace, Void> {
     private final MessagingAttributesGetter<RabbitMQTrace, Void> messagingAttributesGetter;
+    private final Set<String> tracingAttributeHeaders;
 
-    public RabbitMQTraceAttributesExtractor() {
+    public RabbitMQTraceAttributesExtractor(Set<String> tracingAttributeHeaders) {
+        this.tracingAttributeHeaders = tracingAttributeHeaders;
         this.messagingAttributesGetter = new RabbitMQMessagingAttributesGetter();
     }
 
@@ -26,6 +30,24 @@ public class RabbitMQTraceAttributesExtractor implements AttributesExtractor<Rab
             final AttributesBuilder attributes,
             final Context parentContext, final RabbitMQTrace rabbitMQTrace) {
         attributes.put(MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, rabbitMQTrace.getRoutingKey());
+        setTracingHeaderAttributes(attributes, rabbitMQTrace.getHeaders());
+    }
+
+    private void setTracingHeaderAttributes(AttributesBuilder attributes, Map<String, Object> traceHeaders) {
+        tracingAttributeHeaders.stream()
+                .filter(traceHeaders::containsKey)
+                .forEach(attributeHeader -> {
+                    Object value = traceHeaders.get(attributeHeader);
+                    if (value instanceof String) {
+                        attributes.put(attributeHeader, (String) value);
+                    } else if (value instanceof Long) {
+                        attributes.put(attributeHeader, (long) value);
+                    } else if (value instanceof Double) {
+                        attributes.put(attributeHeader, (Double) value);
+                    } else if (value instanceof Boolean) {
+                        attributes.put(attributeHeader, (Boolean) value);
+                    }
+                });
     }
 
     @Override

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/TracingTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/TracingTest.java
@@ -13,6 +13,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.opentelemetry.api.common.AttributeKey;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -85,12 +86,14 @@ public class TracingTest extends WeldTestBase {
                 .with("mp.messaging.incoming.from-rabbitmq.queue.name", queueName)
                 .with("mp.messaging.incoming.from-rabbitmq.exchange.name", exchangeName)
                 .with("mp.messaging.incoming.from-rabbitmq.exchange.routing-keys", routingKeys)
-                .with("mp.messaging.incoming.from-rabbitmq.tracing.enabled", true),
+                .with("mp.messaging.incoming.from-rabbitmq.tracing.enabled", true)
+                .with("mp.messaging.incoming.from-rabbitmq.tracing.attribute-headers", "foo-header,bar-header"),
                 IncomingTracing.class);
 
         AtomicInteger counter = new AtomicInteger(1);
         usage.produce(exchangeName, queueName, routingKeys, 5, counter::getAndIncrement,
-                new AMQP.BasicProperties().builder().expiration("10000").contentType("text/plain").build());
+                new AMQP.BasicProperties().builder().expiration("10000").contentType("text/plain")
+                        .headers(Map.of("foo-header", "foo-value", "bar-header", "bar-value")).build());
         await().atMost(5, SECONDS).until(() -> tracing.getResults().size() == 5);
 
         CompletableResultCode completableResultCode = tracerProvider.forceFlush();
@@ -104,6 +107,8 @@ public class TracingTest extends WeldTestBase {
             assertEquals("rabbitmq", consumer.getAttributes().get(MESSAGING_SYSTEM));
             assertEquals("receive", consumer.getAttributes().get(MESSAGING_OPERATION));
             assertEquals("normal", consumer.getAttributes().get(MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY));
+            assertEquals("foo-value", consumer.getAttributes().get(AttributeKey.stringKey("foo-header")));
+            assertEquals("bar-value", consumer.getAttributes().get(AttributeKey.stringKey("bar-header")));
             assertEquals(queueName, consumer.getAttributes().get(MESSAGING_DESTINATION_NAME));
             assertNull(consumer.getAttributes().get(NETWORK_PROTOCOL_NAME));
             assertNull(consumer.getAttributes().get(NETWORK_PROTOCOL_VERSION));


### PR DESCRIPTION
Resolves #3367 

This re-adds the usage of  `mp.messaging.[incoming/outgoing].*.tracing.attribute-headers` in `RabbitMQTraceAttributesExtractor` to add the specified RMQ Message headers as OTEL span attributes