### PR TITLE
Bump otel sdk to 1.63.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
     <kafka.version>4.2.0</kafka.version>
 
-    <opentelemetry.instrumentation.version>2.28.1</opentelemetry.instrumentation.version> <!-- Otel SDK 1.62.0-->
+    <opentelemetry.instrumentation.version>2.29.0</opentelemetry.instrumentation.version> <!-- Otel SDK 1.63.0-->
     <opentelemetry-semconv.version>1.40.0</opentelemetry-semconv.version>
 
     <smallrye-vertx-mutiny-clients.version>3.19.1</smallrye-vertx-mutiny-clients.version>

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQOpenTelemetryInstrumenter.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQOpenTelemetryInstrumenter.java
@@ -1,10 +1,10 @@
 package io.smallrye.reactive.messaging.rabbitmq.tracing;
 
-import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorCommonConfiguration;
-import jakarta.enterprise.inject.Instance;
-
 import java.util.Arrays;
 import java.util.stream.Collectors;
+
+import jakarta.enterprise.inject.Instance;
+
 import org.eclipse.microprofile.reactive.messaging.Message;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -14,6 +14,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.Messagin
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.smallrye.reactive.messaging.rabbitmq.RabbitMQConnectorCommonConfiguration;
 import io.smallrye.reactive.messaging.tracing.TracingUtils;
 
 public class RabbitMQOpenTelemetryInstrumenter {

--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQTraceAttributesExtractor.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/tracing/RabbitMQTraceAttributesExtractor.java
@@ -4,13 +4,13 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import java.util.Map;
-import java.util.Set;
 
 public class RabbitMQTraceAttributesExtractor implements AttributesExtractor<RabbitMQTrace, Void> {
     private final MessagingAttributesGetter<RabbitMQTrace, Void> messagingAttributesGetter;

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/TracingTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/TracingTest.java
@@ -13,7 +13,6 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import io.opentelemetry.api.common.AttributeKey;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import com.rabbitmq.client.AMQP;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;


### PR DESCRIPTION
When I run the build I got some import reordering as well. 

This is needed by https://github.com/quarkusio/quarkus/pull/55534/