### PR TITLE
Align Jackson annotations with Databind 2.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 
     <jakarta.jms.api.version>3.1.0</jakarta.jms.api.version>
     <jackson.version>2.22.2</jackson.version>
-    <jackson.annotations.version>2.20</jackson.annotations.version>
+    <jackson.annotations.version>2.22</jackson.annotations.version>
     <yasson.version>2.0.3</yasson.version>
 
     <jandex-maven-plugin.version>3.6.0</jandex-maven-plugin.version>

--- a/smallrye-reactive-messaging-amqp/pom.xml
+++ b/smallrye-reactive-messaging-amqp/pom.xml
@@ -46,6 +46,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.annotations.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config</artifactId>
       <scope>test</scope>

--- a/smallrye-reactive-messaging-aws-sns/pom.xml
+++ b/smallrye-reactive-messaging-aws-sns/pom.xml
@@ -88,6 +88,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.annotations.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-connector-attribute-processor</artifactId>
       <version>${project.version}</version>

--- a/smallrye-reactive-messaging-aws-sqs/pom.xml
+++ b/smallrye-reactive-messaging-aws-sqs/pom.xml
@@ -88,6 +88,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.annotations.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-trace</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Completes the Jackson 2.22.2 upgrade started in #3501.

Jackson Annotations stopped using the Databind patch version in the 2.20 line. Databind 2.22.2 now requires `jackson-annotations` 2.22 (including `JsonSerializeAs`), but the Dependabot branch resolves 2.20 in the Jackson connector and 2.16.1 in the AMQP/AWS test classpaths. That prevents Databind from initializing and makes Vert.x report that Databind is unavailable.

This change:

- aligns the repository's annotation property with Jackson 2.22;
- pins that property in the three test classpaths that declare Databind directly (AMQP, AWS SNS, and AWS SQS);
- leaves unrelated dependency management unchanged.

Validation (JDK 21):

- reproduced the Jackson connector failure before the fix: 2 tests, 2 errors (`NoClassDefFoundError: JsonSerializeAs`);
- verified the Jackson, AMQP, AWS SNS, and AWS SQS trees resolve Databind 2.22.2 with Annotations 2.22;
- passed the non-container core reactor: 1,271 tests, 0 failures/errors;
- passed the two AMQP object-serialization regressions that failed on #3501;
- compiled the AWS SNS and AWS SQS main and test sources;
- repeated the affected-module install, Jackson tests, AMQP regression tests, and AWS dependency checks in a clean disposable remote workspace.

The local Docker daemon was unavailable, so the RabbitMQ and LocalStack Testcontainers suites were not claimed locally; the repository's GitHub Actions matrix remains the acceptance gate for those lanes.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, `jaipilot-review-diff`, and `jaipilot-remote-java`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
