### PR TITLE
Kafka ordered stream: Reset ordered groups on seek operations

### DIFF
--- a/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/OrderedStreamHandler.java
+++ b/smallrye-reactive-messaging-kafka/src/main/java/io/smallrye/reactive/messaging/kafka/impl/OrderedStreamHandler.java
@@ -156,6 +156,16 @@ public class OrderedStreamHandler extends ContextHolder implements KafkaCommitHa
 
     @Override
     public void partitionsSeeked(Collection<TopicPartition> partitions) {
+        if (orderedByGroups != null) {
+            orderedByGroups.entrySet().removeIf(entry -> {
+                TopicPartitionKey key = entry.getKey();
+                if (partitions.contains(key.topicPartition()) && key.key() != null) {
+                    entry.getValue().cancel();
+                    return true;
+                }
+                return false;
+            });
+        }
         delegate.partitionsSeeked(partitions);
     }
 


### PR DESCRIPTION
Continued from #3453